### PR TITLE
Disable including the ELF headers in the firmware image.

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -747,7 +747,7 @@ rule("firmware")
 				table.insert(objects, dep:targetfile())
 			end
 		end)
-		batchcmds:vrunv(target:tool("ld"), table.join({"--script=" .. linkerscript, "--relax", "-o", target:targetfile(), "--compartment-report=" .. target:targetfile() .. ".json" }, objects), opt)
+		batchcmds:vrunv(target:tool("ld"), table.join({"-n", "--script=" .. linkerscript, "--relax", "-o", target:targetfile(), "--compartment-report=" .. target:targetfile() .. ".json" }, objects), opt)
 		batchcmds:show_progress(opt.progress, "Creating firmware report " .. target:targetfile() .. ".json")
 		batchcmds:show_progress(opt.progress, "Creating firmware dump " .. target:targetfile() .. ".dump")
 		batchcmds:vexecv(target:tool("objdump"), {"-glxsdrS", "--demangle", target:targetfile()}, table.join(opt, {stdout = target:targetfile() .. ".dump"}))


### PR DESCRIPTION
By default lld will try to write a copy of the ELF PHDRs in the final memory image before the first loadable segment. Normally this is elided because there is insufficient space before the first loadable segment, but if the starting address specified for the instruction_memory (in the board JSON description) leaves sufficient space this can happen. To disable this behaviour add the -n option to the lld command line; the other effects of -n are irrelvant: no page alignment of sections (done already by the linker script), and link against static libraries.