### PR TITLE
Add stdalign.h and stdnoreturn.h.

### DIFF
--- a/scripts/run_clang_tidy_format.sh
+++ b/scripts/run_clang_tidy_format.sh
@@ -35,7 +35,7 @@ DIRECTORIES="sdk tests examples"
 # FreeRTOS-Compat headers follow FreeRTOS naming conventions and should be
 # excluded for now.  Eventually they should be included for everything except
 # the identifier naming checks.
-HEADERS=$(find ${DIRECTORIES} -name '*.h' -or -name '*.hh' | grep -v libc++ | grep -v third_party | grep -v 'std.*.h' | grep -v errno.h | grep -v strings.h | grep -v string.h | grep -v -assembly.h | grep -v cdefs.h | grep -v /riscv.h | grep -v inttypes.h | grep -v /cheri-builtins.h | grep -v c++-config | grep -v ctype.h | grep -v switcher.h | grep -v assert.h | grep -v /build/ | grep -v microvium | grep -v FreeRTOS-Compat)
+HEADERS=$(find ${DIRECTORIES} -name '*.h' -or -name '*.hh' | grep -v libc++ | grep -v third_party | grep -v 'std.*.h' | grep -v errno.h | grep -v strings.h | grep -v string.h | grep -v -assembly.h | grep -v cdefs.h | grep -v /riscv.h | grep -v inttypes.h | grep -v /cheri-builtins.h | grep -v c++-config | grep -v ctype.h | grep -v switcher.h | grep -v assert.h | grep -v std*.h | grep -v /build/ | grep -v microvium | grep -v FreeRTOS-Compat)
 SOURCES=$(find ${DIRECTORIES} -name '*.cc' | grep -v /build/ | grep -v third_party | grep -v arith64.c)
 
 echo Headers: ${HEADERS}

--- a/sdk/include/stdalign.h
+++ b/sdk/include/stdalign.h
@@ -11,12 +11,12 @@
 #	if __STDC_VERSION__ < 202311L
 
 /**
- * C++-compatible spelling for `_Alisnas`.
+ * C++-compatible spelling for `_Alignas`.
  */
 #		define alignas(__x) _Alignas(__x)
 
 /**
- * C++-compatible spelling for `_Alisnof`.
+ * C++-compatible spelling for `_Alignof`.
  */
 #		define alignof(__x) _Alignof(__x)
 

--- a/sdk/include/stdalign.h
+++ b/sdk/include/stdalign.h
@@ -1,0 +1,27 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright CHERIoT Contributors
+
+/**
+ * This header is part of C11 (and supported for compatibility in older
+ * versions) but is gone in C23 because the C keywords matching their C++
+ * equivalents were added.
+ */
+#ifdef __STDC_VERSION__
+#	if __STDC_VERSION__ < 202311L
+
+/**
+ * C++-compatible spelling for `_Alisnas`.
+ */
+#		define alignas(__x) _Alignas(__x)
+
+/**
+ * C++-compatible spelling for `_Alisnof`.
+ */
+#		define alignof(__x) _Alignof(__x)
+
+#		define __alignas_is_defined 1
+#		define __alignof_is_defined 1
+
+#	endif
+#endif

--- a/sdk/include/stdnoreturn.h
+++ b/sdk/include/stdnoreturn.h
@@ -1,0 +1,19 @@
+#pragma once
+// SPDX-License-Identifier: MIT
+// Copyright CHERIoT Contributors
+
+/**
+ * This header is part of C11 (and supported for compatibility in older
+ * versions) but is gone in C23 because the C keywords were moved out of the
+ * reserved-for-the-implementation namespace into the global one.
+ */
+#ifdef __STDC_VERSION__
+#	if __STDC_VERSION__ < 202311L
+
+/**
+ * C++-compatible spelling for `_Alisnas`.
+ */
+#		define noreturn _Noreturn
+
+#	endif
+#endif

--- a/sdk/include/stdnoreturn.h
+++ b/sdk/include/stdnoreturn.h
@@ -11,7 +11,7 @@
 #	if __STDC_VERSION__ < 202311L
 
 /**
- * C++-compatible spelling for `_Alisnas`.
+ * C++-compatible spelling for `_Noreturn`.
  */
 #		define noreturn _Noreturn
 

--- a/tests/ccompile-test.c
+++ b/tests/ccompile-test.c
@@ -21,6 +21,7 @@
 #include <multiwaiter.h>
 #include <queue.h>
 #include <riscvreg.h>
+#include <stdalign.h>
 #include <stdarg.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -28,6 +29,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdnoreturn.h>
 #include <string.h>
 #include <strings.h>
 #include <switcher.h>


### PR DESCRIPTION
These were added in C11 and removed in C23.  The implementations are no-ops in C++ and C >= C23 modes.