### PR TITLE
Reduce the permissions on hazard pointers.

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -1281,7 +1281,7 @@ class MState
 		// It is now safe to walk the hazard list.
 		Capability<void *> hazards =
 		  const_cast<void **>(SHARED_OBJECT_WITH_PERMISSIONS(
-		    void *, allocator_hazard_pointers, true, true, true, false));
+		    void *, allocator_hazard_pointers, true, false, true, false));
 		size_t pointers = hazards.length() / sizeof(void *);
 		for (size_t i = 0; i < pointers; i++)
 		{

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -90,7 +90,7 @@ namespace
 		size_t hazardQuarantineSize =
 		  Capability{
 		    SHARED_OBJECT_WITH_PERMISSIONS(
-		      void *, allocator_hazard_pointers, true, true, true, false)}
+		      void *, allocator_hazard_pointers, true, false, true, false)}
 		    .length();
 
 		m.bounds()            = sizeof(*m);


### PR DESCRIPTION
The allocator is happy with just load + capability permissions.  Without store, it can't accidentally damage hazard lists.  Without load-mutable, it can't accidentally load a writeable capability.

This is purely defence in depth.  The allocator can still write to any heap memory, so not being able to load mutable capabilities doesn't restrict what it can do.  The allocator can still ignore hazard pointers, so not being able to write them is also no reduction in ability.  It simply constrains where bugs must be.