### PR TITLE
Separate static and dynamic sealing types.

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -17,6 +17,16 @@
 #include <token.h>
 #include <utils.hh>
 
+#define SEALING_CAP()                                                          \
+	({                                                                         \
+		void *ret;                                                             \
+		__asm("1:\n"                                                           \
+		      "    auipcc  %0, %%cheriot_compartment_hi(__sealingkey)\n"       \
+		      "    clc     %0, %%cheriot_compartment_lo_i(1b)(%0)\n"           \
+		      : "=C"(ret));                                                    \
+		ret;                                                                   \
+	})
+
 using namespace CHERI;
 
 Revocation::Revoker revoker;

--- a/sdk/core/token_library/token_unseal.S
+++ b/sdk/core/token_library/token_unseal.S
@@ -19,7 +19,7 @@
 	.p2align 1
 	.type    _Z16token_obj_unsealP10SKeyStructP10SObjStruct,@function
 
-_Z16token_obj_unsealP10SKeyStructP10SObjStruct:
+.Ltoken_unseal_internal:
   /*
    * Register allocation:
    *
@@ -27,6 +27,8 @@ _Z16token_obj_unsealP10SKeyStructP10SObjStruct:
    *    replaced with the unsealed value or NULL
    *
    *  - ca1 holds the user's sealed object pointer
+   *
+   *  - a2 contains the expected sealing type.
    *
    *  - t0/ct0 holds a copy of the user key
    *
@@ -59,6 +61,7 @@ _Z16token_obj_unsealP10SKeyStructP10SObjStruct:
 .Lload_sealing_key:
   auipcc ca0, %cheriot_compartment_hi(__sealingkey)
   clc    ca0, %cheriot_compartment_lo_i(.Lload_sealing_key)(ca0)
+  csetaddr ca0, ca0, a2
 
   /* Unseal, clobbering authority */
   cunseal ca0, ca1, ca0
@@ -96,6 +99,18 @@ _Z16token_obj_unsealP10SKeyStructP10SObjStruct:
   /* And that's an unwrap. */
   cret
 
+_Z16token_obj_unsealP10SKeyStructP10SObjStruct:
+	cgettype a2, ca1
+	j        .Ltoken_unseal_internal
+
+_Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct:
+	li       a2, 12
+	j        .Ltoken_unseal_internal
+
+_Z24token_obj_unseal_dynamicP10SKeyStructP10SObjStruct:
+	li       a2, 11
+	j        .Ltoken_unseal_internal
+
 .Lexit_failure:
   /* Failure; clobber potential sensitive state in ca0 and return null */
   cmove ca0, cnull
@@ -104,5 +119,15 @@ _Z16token_obj_unsealP10SKeyStructP10SObjStruct:
 /* TODO: Eventually this goes away, when the assembler can generate it for us */
 CHERIOT_EXPORT_LIBCALL \
   _Z16token_obj_unsealP10SKeyStructP10SObjStruct, \
+  0 /* No stack usage */, \
+  0b00010010 /* IRQs deferred, zero two registers */
+
+CHERIOT_EXPORT_LIBCALL \
+  _Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct, \
+  0 /* No stack usage */, \
+  0b00010010 /* IRQs deferred, zero two registers */
+
+CHERIOT_EXPORT_LIBCALL \
+  _Z24token_obj_unseal_dynamicP10SKeyStructP10SObjStruct, \
   0 /* No stack usage */, \
   0b00010010 /* IRQs deferred, zero two registers */

--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -142,16 +142,6 @@
  */
 #define DEVICE_EXISTS(x) defined(DEVICE_EXISTS_##x)
 
-#define SEALING_CAP()                                                          \
-	({                                                                         \
-		void *ret;                                                             \
-		__asm("1:	"                                                            \
-		      "	auipcc		%0, %%cheriot_compartment_hi(__sealingkey)\n"          \
-		      "	clc			%0, %%cheriot_compartment_lo_i(1b)(%0)\n"                \
-		      : "=C"(ret));                                                    \
-		ret;                                                                   \
-	})
-
 /**
  * Helper macro, used by `STATIC_SEALING_TYPE`.  Do not use this directly, it
  * exists to avoid error-prone copying and pasting of the mangled name for a

--- a/sdk/include/compartment.h
+++ b/sdk/include/compartment.h
@@ -4,46 +4,11 @@
 #pragma once
 #include <cdefs.h>
 #include <compartment-macros.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
 #	include <cheri.hh>
-template<typename T>
-static inline CHERI::Capability<T> compart_seal(T *in)
-{
-	void *key = SEALING_CAP();
-
-	return CHERI::Capability{in}.seal(key);
-}
-
-template<typename T>
-static inline CHERI::Capability<T> compart_unseal(T *in)
-{
-	void *key = SEALING_CAP();
-
-	return CHERI::Capability{in}.unseal(key);
-}
-
-template<typename T>
-static inline auto compart_unseal(void *in)
-{
-	return compart_unseal(static_cast<T *>(in));
-}
-#else
-#	include <cheri-builtins.h>
-static inline void *compart_seal(void *in)
-{
-	void *key = SEALING_CAP();
-
-	return cseal(in, key);
-}
-
-static inline void *compart_unseal(void *in)
-{
-	void *key = SEALING_CAP();
-
-	return cunseal(in, key);
-}
 #endif
 
 /**

--- a/sdk/include/token.h
+++ b/sdk/include/token.h
@@ -69,15 +69,49 @@ SObj __cheri_compartment("alloc")
                      size_t);
 
 /**
- * Unseal the obj given the key.
+ * Unseal the object given the key.
  *
- * The key must have the permit-unseal permission.
+ * The key may be either a static or dynamic key (i.e. one created with the
+ * `STATIC_SEALING_TYPE` macro or with `token_key_new`) and the object may be
+ * either allocated dynamically (via the token APIs) or statically (via the
+ * `DEFINE_STATIC_SEALED_VALUE` macro).
  *
- * @return unsealed obj if key and obj are valid and they match. nullptr
- * otherwise
+ * Returns the unsealed object if the key and object are valid and of the
+ * correct type, null otherwise.
+ *
+ * This function is equivalent to calling both `token_obj_unseal_static` and
+ * `token_obj_unseal_dynamic` and returning the result of the first one that
+ * succeeds, or null if both fail.
  */
 [[cheri::interrupt_state(disabled)]] void *
   __cheri_libcall token_obj_unseal(SKey, SObj);
+
+/**
+ * Unseal the object given the key.
+ *
+ * The key must be a static sealing key (i.e. one created with the
+ * `STATIC_SEALING_TYPE` macro) and the object must be a statically sealed
+ * object (i.e. one created with the `DEFINE_STATIC_SEALED_VALUE` macro).
+ *
+ * Returns the unsealed object if the key and object are valid and of the
+ * correct type, null otherwise.
+ */
+[[cheri::interrupt_state(disabled)]] void *
+  __cheri_libcall token_obj_unseal_static(SKey, SObj);
+
+/**
+ * Unseal the object given the key.
+ *
+ * The key may be either a static or dynamic key (i.e. one created with the
+ * `STATIC_SEALING_TYPE` macro or with `token_key_new`) and the object must be
+ * allocated dynamically with `token_sealed_alloc` or
+ * `token_sealed_unsealed_alloc`.
+ *
+ * Returns the unsealed object if the key and object are valid and of the
+ * correct type, null otherwise.
+ */
+[[cheri::interrupt_state(disabled)]] void *
+  __cheri_libcall token_obj_unseal_dynamic(SKey, SObj);
 
 /**
  * Destroy the obj given its key, freeing memory.


### PR DESCRIPTION
This separates the sealing hardware sealing types used for heap-allocated objects from the sealing type used for static sealed objects.  The main goal of this was to remove the allocator from the TCB for statically sealed objects but, as a side benefit, we also delete about 200 lines of code and make the binaries around 100 bytes smaller.

We had previously reserved a type for the scheduler's sealed types to remove the allocator from the scheduler's TCB for static objects.  This is no longer required.  The allocator is in the scheduler's TCB for dynamically sealed objects (but it is anyway, because they live on the heap), but not for statically sealed objects.  This removes a load of special-case code from the scheduler.

This also means that we didn't increase the number of hardware sealing types used, because the scheduler no longer needs its own one.

The existing APIs are preserved, but the token unsealing APIs now have variants that will work *only* on static or dynamically sealed things and so users can remove allocator from the TCB for other objects that should be only statically sealed (and auditable), not heap allocated.