### PR TITLE
Remove space reserved at the start of privileged compartments.

### DIFF
--- a/sdk/core/loader/types.h
+++ b/sdk/core/loader/types.h
@@ -447,7 +447,7 @@ namespace loader
 			 * The distance from the start of the code region to the end of the
 			 * import table.
 			 */
-			uint16_t importTableSize;
+			AddressRange importTable;
 
 			/**
 			 * The export table for the scheduler.
@@ -465,11 +465,7 @@ namespace loader
 			 */
 			[[nodiscard]] AddressRange import_table() const
 			{
-				// Skip the sealing keys
-				const size_t SealingKeysSize = 2 * sizeof(void *);
-				return {
-				  code.start() + SealingKeysSize,
-				  static_cast<uint16_t>(importTableSize - SealingKeysSize)};
+				return importTable;
 			}
 
 			/**

--- a/sdk/core/token_library/token_unseal.S
+++ b/sdk/core/token_library/token_unseal.S
@@ -2,6 +2,16 @@
 #include <cheri-builtins.h>
 #include "../allocator/token.h"
 
+	.hidden __sealingkey
+	.type   __sealingkey,@object
+	.section    .sealing_key1,"aw",@progbits
+	.globl  __sealingkey
+	.p2align    3
+__sealingkey:
+	.chericap   0
+	.size   __sealingkey, 8
+
+
 /*
  * An in-assembler implementation of
  *
@@ -11,13 +21,9 @@
  * The name has been manually mangled as per the C++ rules.
  */
 
-	.section .text._Z16token_obj_unsealP10SKeyStructP10SObjStruct,"axG", \
-		@progbits,_Z16token_obj_unsealP10SKeyStructP10SObjStruct,comdat
+.section .text,"ax",@progbits
 
-	.hidden  _Z16token_obj_unsealP10SKeyStructP10SObjStruct
-	.globl   _Z16token_obj_unsealP10SKeyStructP10SObjStruct
-	.p2align 1
-	.type    _Z16token_obj_unsealP10SKeyStructP10SObjStruct,@function
+.p2align 1
 
 .Ltoken_unseal_internal:
   /*
@@ -99,14 +105,20 @@
   /* And that's an unwrap. */
   cret
 
+	.hidden _Z16token_obj_unsealP10SKeyStructP10SObjStruct
+	.globl  _Z16token_obj_unsealP10SKeyStructP10SObjStruct
 _Z16token_obj_unsealP10SKeyStructP10SObjStruct:
 	cgettype a2, ca1
 	j        .Ltoken_unseal_internal
 
+	.hidden  _Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct
+	.globl   _Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct
 _Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct:
 	li       a2, 12
 	j        .Ltoken_unseal_internal
 
+	.hidden  _Z16token_obj_unsealP10SKeyStructP10SObjStruct
+	.globl   _Z16token_obj_unsealP10SKeyStructP10SObjStruct
 _Z24token_obj_unseal_dynamicP10SKeyStructP10SObjStruct:
 	li       a2, 11
 	j        .Ltoken_unseal_internal

--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -46,6 +46,8 @@ SECTIONS
 	scheduler_code : CAPALIGN
 	{
 		.scheduler_start = .;
+		*.scheduler.compartment(.compartment_sealing_keys);
+		.scheduler_import_start = .;
 		*.scheduler.compartment(.compartment_import_table);
 		.scheduler_import_end = .;
 		*.scheduler.compartment(.text .text.* .rodata .rodata.* .data.rel.ro);
@@ -55,6 +57,8 @@ SECTIONS
 	allocator_code : CAPALIGN
 	{
 		.allocator_start = .;
+		*/cheriot.allocator.compartment(.compartment_sealing_keys);
+		.allocator_import_start = .;
 		*/cheriot.allocator.compartment(.compartment_import_table);
 		.allocator_import_end = .;
 		allocator.compartment(.text .text.* .rodata .rodata.* .data.rel.ro);
@@ -66,6 +70,8 @@ SECTIONS
 	token_library_code : CAPALIGN
 	{
 		.token_library_start = .;
+		*/cheriot.token_library.library(.compartment_sealing_keys);
+		.token_library_import_start = .;
 		*/cheriot.token_library.library(.compartment_import_table);
 		.token_library_import_end = .;
 		token_library.library(.text .text.* .rodata .rodata.* .data.rel.ro);
@@ -178,8 +184,10 @@ SECTIONS
 		LONG(.scheduler_globals);
 		# Scheduler globals end size
 		SHORT(SIZEOF(.scheduler_globals));
+		# Start of the scheduler's import table
+		LONG(.scheduler_import_start);
 		# Size of the scheduler import table
-		SHORT(.scheduler_import_end - .scheduler_start);
+		SHORT(.scheduler_import_end - .scheduler_import_start);
 		# Address of scheduler export table
 		LONG(.scheduler_export_table);
 		# Size of the scheduler export table
@@ -197,8 +205,10 @@ SECTIONS
 		LONG(.allocator_globals);
 		# Allocator globals end
 		SHORT(SIZEOF(.allocator_globals));
+		# Start of the allocator's import table
+		LONG(.allocator_import_start);
 		# Size of the allocator import table
-		SHORT(.allocator_import_end - .allocator_start);
+		SHORT(.allocator_import_end - .allocator_import_start);
 		# Address of allocator export table
 		LONG(.allocator_export_table);
 		# Size of the allocator export table
@@ -215,8 +225,10 @@ SECTIONS
 		# No data segment
 		LONG(0);
 		SHORT(0);
+		# Start of the token_library's import table
+		LONG(.token_library_import_start);
 		# Size of the token server import table
-		SHORT(.token_library_import_end - .token_library_start);
+		SHORT(.token_library_import_end - .token_library_import_start);
 		# Address of the token server export table
 		LONG(.token_library_export_table);
 		# Size of the token server export table

--- a/sdk/privileged-compartment.ldscript
+++ b/sdk/privileged-compartment.ldscript
@@ -17,17 +17,19 @@ SECTIONS
 		# Array of compartment exports
 		*(.compartment_exports .compartment_exports.*);
 	}
+	# Reserve space at the start for privileged compartments that need special sealing keys.
+	.compartment_sealing_keys : ALIGN(8)
+	{
+		# Start of the compartment's PCC region
+		HIDDEN(__compartment_pcc_start = .);
+		# The sealing keys for this compartment is before the import table, if they exist
+		*(.sealing_key1*)
+		*(.sealing_key2*)
+	}
 	# Lay out the compartment imports section.  This will end up on PCC.
 	.compartment_import_table : ALIGN(8)
 	{
 		# Array of compartment imports 
-		HIDDEN(__compartment_pcc_start = .);
-		# The sealing key for this compartment is before the import table.
-		HIDDEN(__sealingkey = .);
-		. = . + 8;
-		# Space for a second sealing key, used only by the allocator.
-		HIDDEN(__sealingkey2 = .);
-		. = . + 8;
 		# The first import table entry is the compartment switcher.
 		HIDDEN(.compartment_switcher = .);
 		. = . + 8;

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -653,11 +653,9 @@ rule("firmware")
 				"\n\t\tSHORT(.software_revoker_end - .software_revoker_start);" ..
 				"\n\t\tLONG(.software_revoker_globals);" ..
 				"\n\t\tSHORT(SIZEOF(.software_revoker_globals));" ..
-				-- The import table offset is computed from the start by code
-				-- that assumes that the first two words are space for sealing
-				-- keys, so we set it to 16 here to provide a computed size of
-				-- 0.
-				"\n\t\tSHORT(16)" ..
+				-- The software revoker has no import table.
+				"\n\t\tLONG(0)" ..
+				"\n\t\tSHORT(0)" ..
 				"\n\t\tLONG(.software_revoker_export_table);" ..
 				"\n\t\tSHORT(.software_revoker_export_table_end - .software_revoker_export_table);\n" ..
 				"\n\t\tLONG(0);" ..

--- a/tests/static_sealing-test.cc
+++ b/tests/static_sealing-test.cc
@@ -19,6 +19,5 @@ int test_static_sealing()
 {
 	// Get a pointer to it and ask for it to be unsealed.
 	Sealed<TestType> value{STATIC_SEALED_VALUE(test)};
-	test_static_sealed_object(value);
-	return 0;
+	return test_static_sealed_object(value);
 }

--- a/tests/static_sealing.h
+++ b/tests/static_sealing.h
@@ -10,5 +10,5 @@ struct TestType
 	int value;
 };
 
-void __cheri_compartment("static_sealing_inner")
+int __cheri_compartment("static_sealing_inner")
   test_static_sealed_object(Sealed<TestType>);

--- a/tests/static_sealing_inner.cc
+++ b/tests/static_sealing_inner.cc
@@ -4,10 +4,11 @@
 #define TEST_NAME "Static sealing (inner compartment)"
 #include "static_sealing.h"
 #include "tests.hh"
+#include <fail-simulator-on-error.h>
 
 using namespace CHERI;
 
-void test_static_sealed_object(Sealed<TestType> obj)
+int test_static_sealed_object(Sealed<TestType> obj)
 {
 	// Get our static sealing key.
 	SKey       key = STATIC_SEALING_TYPE(SealingType);
@@ -48,4 +49,5 @@ void test_static_sealed_object(Sealed<TestType> obj)
 	                                  Permission::Global}>(unsealed, 1)),
 	     "Incorrect permissions on unsealed statically sealed object {}",
 	     unsealed);
+	return 0;
 }


### PR DESCRIPTION
We originally reserved one capability of space at the start of each of the core RTOS compartments for a sealing key.  Then, when we added the virtualised sealing mechanism to the allocator, this grew to two.

The allocator is the only compartment that uses both slots and, after merging #316, the scheduler doesn't use any.  This space is therefore wasted.

This commit removes this space and adds a mechanism that allows privileged compartments to reserve one or two slots.

Eventually we can probably replace this with a normal imported sealing capability, but for now this at least removes the wasted space.

This does not currently reduce code size, because replacing the inline assembly with a load of a global adds a csetbounds.  This can be fixed in the compiler independently.

While we're here, improve a test that could spuriously pass if the inner compartment faulted.