### PR TITLE
Allow cgp to be larger.

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -250,7 +250,7 @@ namespace
 	         PermissionSet Permissions = Root::Permissions<Type>,
 	         bool          Precise     = true>
 	Capability<T> build(auto &&range)
-	    requires(RawAddressRange<decltype(range)>)
+	    requires(IsAddressRange<decltype(range)>)
 	{
 		return build<T, Type, Permissions, Precise>(range.start(),
 		                                            range.size());
@@ -265,7 +265,7 @@ namespace
 	         // NOLINTNEXTLINE(google-readability-casting)
 	         PermissionSet Permissions = Root::Permissions<Type>>
 	Capability<T> build(auto &&range, ptraddr_t address)
-	    requires(RawAddressRange<decltype(range)>)
+	    requires(IsAddressRange<decltype(range)>)
 	{
 		return build<T, Type, Permissions>(
 		  range.start(), range.size(), address);
@@ -384,7 +384,7 @@ namespace
 	 * is completely contained within a specified range.
 	 */
 	bool contains(const auto &range, ptraddr_t addr, size_t size)
-	    requires(RawAddressRange<decltype(range)>)
+	    requires(IsAddressRange<decltype(range)>)
 	{
 		return (range.start() <= addr) &&
 		       (range.start() + range.size() >= addr + size);
@@ -397,7 +397,7 @@ namespace
 	 */
 	template<typename T = char>
 	bool contains(const auto &range, ptraddr_t addr)
-	    requires(RawAddressRange<decltype(range)>)
+	    requires(IsAddressRange<decltype(range)>)
 	{
 		return contains(range, addr, sizeof(T));
 	}
@@ -448,7 +448,7 @@ namespace
 	 */
 	template<typename T, bool Precise = true>
 	ContiguousPtrRange<T> build_range(const auto &range)
-	    requires(RawAddressRange<decltype(range)>)
+	    requires(IsAddressRange<decltype(range)>)
 	{
 		Capability<T> start = build<T,
 		                            Root::Type::RWGlobal,

--- a/sdk/firmware.rwdata.ldscript.in
+++ b/sdk/firmware.rwdata.ldscript.in
@@ -111,7 +111,8 @@ __cap_relocs_end = .;
     # Scheduler globals start address
     LONG(.scheduler_globals);
     # Scheduler globals end size
-    SHORT(SIZEOF(.scheduler_globals));
+    ASSERT((SIZEOF(.scheduler_globals) % 4) == 0, "Scheduler globals oddly sized");
+    SHORT(SIZEOF(.scheduler_globals) / 4);
     # Start of the scheduler's import table
     LONG(.scheduler_import_start);
     # Size of the scheduler import table
@@ -132,7 +133,8 @@ __cap_relocs_end = .;
     # Allocator globals start address
     LONG(.allocator_globals);
     # Allocator globals end
-    SHORT(SIZEOF(.allocator_globals));
+    ASSERT((SIZEOF(.allocator_globals) % 4) == 0, "Allocator globals oddly sized");
+    SHORT(SIZEOF(.allocator_globals) / 4);
     # Start of the allocator's import table
     LONG(.allocator_import_start);
     # Size of the allocator import table
@@ -172,7 +174,7 @@ __cap_relocs_end = .;
     # loader versions.
     # New versions of this can be generated with:
     # head /dev/random | shasum | cut -c 0-8
-    LONG(0xca2b63de);
+    LONG(0x46391da0);
     # Number of library headers.
     SHORT(@library_count@);
     # Number of compartment headers.

--- a/tests/bigdata-test.cc
+++ b/tests/bigdata-test.cc
@@ -1,0 +1,31 @@
+#include "cheri.hh"
+#define TEST_NAME "Big Data"
+#include "tests.hh"
+
+extern "C" enum ErrorRecoveryBehaviour
+compartment_error_handler(struct ErrorState *frame, size_t mcause, size_t mtval)
+{
+	debug_log("Detected error in instruction {}", frame->pcc);
+	debug_log("Error cause: {}, mtval: {}", mcause, mtval);
+	auto [reg, cause] = CHERI::extract_cheri_mtval(mtval);
+	debug_log("Error {} in register {}", reg, cause);
+	return ErrorRecoveryBehaviour::ForceUnwind;
+}
+
+int test_bigdata()
+{
+	register char *cgpRegister asm("cgp");
+	asm("" : "=C"(cgpRegister));
+	static uint32_t data[16384];
+	debug_log("Data: {}", data);
+	debug_log("CGP: {}", cgpRegister);
+	debug_log("Fill with for loop");
+	for (int i = 0; i < 16000; ++i)
+	{
+		data[i] = 0x01020304;
+	}
+	debug_log("Fill with memset");
+	memset(data, 0x5a, sizeof(data));
+
+	return 0;
+}

--- a/tests/misc-test.cc
+++ b/tests/misc-test.cc
@@ -13,6 +13,8 @@ using namespace CHERI;
 
 namespace
 {
+	char       largeBuffer[4096];
+	const char LargeConstBuffer[4096] = "This is a large const buffer buffer.";
 
 	/**
 	 * Test timeouts.
@@ -343,6 +345,24 @@ int test_misc()
 		TEST(!switcherReturnSentry.permissions().contains(Permission::Global),
 		     "Switcher return sentry should be local");
 	}
+
+	CHERI::Capability largeRW{largeBuffer};
+	CHERI::Capability largeRO{LargeConstBuffer};
+	debug_log("RW: {}", largeRW);
+	debug_log("RO: {}", largeRO);
+	TEST(largeRW.length() == sizeof(largeBuffer),
+	     "Large buffer has the wrong size: {}",
+	     largeRW.length());
+	TEST(largeRO.length() == sizeof(LargeConstBuffer),
+	     "Large const buffer has the wrong size: {}",
+	     largeRO.length());
+	TEST(largeRW.is_valid(), "Large buffer is untagged");
+	TEST(largeRO.is_valid(), "Large const buffer is untagged");
+	TEST(largeRW.permissions().contains(CHERI::Permission::Store),
+	     "Large buffer is not writable: {}",
+	     largeRW);
+	TEST(!largeRO.permissions().contains(CHERI::Permission::Store),
+	     "Large const buffer is writable");
 
 	check_timeouts();
 	check_memchr();

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -185,6 +185,9 @@ int __cheri_compartment("test_runner") run_tests()
 	     csp);
 
 	run_timed("All tests", []() {
+		// This test is disabled because it uses too much memory for the heap
+		// tests to work.
+		// run_timed("big data in globals", test_big_data);
 		run_timed("Debug helpers (C++)", test_debug_cxx);
 		run_timed("Debug helpers (C)", test_debug_c);
 		run_timed("Soft float", test_softfloat);

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -25,6 +25,7 @@ __cheri_compartment("debug_test") int test_debug_cxx();
 __cheri_compartment("debug_test") int test_debug_c();
 __cheri_compartment("unwind_cleanup_test") int test_unwind_cleanup();
 __cheri_compartment("softfloat_test") int test_softfloat();
+__cheri_compartment("bigdata_test") void test_big_data();
 
 int print_version_information();
 

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -67,6 +67,7 @@ test("stdio")
 -- Test the debug helpers.
 test("debug")
 	add_files("debug-test.c")
+-- test("bigdata")
 -- Test the static sealing types
 test("static_sealing")
 compartment("static_sealing_inner")


### PR DESCRIPTION
We store the size of globals as a shifted value, which extends the maximum size of globals in a compartment from 64 KiB to 256 KiB.

This adds two new tests.  One is added to the misc test and just checks that we correctly handle globals that are larger than the range of a csetbounds with an immediate offset.

The second checks that much larger globals work.  This test is disabled because it uses so much RAM that we don't have enough for the allocator tests.

At some point, we should refactor the test suite to allow subsets of the test suite to be built.

Add test for large objects.

Fixes #230