### PR TITLE
Add some primitive unwinding support

### DIFF
--- a/scripts/run_clang_tidy_format.sh
+++ b/scripts/run_clang_tidy_format.sh
@@ -35,7 +35,7 @@ DIRECTORIES="sdk tests examples"
 # FreeRTOS-Compat headers follow FreeRTOS naming conventions and should be
 # excluded for now.  Eventually they should be included for everything except
 # the identifier naming checks.
-HEADERS=$(find ${DIRECTORIES} -name '*.h' -or -name '*.hh' | grep -v libc++ | grep -v third_party | grep -v 'std.*.h' | grep -v errno.h | grep -v strings.h | grep -v string.h | grep -v -assembly.h | grep -v cdefs.h | grep -v /riscv.h | grep -v inttypes.h | grep -v /cheri-builtins.h | grep -v c++-config | grep -v ctype.h | grep -v switcher.h | grep -v assert.h | grep -v std*.h | grep -v /build/ | grep -v microvium | grep -v FreeRTOS-Compat)
+HEADERS=$(find ${DIRECTORIES} -name '*.h' -or -name '*.hh' | grep -v libc++ | grep -v third_party | grep -v 'std.*.h' | grep -v errno.h | grep -v strings.h | grep -v string.h | grep -v -assembly.h | grep -v cdefs.h | grep -v /riscv.h | grep -v inttypes.h | grep -v /cheri-builtins.h | grep -v c++-config | grep -v ctype.h | grep -v switcher.h | grep -v assert.h | grep -v std*.h | grep -v setjmp.h | grep -v unwind.h | grep -v /build/ | grep -v microvium | grep -v FreeRTOS-Compat)
 SOURCES=$(find ${DIRECTORIES} -name '*.cc' | grep -v /build/ | grep -v third_party | grep -v arith64.c)
 
 echo Headers: ${HEADERS}

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -828,10 +828,10 @@ namespace
 
 } // namespace
 
-__cheriot_minimum_stack(0x80) ssize_t
+__cheriot_minimum_stack(0x90) ssize_t
   heap_quota_remaining(struct SObjStruct *heapCapability)
 {
-	STACK_CHECK(0x80);
+	STACK_CHECK(0x90);
 	LockGuard g{lock};
 	auto     *cap = malloc_capability_unseal(heapCapability);
 	if (cap == nullptr)
@@ -841,9 +841,9 @@ __cheriot_minimum_stack(0x80) ssize_t
 	return cap->quota;
 }
 
-__cheriot_minimum_stack(0xb0) void heap_quarantine_empty()
+__cheriot_minimum_stack(0xc0) void heap_quarantine_empty()
 {
-	STACK_CHECK(0xb0);
+	STACK_CHECK(0xc0);
 	LockGuard g{lock};
 	while (gm->heapQuarantineSize > 0)
 	{
@@ -857,12 +857,12 @@ __cheriot_minimum_stack(0xb0) void heap_quarantine_empty()
 	}
 }
 
-__cheriot_minimum_stack(0x200) void *heap_allocate(Timeout *timeout,
+__cheriot_minimum_stack(0x210) void *heap_allocate(Timeout *timeout,
                                                    SObj     heapCapability,
                                                    size_t   bytes,
                                                    uint32_t flags)
 {
-	STACK_CHECK(0x200);
+	STACK_CHECK(0x210);
 	if (!check_timeout_pointer(timeout))
 	{
 		return nullptr;
@@ -882,10 +882,10 @@ __cheriot_minimum_stack(0x200) void *heap_allocate(Timeout *timeout,
 	return malloc_internal(bytes, std::move(g), cap, timeout, false, flags);
 }
 
-__cheriot_minimum_stack(0x1b0) ssize_t
+__cheriot_minimum_stack(0x1c0) ssize_t
   heap_claim(SObj heapCapability, void *pointer)
 {
-	STACK_CHECK(0x1b0);
+	STACK_CHECK(0x1c0);
 	LockGuard g{lock};
 	auto     *cap = malloc_capability_unseal(heapCapability);
 	if (cap == nullptr)
@@ -912,18 +912,18 @@ __cheriot_minimum_stack(0x1b0) ssize_t
 	return 0;
 }
 
-__cheriot_minimum_stack(0xe0) int heap_can_free(SObj  heapCapability,
+__cheriot_minimum_stack(0xf0) int heap_can_free(SObj  heapCapability,
                                                 void *rawPointer)
 {
-	STACK_CHECK(0xe0);
+	STACK_CHECK(0xf0);
 	LockGuard g{lock};
 	return heap_free_internal(heapCapability, rawPointer, false);
 }
 
-__cheriot_minimum_stack(0x250) int heap_free(SObj  heapCapability,
+__cheriot_minimum_stack(0x260) int heap_free(SObj  heapCapability,
                                              void *rawPointer)
 {
-	STACK_CHECK(0x250);
+	STACK_CHECK(0x260);
 	LockGuard g{lock};
 	int       ret = heap_free_internal(heapCapability, rawPointer, true);
 	if (ret != 0)
@@ -942,9 +942,9 @@ __cheriot_minimum_stack(0x250) int heap_free(SObj  heapCapability,
 	return 0;
 }
 
-__cheriot_minimum_stack(0x180) ssize_t heap_free_all(SObj heapCapability)
+__cheriot_minimum_stack(0x190) ssize_t heap_free_all(SObj heapCapability)
 {
-	STACK_CHECK(0x180);
+	STACK_CHECK(0x190);
 	LockGuard g{lock};
 	auto     *capability = malloc_capability_unseal(heapCapability);
 	if (capability == nullptr)
@@ -981,13 +981,13 @@ __cheriot_minimum_stack(0x180) ssize_t heap_free_all(SObj heapCapability)
 	return freed;
 }
 
-__cheriot_minimum_stack(0x200) void *heap_allocate_array(Timeout *timeout,
+__cheriot_minimum_stack(0x210) void *heap_allocate_array(Timeout *timeout,
                                                          SObj   heapCapability,
                                                          size_t nElements,
                                                          size_t elemSize,
                                                          uint32_t flags)
 {
-	STACK_CHECK(0x200);
+	STACK_CHECK(0x210);
 	if (!check_timeout_pointer(timeout))
 	{
 		return nullptr;
@@ -1158,14 +1158,14 @@ SKey token_key_new()
 	return nullptr;
 }
 
-__cheriot_minimum_stack(0x270) SObj
+__cheriot_minimum_stack(0x280) SObj
   token_sealed_unsealed_alloc(Timeout *timeout,
                               SObj     heapCapability,
                               SKey     key,
                               size_t   sz,
                               void   **unsealed)
 {
-	STACK_CHECK(0x270);
+	STACK_CHECK(0x280);
 	if (!check_timeout_pointer(timeout))
 	{
 		return INVALID_SOBJ;
@@ -1185,12 +1185,12 @@ __cheriot_minimum_stack(0x270) SObj
 	return INVALID_SOBJ;
 }
 
-__cheriot_minimum_stack(0x250) SObj token_sealed_alloc(Timeout *timeout,
+__cheriot_minimum_stack(0x260) SObj token_sealed_alloc(Timeout *timeout,
                                                        SObj     heapCapability,
                                                        SKey     rawKey,
                                                        size_t   sz)
 {
-	STACK_CHECK(0x250);
+	STACK_CHECK(0x260);
 	return allocate_sealed_unsealed(
 	         timeout, heapCapability, rawKey, sz, {Permission::Seal})
 	  .first;
@@ -1218,11 +1218,11 @@ __noinline static SealedAllocation unseal_internal(SKey rawKey, SObj obj)
 	return unseal_if_valid(obj);
 }
 
-__cheriot_minimum_stack(0x250) int token_obj_destroy(SObj heapCapability,
+__cheriot_minimum_stack(0x260) int token_obj_destroy(SObj heapCapability,
                                                      SKey key,
                                                      SObj object)
 {
-	STACK_CHECK(0x250);
+	STACK_CHECK(0x260);
 	void *unsealed;
 	{
 		LockGuard g{lock};
@@ -1240,11 +1240,11 @@ __cheriot_minimum_stack(0x250) int token_obj_destroy(SObj heapCapability,
 	return heap_free(heapCapability, unsealed);
 }
 
-__cheriot_minimum_stack(0xe0) int token_obj_can_destroy(SObj heapCapability,
+__cheriot_minimum_stack(0xf0) int token_obj_can_destroy(SObj heapCapability,
                                                         SKey key,
                                                         SObj object)
 {
-	STACK_CHECK(0xe0);
+	STACK_CHECK(0xf0);
 	void *unsealed;
 	{
 		LockGuard g{lock};

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -434,10 +434,10 @@ SystickReturn __cheri_compartment("sched") thread_systemtick_get()
 	return ret;
 }
 
-__cheriot_minimum_stack(0x80) int __cheri_compartment("sched")
+__cheriot_minimum_stack(0x90) int __cheri_compartment("sched")
   thread_sleep(Timeout *timeout, uint32_t flags)
 {
-	STACK_CHECK(0x80);
+	STACK_CHECK(0x90);
 	if (!check_timeout_pointer(timeout))
 	{
 		return -EINVAL;
@@ -449,12 +449,12 @@ __cheriot_minimum_stack(0x80) int __cheri_compartment("sched")
 	return 0;
 }
 
-__cheriot_minimum_stack(0xa0) int futex_timed_wait(Timeout        *timeout,
+__cheriot_minimum_stack(0xb0) int futex_timed_wait(Timeout        *timeout,
                                                    const uint32_t *address,
                                                    uint32_t        expected,
                                                    uint32_t        flags)
 {
-	STACK_CHECK(0xa0);
+	STACK_CHECK(0xb0);
 	if (!check_timeout_pointer(timeout) ||
 	    !check_pointer<PermissionSet{Permission::Load}>(address))
 	{
@@ -536,9 +536,9 @@ __cheriot_minimum_stack(0xa0) int futex_timed_wait(Timeout        *timeout,
 	return 0;
 }
 
-__cheriot_minimum_stack(0x90) int futex_wake(uint32_t *address, uint32_t count)
+__cheriot_minimum_stack(0xa0) int futex_wake(uint32_t *address, uint32_t count)
 {
-	STACK_CHECK(0x90);
+	STACK_CHECK(0xa0);
 	if (!check_pointer<PermissionSet{Permission::Store}>(address))
 	{
 		return -EINVAL;
@@ -577,13 +577,13 @@ __cheriot_minimum_stack(0x90) int futex_wake(uint32_t *address, uint32_t count)
 	return woke;
 }
 
-__cheriot_minimum_stack(0x50) int multiwaiter_create(
+__cheriot_minimum_stack(0x60) int multiwaiter_create(
   Timeout           *timeout,
   struct SObjStruct *heapCapability,
   MultiWaiter      **ret,
   size_t             maxItems)
 {
-	STACK_CHECK(0x50);
+	STACK_CHECK(0x60);
 	int error;
 	// Don't bother checking if timeout is valid, the allocator will check for
 	// us.
@@ -597,20 +597,20 @@ __cheriot_minimum_stack(0x50) int multiwaiter_create(
 	return write_result(reinterpret_cast<void **>(ret), mw);
 }
 
-__cheriot_minimum_stack(0x60) int multiwaiter_delete(
+__cheriot_minimum_stack(0x70) int multiwaiter_delete(
   struct SObjStruct *heapCapability,
   MultiWaiter       *mw)
 {
-	STACK_CHECK(0x60);
+	STACK_CHECK(0x70);
 	return deallocate<MultiWaiterInternal>(heapCapability, mw);
 }
 
-__cheriot_minimum_stack(0xb0) int multiwaiter_wait(Timeout           *timeout,
+__cheriot_minimum_stack(0xc0) int multiwaiter_wait(Timeout           *timeout,
                                                    MultiWaiter       *waiter,
                                                    EventWaiterSource *events,
                                                    size_t newEventsCount)
 {
-	STACK_CHECK(0xb0);
+	STACK_CHECK(0xc0);
 	return typed_op<MultiWaiterInternal>(waiter, [&](MultiWaiterInternal &mw) {
 		if (newEventsCount > mw.capacity())
 		{
@@ -699,9 +699,9 @@ namespace
 } // namespace
 
 [[cheri::interrupt_state(disabled)]] __cheriot_minimum_stack(
-  0x20) const uint32_t *interrupt_futex_get(struct SObjStruct *sealed)
+  0x30) const uint32_t *interrupt_futex_get(struct SObjStruct *sealed)
 {
-	STACK_CHECK(0x20);
+	STACK_CHECK(0x30);
 	auto     *interruptCapability = Handle::unseal<InterruptCapability>(sealed);
 	uint32_t *result              = nullptr;
 	if (interruptCapability && interruptCapability->state.mayWait)
@@ -719,9 +719,9 @@ namespace
 }
 
 [[cheri::interrupt_state(disabled)]] __cheriot_minimum_stack(
-  0x10) int interrupt_complete(struct SObjStruct *sealed)
+  0x20) int interrupt_complete(struct SObjStruct *sealed)
 {
-	STACK_CHECK(0x10);
+	STACK_CHECK(0x20);
 	auto *interruptCapability = Handle::unseal<InterruptCapability>(sealed);
 	if (interruptCapability && interruptCapability->state.mayComplete)
 	{

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -227,6 +227,8 @@ __Z26compartment_switcher_entryz:
 #endif
 	zero_stack         t2, s0, gp
 after_zero:
+	// Reserve space for unwind state and so on.
+	cincoffset 	       csp, csp, -16
 #ifdef CONFIG_MSHWM
 	// store new stack top as stack high water mark
 	csrw               CSR_MSHWM, sp
@@ -256,6 +258,8 @@ after_zero:
 	// At this point, we have already truncated the stack and so the length of
 	// the stack is the length that the callee can use.
 	cgetlen            t2, csp
+	// Include the space we reserved for the unwind state.
+	addi               t2, t2, -16
 	bgtu               tp, t2, .Lstack_too_small
 
 	// Get the flags field into tp

--- a/sdk/include/setjmp.h
+++ b/sdk/include/setjmp.h
@@ -1,0 +1,64 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+/**
+ * This is a minimal implementation of setjmp/longjmp.
+ *
+ * CHERIoT cannot store a `jmp_buf` anywhere other than the stack without
+ * clearing tags (which will then cause `longjmp` to fail).
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * Jump buffer for setjmp/longjmp.
+ */
+struct __jmp_buf
+{
+	uintptr_t __cs0;
+	uintptr_t __cs1;
+	uintptr_t __csp;
+	uintptr_t __cra;
+};
+
+/**
+ * C requires that `setjmp` and `longjmp` take a `jmp_buf` by reference and so
+ * this ends up being defined as an array of one element, which allows it to
+ * both be allocated and passed by reference.
+ */
+typedef struct __jmp_buf jmp_buf[1];
+
+/**
+ * C `setjmp` function.  Returns (up to) twice.  First returns 0, returns a
+ * value passed to `longjmp` on the second return.
+ */
+__attribute__((returns_twice)) extern "C" int setjmp(jmp_buf env);
+__asm__(".section .text.setjmp,\"awG\",@progbits,setjmp,comdat\n"
+        ".globl setjmp\n"
+        ".p2align 2\n"
+        ".type setjmp,@function\n"
+        "setjmp:\n"
+        "	csc	cs0, 0(ca0)\n"
+        "	csc	cs1, 8(ca0)\n"
+        "	csc	csp, 16(ca0)\n"
+        "	csc	cra, 24(ca0)\n"
+        "	li	a0, 0\n"
+        "	cret\n");
+
+/**
+ * C `longjmp` function.  Does not return, jumps back to the `setjmp` call.
+ */
+extern "C" void longjmp(jmp_buf env, int val);
+__asm__(".section .text.longjmp,\"awG\",@progbits,longjmp,comdat\n"
+        ".globl longjmp\n"
+        ".p2align 2\n"
+        ".type longjmp,@function\n"
+        "longjmp:\n"
+        "	clc	cs0, 0(ca0)\n"
+        "	clc	cs1, 8(ca0)\n"
+        "	clc	csp, 16(ca0)\n"
+        "	clc	cra, 24(ca0)\n"
+        "	mv	a0, a1\n"
+        "	cjr	cra\n");

--- a/sdk/include/unwind.h
+++ b/sdk/include/unwind.h
@@ -1,0 +1,98 @@
+#pragma once
+#include <cdefs.h>
+#include <setjmp.h>
+
+/**
+ * On-stack linked list of cleanup handlers.
+ */
+struct CleanupList
+{
+	/// Next pointer.
+	CleanupList *next;
+	/// Jump buffer to return to.
+	__jmp_buf env;
+};
+
+/**
+ * Head of the cleanup list.
+ *
+ * This is stored in the space that the switcher reserves at the top of the
+ * stack.  The stack is zeroed on entry to a compartment and so this will be
+ * null until explicitly written to.
+ */
+__always_inline static inline struct CleanupList **cleanup_list_head()
+{
+	void     *csp = __builtin_cheri_stack_get();
+	ptraddr_t top =
+	  __builtin_cheri_base_get(csp) + __builtin_cheri_length_get(csp);
+	csp = __builtin_cheri_address_set(csp, top - 8);
+	return (struct CleanupList **)csp;
+}
+
+/**
+ * Unwind the stack to the most recent `CHERIOT_HANDLER` block.
+ */
+__always_inline static inline void cleanup_unwind(void)
+{
+	CleanupList **__head = cleanup_list_head();
+	CleanupList  *__top  = *__head;
+	*__head              = __top->next;
+	longjmp(&__top->env, 1);
+}
+
+/**
+ * Simple error handling macros.  These are modelled on the OpenStep exception
+ * macros and are similarly built on top of `setjmp`.  Code between
+ * `CHERIOT_DURING` and `CHERIOT_HANDLER` corresponds to a `try` block.  Code
+ * between `CHERIOT_HANDLER` and `CHERIOT_END_HANDLER` corresponds to a `catch`
+ * block, though no exception value is actually thrown.
+ *
+ * Any automatic-storage values accessed in both blocks must be declared
+ * `volatile`.
+ */
+#define CHERIOT_DURING                                                         \
+	{                                                                          \
+		CleanupList cleanupListEntry;                                          \
+		auto      **__head    = cleanup_list_head();                           \
+		cleanupListEntry.next = *__head;                                       \
+		*__head               = &cleanupListEntry;                             \
+		if (setjmp(&cleanupListEntry.env) == 0)                                \
+		{
+/// See CHERIOT_DURING.
+#define CHERIOT_HANDLER                                                        \
+	*__head = cleanupListEntry.next;                                           \
+	}                                                                          \
+	else                                                                       \
+	{                                                                          \
+		*__head = cleanupListEntry.next;
+
+/// See CHERIOT_DURING.
+#define CHERIOT_END_HANDLER                                                    \
+	}                                                                          \
+	}
+
+#ifdef __cplusplus
+
+/**
+ * On-error helper.  Invokes `fn` and, if `cleanup_unwind` is called, invokes
+ * `err`.  Destructors in between `fn` and the frame that calls
+ * `cleanup_unwind` are not called, but this function returns normally and so
+ * destructors of objects above this on the stack will be called normally.
+ */
+void on_error(auto fn, auto err)
+{
+	CHERIOT_DURING
+	fn();
+	CHERIOT_HANDLER
+	err();
+	CHERIOT_END_HANDLER
+}
+
+/**
+ * On-error helper with no error handler (returns normally from forced unwind).
+ */
+void on_error(auto fn)
+{
+	on_error(fn, []() {});
+}
+#endif

--- a/tests/stack-test.cc
+++ b/tests/stack-test.cc
@@ -127,17 +127,17 @@ __cheri_callback void (*volatile crossCompartmentCall)();
  */
 void test_stack()
 {
-	int ret = test_with_small_stack(128);
-	TEST(ret == 0,
-	     "test_with_small_stack failed, returned {} with 128-byte stack",
-	     ret);
-	ret = test_with_small_stack(144);
+	int ret = test_with_small_stack(144);
 	TEST(ret == 0,
 	     "test_with_small_stack failed, returned {} with 144-byte stack",
 	     ret);
-	ret = test_with_small_stack(112);
+	ret = test_with_small_stack(160);
+	TEST(ret == 0,
+	     "test_with_small_stack failed, returned {} with 160-byte stack",
+	     ret);
+	ret = test_with_small_stack(128);
 	TEST(ret == -ENOTENOUGHSTACK,
-	     "test_with_small_stack failed, returned {} with 112-byte stack",
+	     "test_with_small_stack failed, returned {} with 128-byte stack",
 	     ret);
 	__cheri_callback void (*callback)() = cross_compartment_call;
 

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -115,6 +115,7 @@ void __cheri_compartment("test_runner") run_tests()
 		run_timed("Debug helpers (C++)", test_debug_cxx);
 		run_timed("Debug helpers (C)", test_debug_c);
 		run_timed("MMIO", test_mmio);
+		run_timed("Unwind cleanup", test_unwind_cleanup);
 		run_timed("stdio", test_stdio);
 		run_timed("Static sealing", test_static_sealing);
 		run_timed("Crash recovery", test_crash_recovery);

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -23,6 +23,7 @@ __cheri_compartment("static_sealing_test") void test_static_sealing();
 __cheri_compartment("stdio_test") void test_stdio();
 __cheri_compartment("debug_test") void test_debug_cxx();
 __cheri_compartment("debug_test") void test_debug_c();
+__cheri_compartment("unwind_cleanup_test") void test_unwind_cleanup();
 
 // Simple tests don't need a separate compartment.
 void test_global_constructors();

--- a/tests/unwind_cleanup-test.cc
+++ b/tests/unwind_cleanup-test.cc
@@ -1,0 +1,104 @@
+// Copyright CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#define TEST_NAME "Test unwind cleanup"
+#include "locks.hh"
+#include "tests.hh"
+#include "unwind.h"
+
+extern "C" ErrorRecoveryBehaviour
+compartment_error_handler(ErrorState *, size_t, size_t)
+{
+	cleanup_unwind();
+	return ErrorRecoveryBehaviour::ForceUnwind;
+}
+
+namespace
+{
+	void test_setjmp()
+	{
+		jmp_buf      env;
+		volatile int x = 0;
+		if (int r = setjmp(env); r == 0)
+		{
+			TEST_EQUAL(x, 0, "setjmp should return 0 the first time");
+			x = 42;
+			longjmp(env, 1);
+		}
+		else
+		{
+			TEST_EQUAL(r, 1, "setjmp should return 1 the second time");
+			TEST_EQUAL(
+			  x, 42, "On the second return, x should have been modified");
+			x = 53;
+		}
+		TEST_EQUAL(x, 53, "After longjmp, x should have been modified");
+	}
+
+	FlagLock flagLock;
+
+	void test_on_error()
+	{
+		LockGuard g(flagLock);
+		on_error([&]() { cleanup_unwind(); }, [&]() { g.unlock(); });
+		TEST(!g, "on_error should lock the lock");
+	}
+
+	void test_on_error_raii_inner()
+	{
+		LockGuard g(flagLock);
+		// No handler.  g's destructor runs after on_error returns.
+		on_error([&]() { cleanup_unwind(); });
+	}
+
+	void test_on_error_raii()
+	{
+		test_on_error_raii_inner();
+		TEST(flagLock.try_lock(), "raii should have been dropped the lock");
+		flagLock.unlock();
+	}
+
+	void test_c_macros()
+	{
+		volatile int x = 0;
+		CHERIOT_DURING
+		{
+			x = 42;
+			cleanup_unwind();
+		}
+		CHERIOT_HANDLER
+		{
+			TEST_EQUAL(x, 42, "In the handler, x should have been modified");
+			x = 53;
+		}
+		CHERIOT_END_HANDLER
+		TEST_EQUAL(x, 53, "After longjmp, object should have been modified");
+	}
+
+	void test_from_trap()
+	{
+		volatile int x = 0;
+		CHERIOT_DURING
+		{
+			x = 42;
+			__builtin_trap();
+		}
+		CHERIOT_HANDLER
+		{
+			TEST_EQUAL(x, 42, "In the handler, x should have been modified");
+			x = 53;
+		}
+		CHERIOT_END_HANDLER
+		TEST_EQUAL(x, 53, "After longjmp, object should have been modified");
+	}
+
+} // namespace
+
+void test_unwind_cleanup()
+{
+	test_setjmp();
+	test_on_error();
+	test_c_macros();
+	test_from_trap();
+	debug_log("Test unwind_cleanup passed");
+}

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -88,6 +88,7 @@ test("misc")
     on_load(function(target)
         target:values_set("shared_objects", { exampleK = 1024, test_word = 4 }, {expand = false})
     end)
+test("unwind_cleanup")
 
 includes(path.join(sdkdir, "lib"))
 
@@ -122,6 +123,7 @@ firmware("test-suite")
     add_deps("misc_test")
     add_deps("stdio_test")
     add_deps("debug_test")
+    add_deps("unwind_cleanup_test")
     -- Set the thread entry point to the test runner.
     on_load(function(target)
         target:values_set("board", "$(board)")


### PR DESCRIPTION
This is two commits.  The first reserves space on the stack on each compartment transition so that you have space for per-thread per-invocation state.

The second adds some exception-like macros that are similar to Win16 SEH and OpenStep exceptions.