### PR TITLE
Add APIs to retrieve the thread ID of the owner of a lock.

### DIFF
--- a/sdk/include/locks.hh
+++ b/sdk/include/locks.hh
@@ -93,6 +93,19 @@ class FlagLockGeneric
 	{
 		flaglock_upgrade_for_destruction(&state);
 	}
+
+	/**
+	 * Return the thread ID of the owner of the lock.
+	 *
+	 * This is only available for priority inherited locks, as this is the
+	 * only case where we store the thread ID of the owner. See the
+	 * documentation of `flaglock_priority_inheriting_get_owner_thread_id`
+	 * for more information.
+	 */
+	__always_inline uint16_t get_owner_thread_id() requires(IsPriorityInherited)
+	{
+		return flaglock_priority_inheriting_get_owner_thread_id(&state);
+	}
 };
 
 /**


### PR DESCRIPTION
It is commonly needed in error handlers to have to check if the thread on which the error handler was invoked was holding a particular lock when it crashed. Typically, we would want to do this to be able to forcefully release the lock. This is currently difficult to do, as the thread ID which is stored in priority inheriting flag locks is not exposed through the C/C++ APIs.

This commit adds news APIs `get_owner_thread_id` (C++) and `flaglock_priority_inheriting_get_owner_thread_id` (C) to retrieve the thread ID of the owner of a lock.

Following this commit, error handlers can call `get_owner_thread_id` (or `flaglock_priority_inheriting_get_owner_thread_id`) on a lock and compare the result with `thread_id_get` to know if the thread which crashed owned the lock.