### PR TITLE
switcher: change TrustedStack underflow to exit

### DIFF
--- a/sdk/core/loader/types.h
+++ b/sdk/core/loader/types.h
@@ -363,6 +363,12 @@ namespace loader
 			AddressRange code;
 
 			/**
+			 * The PCC-relative location of the cross-compartment call return
+			 * path, used to build the initial return addresses for threads.
+			 */
+			uint16_t crossCallReturnEntry;
+
+			/**
 			 * The PCC-relative location of the sealing key, which the
 			 * compartment switcher will use to unseal import table entries.
 			 */
@@ -608,7 +614,7 @@ namespace loader
 			// This is a random 32-bit number and should be changed whenever
 			// the compartment header layout changes to provide some sanity
 			// checking.
-			return magic == 0x6cef3879;
+			return magic == 0xca2b63de;
 		}
 
 		/**

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -643,7 +643,7 @@ exception_entry_asm:
 	// See if we can find a handler:
 	clhu               tp, TrustedStack_offset_frameoffset(csp)
 	li                 t1, TrustedStack_offset_frames
-	beq                tp, t1, .Lreset_mepcc_and_install_context
+	beq                tp, t1, .Lset_mcause_and_exit_thread
 	addi               tp, tp, -TrustedStackFrame_size
 
 	// ctp points to the current available trusted stack frame.
@@ -864,13 +864,6 @@ exception_entry_asm:
 	zeroOne            sp
 	cspecialrw         csp, mtdc, csp
 	j                  .Lthread_exit
-
-	// The continue-resume path expects the location that we will mret to to be
-	// in ct2.  If we're just resuming, then resume from the stashed link
-	// register value.
-.Lreset_mepcc_and_install_context:
-	clc                ct2, TrustedStack_offset_mepcc(csp)
-	j                  .Linstall_context
 
 	/*
 	 * Some switcher instructions' traps are handled specially, by looking at

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -339,7 +339,8 @@ __Z26compartment_switcher_entryz:
 	zeroRegisters      tp, t1, t2, s0, s1
 	cjalr              cra
 
-.Lskip_compartment_call:
+	.globl switcher_skip_compartment_call
+switcher_skip_compartment_call:
 	// If we are doing a forced unwind of the trusted stack then we do almost
 	// exactly the same as a normal unwind.  We will jump here from the
 	// exception path (.Lforce_unwind)
@@ -417,7 +418,7 @@ __Z26compartment_switcher_entryz:
 .Lstack_too_small:
 	li                 a0, -ENOTENOUGHSTACK
 	li                 a1, 0
-	j                  .Lskip_compartment_call
+	j                  switcher_skip_compartment_call
 .size compartment_switcher_entry, . - compartment_switcher_entry
 
 	// the entry point of all exceptions and interrupts
@@ -586,7 +587,7 @@ exception_entry_asm:
 .Lforce_unwind:
 	li                 a0, -ECOMPARTMENTFAIL
 	li                 a1, 0
-	j                  .Lskip_compartment_call
+	j                  switcher_skip_compartment_call
 
 
 // If we have run out of trusted stack, then just restore the caller's state

--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -162,6 +162,8 @@ SECTIONS
 		LONG(.compartment_switcher_start);
 		# Compartment switcher end
 		SHORT(.compartment_switcher_end - .compartment_switcher_start);
+		# Cross-compartment call return path
+		SHORT(switcher_skip_compartment_call - .compartment_switcher_start);
 		# Compartment switcher sealing key
 		SHORT(compartment_switcher_sealing_key - .compartment_switcher_start);
 		# Switcher's copy of the scheduler's PCC.
@@ -244,7 +246,7 @@ SECTIONS
 		# loader versions.
 		# New versions of this can be generated with:
 		# head /dev/random | shasum | cut -c 0-8
-		LONG(0x6cef3879);
+		LONG(0xca2b63de);
 		# Number of library headers.
 		SHORT(@library_count@);
 		# Number of compartment headers.


### PR DESCRIPTION
Rather than infinitely looping such a damaged thread, request that the scheduler stop running it (via .Lset_mcause_and_exit_thread).  This should never happen, as .Lpop_trusted_stack_frame tries to exit any thread that runs out of trusted stack frames, but the scheduler could ask us to resume such a thing anyway.