### PR TITLE
Simplify message queues.

### DIFF
--- a/examples/06.producer-consumer/producer.cc
+++ b/examples/06.producer-consumer/producer.cc
@@ -16,17 +16,16 @@ using Debug = ConditionalDebug<true, "Producer">;
 void __cheri_compartment("producer") run()
 {
 	// Allocate the queue
-	SObj sendHandle;
-	SObj receiveHandle;
+	SObj queue;
 	non_blocking<queue_create_sealed>(
-	  MALLOC_CAPABILITY, &sendHandle, &receiveHandle, sizeof(int), 16);
+	  MALLOC_CAPABILITY, &queue, sizeof(int), 16);
 	// Pass the queue handle to the consumer.
-	set_queue(receiveHandle);
+	set_queue(queue);
 	Debug::log("Starting producer loop");
 	// Loop, sending some numbers to the other thread.
 	for (int i = 1; i < 200; i++)
 	{
-		int ret = blocking_forever<queue_send_sealed>(sendHandle, &i);
+		int ret = blocking_forever<queue_send_sealed>(queue, &i);
 		// Abort if the queue send errors.
 		Debug::Invariant(ret == 0, "Queue send failed {}", ret);
 	}

--- a/sdk/lib/queue/README.md
+++ b/sdk/lib/queue/README.md
@@ -1,0 +1,12 @@
+Message queues
+==============
+
+Message queues, as described in [`queue.h`](../../include/queue.h).
+
+This directory provides two targets.
+
+ - The message queue library (`message_queue_library`) provides APIs for message queues that can be shared between two threads in the same compartment.
+ - The message queue compartment (`message_queue`) wraps these in APIs that can be used from different compartments.
+
+The library uses the `setjmp`-based error handler (see: [`unwind.h`](../../include/unwind.h)) to recover from invalid bounds or permissions.
+If you are using the library and want to be robust in the presence of CHERI exceptions, you should either add `unwind_error_handler` as a dependency of your compartment or provide an error handler that calls `cleanup_unwind`.

--- a/sdk/lib/queue/queue_compartment.cc
+++ b/sdk/lib/queue/queue_compartment.cc
@@ -8,10 +8,14 @@
 
 using namespace CHERI;
 
-using Debug = ConditionalDebug<false, "Queue compartment">;
+using Debug = ConditionalDebug<false, "MessageQueue compartment">;
 
 namespace
 {
+	__always_inline SKey handle_key()
+	{
+		return STATIC_SEALING_TYPE(MessageQueueHandle);
+	}
 	__always_inline SKey receive_key()
 	{
 		return STATIC_SEALING_TYPE(ReceiveHandle);
@@ -21,88 +25,62 @@ namespace
 		return STATIC_SEALING_TYPE(SendHandle);
 	}
 
-	struct QueueEndpoint
+	/**
+	 * Wrapper used for restricted endpoints.  This is used to provide
+	 * capabilities that allow only sending or receiving.  Instances of this
+	 * will be sealed with either `send_key()` or `receive_key()` to define
+	 * their types.
+	 */
+	struct RestrictedEndpoint
 	{
-		QueueHandle handle;
-		void       *allocation;
-		// Lock that protects against double free.
-		FlagLockPriorityInherited lock;
+		MessageQueue *handle;
 	};
+
+	/**
+	 * Unseal something that is either a queue handle or a restricted endpoint
+	 * with the specified key.
+	 */
+	MessageQueue *unseal(SKey key, SObj handle)
+	{
+		MessageQueue *queue = nullptr;
+		if (auto *unsealed =
+		      token_unseal(key, Sealed<RestrictedEndpoint>{handle}))
+		{
+			queue = unsealed->handle;
+		}
+		else if (auto *unsealed =
+		           token_unseal(handle_key(), Sealed<MessageQueue>{handle}))
+		{
+			queue = unsealed;
+		}
+		return queue;
+	}
 
 } // namespace
 
 int queue_create_sealed(Timeout            *timeout,
                         struct SObjStruct  *heapCapability,
-                        struct SObjStruct **outQueueSend,
-                        struct SObjStruct **outQueueReceive,
+                        struct SObjStruct **outQueue,
                         size_t              elementSize,
                         size_t              elementCount)
 {
-	if (!check_timeout_pointer(timeout))
+	ssize_t allocSize = queue_allocation_size(elementSize, elementCount);
+	if (allocSize < 0)
 	{
-		return -EPERM;
+		return -EINVAL;
 	}
 
-	// Allocate the queue endpoints
-	auto [send, sendSealed] =
-	  token_allocate<QueueEndpoint>(timeout, heapCapability, send_key());
-	if (!send)
+	void *unsealed = nullptr;
+	// Allocate the space for the queue.
+	auto sealed = token_sealed_unsealed_alloc(
+	  timeout, heapCapability, handle_key(), allocSize, &unsealed);
+	if (!unsealed)
 	{
-		return timeout->may_block() ? -ENOMEM : -ETIMEDOUT;
-	}
-	auto [receive, receiveSealed] =
-	  token_allocate<QueueEndpoint>(timeout, heapCapability, receive_key());
-	if (!receive)
-	{
-		token_obj_destroy(heapCapability, send_key(), sendSealed);
-		return timeout->may_block() ? -ENOMEM : -ETIMEDOUT;
+		return -ENOMEM;
 	}
 
-	// Bidirectional queue handle
-	QueueHandle handle;
-	// The pointer to the queue that is used when freeing
-	void *freeBuffer;
-	// Allocate the queue object
-	int ret = queue_create(
-	  timeout, heapCapability, &handle, &freeBuffer, elementSize, elementCount);
-	if (ret != 0)
-	{
-		token_obj_destroy(heapCapability, send_key(), sendSealed);
-		token_obj_destroy(heapCapability, receive_key(), receiveSealed);
-		return ret;
-	}
-
-	send->handle        = queue_make_send_handle(handle);
-	send->allocation    = freeBuffer;
-	receive->handle     = queue_make_receive_handle(handle);
-	receive->allocation = freeBuffer;
-	// Add a second claim on the buffer so that we can free the queue by freeing
-	// it twice, once in each endpoint.
-	// TODO we should check the return value of `heap_claim`
-	heap_claim(heapCapability, freeBuffer);
-
-	if (int claimed = heap_claim_fast(timeout, outQueueSend, outQueueReceive);
-	    claimed != 0)
-	{
-		return claimed;
-	}
-	if (!check_pointer<PermissionSet{Permission::Load,
-	                                 Permission::Store,
-	                                 Permission::LoadStoreCapability}>(
-	      outQueueReceive, sizeof(void *)) ||
-	    !check_pointer<PermissionSet{Permission::Load,
-	                                 Permission::Store,
-	                                 Permission::LoadStoreCapability}>(
-	      outQueueSend, sizeof(void *)))
-	{
-		// Free twice because we claimed it once in addition to the original
-		// allocation.
-		heap_free(heapCapability, freeBuffer);
-		heap_free(heapCapability, freeBuffer);
-		return -EPERM;
-	}
-	*outQueueSend    = sendSealed;
-	*outQueueReceive = receiveSealed;
+	new (unsealed) MessageQueue(elementSize, elementCount);
+	*outQueue = sealed;
 	return 0;
 }
 
@@ -110,99 +88,131 @@ int queue_destroy_sealed(Timeout           *timeout,
                          struct SObjStruct *heapCapability,
                          struct SObjStruct *queueHandle)
 {
-	if (!check_timeout_pointer(timeout))
+	if (token_obj_unseal(handle_key(), queueHandle) != nullptr)
 	{
-		return -EPERM;
+		token_obj_destroy(heapCapability, handle_key(), queueHandle);
+		return 0;
 	}
-	Debug::log("Destroying queue {}", queueHandle);
-	auto  token = receive_key();
-	auto *end   = token_unseal(token, Sealed<QueueEndpoint>{queueHandle});
-	// This function takes either endpoint, so we need to try unsealing with
-	// both keys.
-	if (!end)
+	if (token_obj_unseal(send_key(), queueHandle) != nullptr)
 	{
-		token = send_key();
-		end   = token_unseal(token, Sealed<QueueEndpoint>{queueHandle});
+		token_obj_destroy(heapCapability, send_key(), queueHandle);
+		return 0;
 	}
-	if (!end)
+	if (token_obj_unseal(receive_key(), queueHandle) != nullptr)
 	{
-		return -EINVAL;
+		token_obj_destroy(heapCapability, receive_key(), queueHandle);
+		return 0;
 	}
-	// Don't bother with a lock guard: we will destroy this lock if we reach the
-	// end. If we lose a race here, this will trap and we will implicitly return
-	// `-ECOMPARTMENTFAIL`.
-	if (!end->lock.try_lock(timeout))
-	{
-		return -ETIMEDOUT;
-	}
-	if (heap_free(heapCapability, end->allocation) != 0)
-	{
-		end->lock.unlock();
-		return -EPERM;
-	}
-	token_obj_destroy(heapCapability, token, queueHandle);
-	return 0;
+	return -EINVAL;
 }
 
 int queue_send_sealed(Timeout           *timeout,
                       struct SObjStruct *handle,
                       const void        *src)
 {
-	auto *end = token_unseal(send_key(), Sealed<QueueEndpoint>{handle});
-	// If we failed to unseal, or if the timeout pointer is invalid, invalid
-	// argument error.
-	if (!end || !check_timeout_pointer(timeout))
+	MessageQueue *queue = unseal(send_key(), handle);
+	if (!queue || !check_timeout_pointer(timeout))
 	{
 		return -EINVAL;
 	}
-	return queue_send(timeout, &end->handle, src);
+	return queue_send(timeout, queue, src);
 }
 
 int queue_receive_sealed(Timeout *timeout, struct SObjStruct *handle, void *dst)
 {
-	auto *end = token_unseal(receive_key(), Sealed<QueueEndpoint>{handle});
-	// If we failed to unseal, or if the timeout is on the heap, invalid
-	// argument error.
-	if (!end || !check_timeout_pointer(timeout))
+	MessageQueue *queue = unseal(receive_key(), handle);
+	if (!queue || !check_timeout_pointer(timeout))
 	{
 		return -EINVAL;
 	}
-	return queue_receive(timeout, &end->handle, dst);
+	return queue_receive(timeout, queue, dst);
 }
 
 int multiwaiter_queue_receive_init_sealed(struct EventWaiterSource *source,
                                           struct SObjStruct        *handle)
 {
-	auto *end = token_unseal(receive_key(), Sealed<QueueEndpoint>{handle});
-	if (!end)
+	MessageQueue *queue = unseal(receive_key(), handle);
+	if (!queue)
 	{
 		return -EINVAL;
 	}
-	multiwaiter_queue_receive_init(source, &end->handle);
+	multiwaiter_queue_receive_init(source, queue);
 	return 0;
 }
 
 int multiwaiter_queue_send_init_sealed(struct EventWaiterSource *source,
                                        struct SObjStruct        *handle)
 {
-	auto *end = token_unseal(send_key(), Sealed<QueueEndpoint>{handle});
-	if (!end)
+	MessageQueue *queue = unseal(send_key(), handle);
+	if (!queue)
 	{
 		return -EINVAL;
 	}
-	multiwaiter_queue_send_init(source, &end->handle);
+	multiwaiter_queue_send_init(source, queue);
 	return 0;
 }
 
-int queue_items_remaining_sealed(struct SObjStruct *queueHandle, size_t *items)
+int queue_items_remaining_sealed(struct SObjStruct *handle, size_t *items)
 {
-	auto *end = token_unseal(receive_key(), Sealed<QueueEndpoint>{queueHandle});
+	MessageQueue *queue = unseal(send_key(), handle);
 	// This function takes either endpoint, so we need to try unsealing with
 	// both keys.
-	if (!end)
+	if (!queue)
 	{
-		end = token_unseal(send_key(), Sealed<QueueEndpoint>{queueHandle});
+		if (auto *unsealed =
+		      token_unseal(receive_key(), Sealed<RestrictedEndpoint>{handle}))
+		{
+			queue = unsealed->handle;
+		}
 	}
-	queue_items_remaining(&end->handle, items);
+	if (!queue)
+	{
+		return -EINVAL;
+	}
+	queue_items_remaining(queue, items);
+	return 0;
+}
+
+int queue_receive_handle_create_sealed(struct Timeout     *timeout,
+                                       struct SObjStruct  *heapCapability,
+                                       struct SObjStruct  *handle,
+                                       struct SObjStruct **outHandle)
+{
+	MessageQueue *queue =
+	  token_unseal(handle_key(), Sealed<MessageQueue>(handle));
+	if (!queue)
+	{
+		return -EINVAL;
+	}
+	auto [unsealed, sealed] = token_allocate<RestrictedEndpoint>(
+	  timeout, heapCapability, receive_key());
+	if (!unsealed)
+	{
+		return -ENOMEM;
+	}
+	unsealed->handle = queue;
+	*outHandle       = sealed;
+	return 0;
+}
+
+int queue_send_handle_create_sealed(struct Timeout     *timeout,
+                                    struct SObjStruct  *heapCapability,
+                                    struct SObjStruct  *handle,
+                                    struct SObjStruct **outHandle)
+{
+	MessageQueue *queue =
+	  token_unseal(handle_key(), Sealed<MessageQueue>(handle));
+	if (!queue)
+	{
+		return -EINVAL;
+	}
+	auto [unsealed, sealed] =
+	  token_allocate<RestrictedEndpoint>(timeout, heapCapability, send_key());
+	if (!unsealed)
+	{
+		return -ENOMEM;
+	}
+	unsealed->handle = queue;
+	*outHandle       = sealed;
 	return 0;
 }

--- a/sdk/lib/queue/xmake.lua
+++ b/sdk/lib/queue/xmake.lua
@@ -9,6 +9,7 @@ library("message_queue_library")
   add_files("queue.cc")
 
 compartment("message_queue")
+  add_deps("unwind_error_handler")
   add_deps("message_queue_library")
   set_default(false)
   add_files("queue_compartment.cc")

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -666,7 +666,9 @@ int test_allocator()
 	  !array.is_valid(), "Allocating too large an array succeeded: {}", array);
 	array = heap_allocate_array(&t, MALLOC_CAPABILITY, 16, 2);
 	TEST(array.is_valid(), "Allocating array failed: {}", array);
-	TEST(array.length() == 32,
+	// If there's heap fragmentation, this may be rounded up to 40 because we
+	// can't use the 8 bytes after the end for another object.
+	TEST((array.length() >= 32) && (array.length() <= 40),
 	     "Allocating array returned incorrect length: {}",
 	     array);
 	ret = heap_free(MALLOC_CAPABILITY, array);


### PR DESCRIPTION
My original implementation was a bit CHERI-happy and put a lot of capabilities in each endpoint to enforce properties with a not-very-well-thought-through thread model.

The new code is simpler in a few ways:

 - The queue metadata and ring buffer are a single allocation.
 - The producer / consumer counters are indexed directly, not via indirection.
 - We don't do permission checks and claims for defensive programming in the send and receive functions, we use the unwind error handling so don't need to enumerate possible badness.
 - The library returns a pointer to the allocation directly, rather than a (large) value type and a pointer that is used for freeing.
 - Restricted endpoints are just a simple indirection layer and are only in the sealed version where they might make sense with a threat model.
 - The FreeRTOS compatibility APIs no longer need a heap allocation to store a pointer to another heap allocation.

This is an API break, but the new APIs are simpler so it's probably worth it, and good to do before 1.0.  I believe the only users are using the FreeRTOS-Compat wrappers, which are not changed (though can now easily be extended to support message queues between compartments in the compat layer).

Fixes #309