### PR TITLE
Add stdaligned.h & stdnoreturn.h.

### DIFF
--- a/sdk/include/stdalign.h
+++ b/sdk/include/stdalign.h
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STDALIGN_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STDALIGN_H_
+
+/**
+ * @file
+ * @brief C library Alignment (Freestanding)
+ *
+ * This header implements the stdalign.h standard header, as required by C11
+ * S4p6. This header is specified in detail in S7.15 of the same.
+ */
+
+#define alignas _Alignas
+#define __alignas_is_defined 1
+
+#define alignof _Alignof
+#define __alignof_is_defined 1
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STDALIGN_H_

--- a/sdk/include/stdnoreturn.h
+++ b/sdk/include/stdnoreturn.h
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STDNORETURN_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STDNORETURN_H_
+
+/**
+ * @file
+ * @brief C library _Noreturn (Freestanding)
+ *
+ * This header implements the stdnoreturn.h standard header, as required by C11
+ * S4p6. This header is specified in detail in S7.23 of the same.
+ */
+
+#define noreturn _Noreturn
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_FREESTANDING_STDNORETURN_H_


### PR DESCRIPTION
Added in C11, deprecated in C23.

Pulled verbatim from OpenTitan. 
