### PR TITLE
Add initial support for pre-shared globals.

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -1030,7 +1030,7 @@ class MState
 	 */
 	[[nodiscard]] __always_inline auto hazard_list_begin()
 	{
-		auto    *lockWord{MMIO_CAPABILITY(uint32_t, allocator_epoch)};
+		auto    *lockWord{SHARED_OBJECT(uint32_t, allocator_epoch)};
 		uint32_t epoch = *lockWord >> 16;
 		Debug::Invariant(
 		  (epoch & 1) == 0,
@@ -1280,8 +1280,8 @@ class MState
 	{
 		// It is now safe to walk the hazard list.
 		Capability<void *> hazards =
-		  const_cast<void **>(MMIO_CAPABILITY_WITH_PERMISSIONS(
-		    void *, hazard_pointers, true, true, true, false));
+		  const_cast<void **>(SHARED_OBJECT_WITH_PERMISSIONS(
+		    void *, allocator_hazard_pointers, true, true, true, false));
 		size_t pointers = hazards.length() / sizeof(void *);
 		for (size_t i = 0; i < pointers; i++)
 		{

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -88,8 +88,9 @@ namespace
 		Capability m{tbase.cast<MState>()};
 
 		size_t hazardQuarantineSize =
-		  Capability{MMIO_CAPABILITY_WITH_PERMISSIONS(
-		               void *, hazard_pointers, true, true, true, false)}
+		  Capability{
+		    SHARED_OBJECT_WITH_PERMISSIONS(
+		      void *, allocator_hazard_pointers, true, true, true, false)}
 		    .length();
 
 		m.bounds()            = sizeof(*m);

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -471,22 +471,18 @@ namespace
 			Debug::Invariant(
 			  ((entry.address >= LA_ABS(__mmio_region_start)) &&
 			   (entry.address + entry.size() <= LA_ABS(__mmio_region_end))) ||
-			    ((entry.address == LA_ABS(__export_mem_allocator_epoch)) &&
-			     (entry.address + entry.size() ==
-			      LA_ABS(__export_mem_allocator_epoch_end))) ||
-			    ((entry.address == LA_ABS(__export_mem_hazard_pointers)) &&
-			     (entry.address + entry.size() ==
-			      LA_ABS(__export_mem_hazard_pointers_end))),
-			  "{}--{} is not in the MMIO range ({}--{}) or the hazard pointer "
-			  "range ({}--{}) or the allocator epoch range ({}--{})",
+			    ((entry.address >= LA_ABS(__shared_objects_start)) &&
+			     (entry.address + entry.size() <=
+			      LA_ABS(__shared_objects_end))),
+			  "{}--{} is not in the MMIO range ({}--{}) or the shared object "
+			  "range ({}--{})",
 			  entry.address,
 			  entry.address + entry.size(),
 			  LA_ABS(__mmio_region_start),
 			  LA_ABS(__mmio_region_end),
-			  LA_ABS(__export_mem_hazard_pointers),
-			  LA_ABS(__export_mem_hazard_pointers_end),
-			  LA_ABS(__export_mem_allocator_epoch),
-			  LA_ABS(__export_mem_allocator_epoch_end));
+			  LA_ABS(__shared_objects_start),
+			  LA_ABS(__shared_objects_end));
+
 			auto ret = build(entry.address, entry.size());
 			// Remove any permissions that shouldn't be held here.
 			ret.permissions() &= entry.permissions();

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -778,9 +778,9 @@ namespace
 		        Root::Type::RWGlobal,
 		        PermissionSet{Permission::Store,
 		                      Permission::LoadStoreCapability}>(
-		    LA_ABS(__export_mem_hazard_pointers),
-		    LA_ABS(__export_mem_hazard_pointers_end) -
-		      LA_ABS(__export_mem_hazard_pointers));
+		    LA_ABS(__cheriot_shared_object_allocator_hazard_pointers),
+		    LA_ABS(__cheriot_shared_object_allocator_hazard_pointers_end) -
+		      LA_ABS(__cheriot_shared_object_allocator_hazard_pointers));
 		// Space per thread for hazard pointers.
 		static constexpr size_t HazardPointerSpace =
 		  HazardPointersPerThread * sizeof(void *);

--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -107,6 +107,20 @@ SECTIONS
 	}
 	.allocator_globals_end = .;
 
+
+	@software_revoker_globals@
+
+	@gdc_ld@
+
+	__compart_cgps_end = .;
+
+	.sealed_objects :
+	{
+		@sealed_objects@
+	}
+
+	__shared_objects_start = .;
+	@shared_objects@
 	. = ALIGN(8);
 	__export_mem_hazard_pointers = .;
 	# Two hazard pointers per thread
@@ -117,17 +131,9 @@ SECTIONS
 	. += 4;
 	__export_mem_allocator_epoch_end = .;
 	
+	__shared_objects_end = .;
 
-	@software_revoker_globals@
-
-	@gdc_ld@
-
-	.sealed_objects :
-	{
-		@sealed_objects@
-	}
-
-	__compart_cgps_end = ALIGN(64);
+	. = ALIGN(64);
 
 	# Everything after this point can be discarded after the loader has
 	# finished.

--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -121,16 +121,6 @@ SECTIONS
 
 	__shared_objects_start = .;
 	@shared_objects@
-	. = ALIGN(8);
-	__export_mem_hazard_pointers = .;
-	# Two hazard pointers per thread
-	. += @thread_count@ * 8 * 2;
-	__export_mem_hazard_pointers_end = .;
-	# 32-bit counter for allocator epochs.
-	__export_mem_allocator_epoch = .;
-	. += 4;
-	__export_mem_allocator_epoch_end = .;
-	
 	__shared_objects_end = .;
 
 	. = ALIGN(64);

--- a/sdk/lib/compartment_helpers/claim_fast.cc
+++ b/sdk/lib/compartment_helpers/claim_fast.cc
@@ -11,7 +11,7 @@ int heap_claim_fast(Timeout *timeout, const void *ptr, const void *ptr2)
 {
 	void   **hazards = switcher_thread_hazard_slots();
 	auto    *epochCounter{const_cast<
-      cheriot::atomic<uint32_t> *>(MMIO_CAPABILITY_WITH_PERMISSIONS(
+      cheriot::atomic<uint32_t> *>(SHARED_OBJECT_WITH_PERMISSIONS(
 	     cheriot::atomic<uint32_t>, allocator_epoch, true, false, false, false))};
 	uint32_t epoch  = epochCounter->load();
 	int      values = 2;

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -683,7 +683,12 @@ rule("firmware")
 			end
 		end)
 
-		local shared_objects = {}
+		local shared_objects = {
+			-- 32-bit counter for the hazard-pointer epoch.
+			allocator_epoch = 4,
+			-- Two hazard pointers per thread.
+			allocator_hazard_pointers = #(threads) * 8 * 2
+			}
 		visit_all_dependencies(function (target)
 			local globals = target:values("shared_objects")
 			if globals then

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -683,6 +683,37 @@ rule("firmware")
 			end
 		end)
 
+		local shared_objects = {}
+		visit_all_dependencies(function (target)
+			local globals = target:values("shared_objects")
+			if globals then
+				for name, size in pairs(globals) do
+					if not (name == "__wrap_locked__") then
+						if shared_objects[global] and (not (shared_objects[global] == size)) then
+							raise("Global " .. global .. " is declared with different sizes.")
+						end
+						shared_objects[name] = size
+					end
+				end
+			end
+		end)
+		-- TODO: We should sort pre-shared globals by size to minimise padding.
+		-- Each global is emitted as a separate section so that we can use
+		-- CAPALIGN and let the linker insert the required padding.
+		local shared_objects_template =
+			"\n\t\t. = ALIGN(MIN(${size}, 8));" ..
+			"\n\t\t__cheriot_shared_object_section_${global} : CAPALIGN" ..
+			"\n\t\t{" ..
+			"\n\t\t\t__cheriot_shared_object_${global} = .;" ..
+			"\n\t\t\t. += ${size};" ..
+			"\n\t\t\t__cheriot_shared_object_${global}_end = .;" ..
+			"\n\t\t}\n"
+		local shared_objects_section = ""
+		for global, size in table.orderpairs(shared_objects) do
+			shared_objects_section = shared_objects_section .. string.gsub(shared_objects_template, "${([_%w]*)}", {global=global, size=size})
+		end
+		ldscript_substitutions.shared_objects = shared_objects_section
+
 		-- Add the counts of libraries and compartments to the substitution list.
 		ldscript_substitutions.compartment_count = compartment_count
 		ldscript_substitutions.library_count = library_count

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -85,6 +85,9 @@ test("compartment_calls")
 test("check_pointer")
 -- Test various APIs that are too small to deserve their own test file
 test("misc")
+    on_load(function(target)
+        target:values_set("shared_objects", { exampleK = 1024, test_word = 4 }, {expand = false})
+    end)
 
 includes(path.join(sdkdir, "lib"))
 


### PR DESCRIPTION
This provides a mechanism to statically define globals that can be shared between compartments statically.  As with MMIO imports, these can be imported with restricted permissions.

They currently show up in the audit log as MMIO imports.  This is not ideal, we should plumb their names through into the audit log so that cheriot-audit can check that all references to a pre-shared object refer to exactly one object.

Fixes #282