### PR TITLE
Make `unwind.h` a C-compatible header.

### DIFF
--- a/sdk/include/setjmp.h
+++ b/sdk/include/setjmp.h
@@ -30,11 +30,12 @@ struct __jmp_buf
  */
 typedef struct __jmp_buf jmp_buf[1];
 
+__BEGIN_DECLS
 /**
  * C `setjmp` function.  Returns (up to) twice.  First returns 0, returns a
  * value passed to `longjmp` on the second return.
  */
-__attribute__((returns_twice)) extern "C" int setjmp(jmp_buf env);
+__attribute__((returns_twice)) int setjmp(jmp_buf env);
 __asm__(".section .text.setjmp,\"awG\",@progbits,setjmp,comdat\n"
         ".globl setjmp\n"
         ".p2align 2\n"
@@ -50,7 +51,7 @@ __asm__(".section .text.setjmp,\"awG\",@progbits,setjmp,comdat\n"
 /**
  * C `longjmp` function.  Does not return, jumps back to the `setjmp` call.
  */
-extern "C" void longjmp(jmp_buf env, int val);
+void longjmp(jmp_buf env, int val);
 __asm__(".section .text.longjmp,\"awG\",@progbits,longjmp,comdat\n"
         ".globl longjmp\n"
         ".p2align 2\n"
@@ -62,3 +63,4 @@ __asm__(".section .text.longjmp,\"awG\",@progbits,longjmp,comdat\n"
         "	clc	cra, 24(ca0)\n"
         "	mv	a0, a1\n"
         "	cjr	cra\n");
+__END_DECLS

--- a/sdk/include/unwind.h
+++ b/sdk/include/unwind.h
@@ -9,9 +9,9 @@
 struct CleanupList
 {
 	/// Next pointer.
-	CleanupList *next;
+	struct CleanupList *next;
 	/// Jump buffer to return to.
-	__jmp_buf env;
+	struct __jmp_buf env;
 };
 
 /**
@@ -34,9 +34,9 @@ __always_inline static inline struct CleanupList **cleanup_list_head()
  */
 __always_inline static inline void cleanup_unwind(void)
 {
-	CleanupList **__head = cleanup_list_head();
-	CleanupList  *__top  = *__head;
-	*__head              = __top->next;
+	struct CleanupList **__head = cleanup_list_head();
+	struct CleanupList  *__top  = *__head;
+	*__head                     = __top->next;
 	switcher_handler_invocation_count_reset();
 	longjmp(&__top->env, 1);
 }
@@ -53,10 +53,10 @@ __always_inline static inline void cleanup_unwind(void)
  */
 #define CHERIOT_DURING                                                         \
 	{                                                                          \
-		CleanupList cleanupListEntry;                                          \
-		auto      **__head    = cleanup_list_head();                           \
-		cleanupListEntry.next = *__head;                                       \
-		*__head               = &cleanupListEntry;                             \
+		struct CleanupList   cleanupListEntry;                                 \
+		struct CleanupList **__head = cleanup_list_head();                     \
+		cleanupListEntry.next       = *__head;                                 \
+		*__head                     = &cleanupListEntry;                       \
 		if (setjmp(&cleanupListEntry.env) == 0)                                \
 		{
 /// See CHERIOT_DURING.

--- a/tests/ccompile-test.c
+++ b/tests/ccompile-test.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <cdefs.h>
 #include <cheri-builtins.h>
+#include <cheri.h>
 #include <compartment.h>
 #include <ctype.h>
 #include <errno.h>
@@ -38,4 +39,4 @@
 #include <time.h>
 #include <timeout.h>
 #include <token.h>
-#include <cheri.h>
+#include <unwind.h>


### PR DESCRIPTION
`unwind.h` does not currently compile as a C header, which is necessary for error handling in the network stack (to use `CHERIOT_*` macros).

Assuming that this is a bug, here is a tentative fix.