### PR TITLE
fixing destructor error with unique ptrs

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -78,6 +78,7 @@ toolchain("cheriot-clang")
 			"-fno-builtin",
 			"-fno-exceptions",
 			"-fno-asynchronous-unwind-tables",
+			"-fno-c++-static-destructors",
 			"-fno-rtti",
 			"-Werror",
 			"-I" .. path.join(include_directory, "c++-config"),


### PR DESCRIPTION
Flag to fix this error when defining global unique pointers:

[ 95%]: linking firmware build/cheriot/cheriot/release/dma_test
error: ld.lld: error: undefined symbol: __library_export_libcalls___cxa_atexit
>>> referenced by __cpp_dma_compartment.cc.cc
>>>               build/cheriot/cheriot/release/dma.compartment:()
