### PR TITLE
Sonata Ethernet driver cleanups.

### DIFF
--- a/sdk/boards/sonata-0.2.json
+++ b/sdk/boards/sonata-0.2.json
@@ -70,7 +70,9 @@
         "IBEX",
         "SUNBURST",
         "SUNBURST_SHADOW_BASE=0x30000000",
-        "SUNBURST_SHADOW_SIZE=0x4000"
+        "SUNBURST_SHADOW_SIZE=0x4000",
+        "ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM=1",
+        "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1"
     ],
     "driver_includes" : [
         "../include/platform/sunburst",

--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -77,7 +77,9 @@
         "IBEX",
         "SUNBURST",
         "SUNBURST_SHADOW_BASE=0x30000000",
-        "SUNBURST_SHADOW_SIZE=0x4000"
+        "SUNBURST_SHADOW_SIZE=0x4000",
+        "ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM=1",
+        "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1"
     ],
     "driver_includes" : [
         "../include/platform/sunburst",

--- a/sdk/include/platform/sunburst/platform-ethernet.hh
+++ b/sdk/include/platform/sunburst/platform-ethernet.hh
@@ -32,7 +32,7 @@ class Ksz8851Ethernet
 	/**
 	 * Flag set to log messages when frames are dropped.
 	 */
-	static constexpr bool DebugDroppedFrames = false;
+	static constexpr bool DebugDroppedFrames = true;
 
 	/**
 	 * Maxmium size of a single Ethernet frame.
@@ -43,6 +43,12 @@ class Ksz8851Ethernet
 	 * Helper for conditional debug logs and assertions.
 	 */
 	using Debug = ConditionalDebug<DebugEthernet, "Ethernet driver">;
+
+	/**
+	 * Helper for conditional debug logs and assertions for dropped frames.
+	 */
+	using DebugFrameDrops =
+	  ConditionalDebug<DebugDroppedFrames, "Ethernet driver">;
 
 	/**
 	 * Import the Capability helper from the CHERI namespace.
@@ -649,10 +655,7 @@ class Ksz8851Ethernet
 
 			if (!valid)
 			{
-				if (DebugDroppedFrames)
-				{
-					Debug::log("Dropping frame with status: {}", status);
-				}
+				DebugFrameDrops::log("Dropping frame with status: {}", status);
 
 				drop_error_frame();
 				continue;
@@ -660,10 +663,7 @@ class Ksz8851Ethernet
 
 			if (length == 0)
 			{
-				if (DebugDroppedFrames)
-				{
-					Debug::log("Dropping frame with zero length");
-				}
+				DebugFrameDrops::log("Dropping frame with zero length");
 
 				drop_error_frame();
 				continue;
@@ -674,10 +674,8 @@ class Ksz8851Ethernet
 			uint16_t paddedLength = (length + 3) & ~0x3;
 			if (paddedLength > MaxFrameSize)
 			{
-				if (DebugDroppedFrames)
-				{
-					Debug::log("Dropping frame that is too large: {}", length);
-				}
+				DebugFrameDrops::log("Dropping frame that is too large: {}",
+				                     length);
 
 				drop_error_frame();
 				continue;


### PR DESCRIPTION
The log packet filtering was being wrapped in a conditional and then using a template that used a different conditional, so never reported anything.  Fix this to instantiate the template properly.

Also add two defines that tell FreeRTOS+TCP the offload features that this network interface exposes.  This improves performance and reduces code size.