### PR TITLE
Implement PWM Driver for Sonata Board

### DIFF
--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -63,6 +63,10 @@
         "plic": {
             "start" : 0x88000000,
             "end"   : 0x88400000
+        },
+        "pwm": {
+            "start" : 0x80001000,
+            "length": 0x00001000
         }
     },
     "instruction_memory": {

--- a/sdk/include/platform/sunburst/platform-pwm.hh
+++ b/sdk/include/platform/sunburst/platform-pwm.hh
@@ -1,0 +1,68 @@
+#pragma once
+#include <debug.hh>
+#include <stdint.h>
+
+/**
+ * A driver for Sonata's Pulse-Width Modulation (PWM).
+ *
+ * Documentation source can be found at:
+ * https://github.com/lowRISC/sonata-system/blob/97a525c48f7bf051b999d0178dba04859819bc5e/doc/ip/pwm.md
+ *
+ * Rendered documentation is served from:
+ * https://lowrisc.github.io/sonata-system/doc/ip/pwm.html
+ */
+struct SonataPulseWidthModulation
+{
+	/**
+	 * Flag to set when debugging the driver for UART log messages.
+	 */
+	static constexpr bool DebugDriver = false;
+
+	/**
+	 * Helper for conditional debug logs and assertions.
+	 */
+	using Debug = ConditionalDebug<DebugDriver, "PWM">;
+
+	/**
+	 * The number of pulse-width modulated outputs that are available.
+	 */
+	static constexpr size_t OutputCount = 1;
+
+	/**
+	 * The pulse-width modulation outputs available on Sonata.
+	 */
+	struct OutputRegisters
+	{
+		/**
+		 * The duty cycle of the wave, represented as a width counter. That
+		 * is, the number of clock cycles for which the signal will be on. The
+		 * duty cycle as a percentage is (duty cycle / period) * 100.
+		 */
+		uint32_t dutyCycle;
+
+		/**
+		 * The period (width) of the output block wave, set with the number of
+		 * clock cycles that one period should last. The maximum period is 255
+		 * as only an 8 bit counter is being used.
+		 */
+		uint32_t period;
+	} outputs[OutputCount];
+
+	/*
+	 * Sets the output of a specified pulse-width modulated output.
+	 *
+	 * The first argument is the index of the output. The second argument is
+	 * the period (length) of the output wave represented as a counter of
+	 * system clock cycles. The third argument is the number of clock cycles
+	 * for which a high pulse is sent within that period.
+	 *
+	 * So for example `output_set(0, 200, 31)` should set a 15.5% output.
+	 */
+	void output_set(uint32_t index, uint8_t period, uint8_t dutyCycle) volatile
+	{
+		Debug::Assert(index < OutputCount, "Specified PWM is out of range");
+		Debug::Assert(dutyCycle <= period, "Duty cycle cannot exceed 100%");
+		outputs[index].period    = period;
+		outputs[index].dutyCycle = dutyCycle;
+	}
+};


### PR DESCRIPTION
This PR implements a driver for the Pulse-Width Modulation (PWM) used on the Sonata board.

Note that the linked documentation source is currently out of date - I believe that @HU90m intends to update that to reflect the actual hardware, which is what this driver is based on.

I've confirmed that this is working for the 1 PWM that we have on Sonata by implementing the following in a simple piece of firmware with a single compartment: 
```cpp
#include <compartment.h>
#include <platform-pwm.hh>
#include <thread.h>

void __cheri_compartment("pwm_test") pwm_test()
{	
	auto pwm = MMIO_CAPABILITY(SonataPulseWidthModulation, pwm);
	uint8_t counter = 0;
	while (true) 
        {
		counter = (counter + 1) % 255;
		pwm->output_set(0, 255, counter);
		thread_millisecond_wait(50);
	}
}
```

Checking with a Multimeter I can then see analogue variation between 0V and 3.3V on the mikroBUS PWM output. 

Sonata currently only supports 1 PWM but this could potentially be changed, so I've designed the driver to be extensible for this case.