### PR TITLE
Fix a bug in the Sonata Ethernet driver.

### DIFF
--- a/sdk/include/platform/sunburst/platform-ethernet.hh
+++ b/sdk/include/platform/sunburst/platform-ethernet.hh
@@ -711,7 +711,7 @@ class Ksz8851Ethernet
 			framesToProcess -= 1;
 
 			Capability<uint8_t> boundedBuffer{receiveBuffer.get()};
-			boundedBuffer.bounds() = length;
+			boundedBuffer.bounds().set_inexact(length);
 			// Remove all permissions except load.  This also removes global, so
 			// that this cannot be captured.
 			boundedBuffer.permissions() &=


### PR DESCRIPTION
The returned Ethernet frame was precisely bounded, but Ethernet frames can be all sorts of odd sizes and may not be representable with the capability bounds encoding.  This resulted in the tag being cleared, which caused a trap in the firewall.  The firewall is designed to fail closed, so this then prevented any further packets from arriving.

The bounding is purely defence in depth, so it's fine to use imprecise bounds here.