### PR TITLE
IRQs on in compartment fault handlers

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -68,12 +68,12 @@ namespace
 		/**
 		 * 0 represents unsealed.
 		 */
-		Unsealed = 0,
+		Unsealed = CheriSealTypeUnsealed,
 
 		/**
 		 * Sentry that inherits interrupt status.
 		 */
-		SentryInheriting,
+		SentryInheriting = CheriSealTypeSentryInheriting,
 
 		/// Alternative name: the default sentry type.
 		Sentry = SentryInheriting,
@@ -81,32 +81,32 @@ namespace
 		/**
 		 * Sentry that disables interrupts on calls.
 		 */
-		SentryDisabling,
+		SentryDisabling = CheriSealTypeSentryDisabling,
 
 		/**
 		 * Sentry that enables interrupts on calls.
 		 */
-		SentryEnabling,
+		SentryEnabling = CheriSealTypeSentryEnabling,
 
 		/**
 		 * Return sentry that disables interrupts on return
 		 */
-		ReturnSentryDisabling,
+		ReturnSentryDisabling = CheriSealTypeReturnSentryDisabling,
 
 		/**
 		 * Return sentry that enables interrupts on return
 		 */
-		ReturnSentryEnabling,
+		ReturnSentryEnabling = CheriSealTypeReturnSentryEnabling,
 
 		/**
 		 * Marker for the first sealing type that's valid for data capabilities.
 		 */
-		FirstDataSealingType = 9,
+		FirstDataSealingType = CheriSealTypeFirstDataSealingType,
 
 		/**
 		 * The sealing type used for sealed export table entries.
 		 */
-		SealedImportTableEntries = FirstDataSealingType,
+		SealedImportTableEntries = CheriSealTypeSealedImportTableEntries,
 
 		/**
 		 * The compartment switcher has a sealing type for the trusted stack.
@@ -114,13 +114,13 @@ namespace
 		 * This must be the second data sealing type so that we can also permit
 		 * the switcher to unseal sentries and export table entries.
 		 */
-		SealedTrustedStacks,
+		SealedTrustedStacks = CheriSealTypeSealedTrustedStacks,
 
 		/**
 		 * The allocator has a sealing type for the software sealing mechanism
 		 * with dynamically allocated objects.
 		 */
-		Allocator,
+		Allocator = CheriSealTypeAllocator,
 
 		/**
 		 * The loader reserves a sealing type for the software sealing
@@ -129,19 +129,19 @@ namespace
 		 * type was present in the original firmware image.  The token library
 		 * has the only permit-unseal capability for this type.
 		 */
-		StaticToken,
+		StaticToken = CheriSealTypeStaticToken,
 
 		/**
 		 * The first sealing key that is reserved for use by the allocator's
 		 * software sealing mechanism and used for static sealing types,
 		 */
-		FirstStaticSoftware = 16,
+		FirstStaticSoftware = CheriSealTypeFirstStaticSoftware,
 
 		/**
 		 * The first sealing key in the space that the allocator will
 		 * dynamically allocate for sealing types.
 		 */
-		FirstDynamicSoftware = 0x1000000,
+		FirstDynamicSoftware = CheriSealTypeFirstDynamicSoftware,
 	};
 
 	// The switcher assembly includes the types of import table entries and

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -777,6 +777,9 @@ exception_entry_asm:
 	cmove              csp, ca0
 
 .Linvoke_error_handler:
+	// Enable interrupts before invoking the handler
+	csrsi              mstatus, 0x8
+
 	// Clear all registers except:
 	// cra is set by cjalr.  csp and cgp are needed for the called compartment.
 	// ca0, used for the register state
@@ -785,6 +788,15 @@ exception_entry_asm:
 	zeroAllRegistersExcept ra, sp, gp, a0, a1, a2
 	// Call the handler.
 	cjalr              cra
+
+	/*
+	 * Now that we're back, defer interrupts again before we do anything that
+	 * manipulates the TrustedStack.
+	 *
+	 * TODO: Eventually we'd like to move this down onto the paths where it
+	 * actually matters and let most of this code run with IRQs enabled.
+	 */
+	csrci              mstatus, 0x8
 
 	// Move the return value to a register that will be cleared in a forced
 	// unwind and zero the return registers.

--- a/sdk/include/cheri.h
+++ b/sdk/include/cheri.h
@@ -269,6 +269,99 @@ enum CHERIRegisterNumber
 };
 
 /**
+ * Sealing types.
+ */
+enum CHERISealingType
+{
+	/**
+	 * 0 represents unsealed.
+	 */
+	CheriSealTypeUnsealed = 0,
+
+	/**
+	 * Sentry that inherits interrupt status.
+	 */
+	CheriSealTypeSentryInheriting,
+
+	/**
+	 * Sentry that disables interrupts on calls.
+	 */
+	CheriSealTypeSentryDisabling,
+
+	/**
+	 * Sentry that enables interrupts on calls.
+	 */
+	CheriSealTypeSentryEnabling,
+
+	/**
+	 * Return sentry that disables interrupts on return
+	 */
+	CheriSealTypeReturnSentryDisabling,
+
+	/**
+	 * Return sentry that enables interrupts on return
+	 */
+	CheriSealTypeReturnSentryEnabling,
+
+	/**
+	 * Marker for the first sealing type that's valid for data capabilities.
+	 */
+	CheriSealTypeFirstDataSealingType = 9,
+
+	/**
+	 * The sealing type used for sealed export table entries.
+	 *
+	 * This is RTOS- and not CHERIoT-specific.
+	 */
+	CheriSealTypeSealedImportTableEntries = CheriSealTypeFirstDataSealingType,
+
+	/**
+	 * The compartment switcher has a sealing type for the trusted stack.
+	 *
+	 * This must be the second data sealing type so that we can also permit
+	 * the switcher to unseal sentries and export table entries.
+	 *
+	 * This is RTOS- and not CHERIoT-specific.
+	 */
+	CheriSealTypeSealedTrustedStacks,
+
+	/**
+	 * The allocator has a sealing type for the software sealing mechanism
+	 * with dynamically allocated objects.
+	 *
+	 * This is RTOS- and not CHERIoT-specific.
+	 */
+	CheriSealTypeAllocator,
+
+	/**
+	 * The loader reserves a sealing type for the software sealing
+	 * mechanism.  The permit-unseal capability for this is destroyed after
+	 * the loader has run, which guarantees that anything sealed with this
+	 * type was present in the original firmware image.  The token library
+	 * has the only permit-unseal capability for this type.
+	 *
+	 * This is RTOS- and not CHERIoT-specific.
+	 */
+	CheriSealTypeStaticToken,
+
+	/**
+	 * The first sealing key that is reserved for use by the allocator's
+	 * software sealing mechanism and used for static sealing types,
+	 *
+	 * Architecturally, this is the smallest non-interpreted sealing type.
+	 */
+	CheriSealTypeFirstStaticSoftware = 16,
+
+	/**
+	 * The first sealing key in the space that the allocator will
+	 * dynamically allocate for sealing types.
+	 *
+	 * This is RTOS- and not CHERIoT-specific.
+	 */
+	CheriSealTypeFirstDynamicSoftware = 0x1000000
+};
+
+/**
  * Checks that `ptr` is valid, unsealed, has at least `rawPermissions`, and has
  * at least `space` bytes after the current offset.
  *

--- a/sdk/include/cheri.h
+++ b/sdk/include/cheri.h
@@ -9,6 +9,266 @@
 struct Timeout;
 
 /**
+ * The complete set of architectural permissions.
+ */
+enum CHERIPermission
+{
+	/**
+	 * Capability refers to global memory (this capability may be stored
+	 * anywhere).
+	 */
+	CheriPermissionGlobal = 0,
+	/**
+	 * Global capabilities can be loaded through this capability.  Without
+	 *  this permission, any capability loaded via this capability will
+	 *  have `Global` and `LoadGlobal` removed.
+	 */
+	CheriPermissionLoadGlobal = 1,
+	/**
+	 * Capability may be used to store.  Any store via a capability without
+	 * this permission will trap.
+	 */
+	CheriPermissionStore = 2,
+	/**
+	 * Capabilities with store permission may be loaded through this
+	 * capability.  Without this, any loaded capability will have
+	 * `LoadMutable` and `Store` removed.
+	 */
+	CheriPermissionLoadMutable = 3,
+	/**
+	 * This capability may be used to store capabilities that do not have
+	 * `Global` permission.
+	 */
+	CheriPermissionStoreLocal = 4,
+	/**
+	 * This capability can be used to load.
+	 */
+	CheriPermissionLoad = 5,
+	/**
+	 * Any load and store permissions on this capability convey the right to
+	 * load or store capabilities in addition to data.
+	 */
+	CheriPermissionLoadStoreCapability = 6,
+	/**
+	 * If installed as the program counter capability, running code may
+	 * access privileged system registers.
+	 */
+	CheriPermissionAccessSystemRegisters = 7,
+	/**
+	 * This capability may be used as a jump target and used to execute
+	 * instructions.
+	 */
+	CheriPermissionExecute = 8,
+	/**
+	 * This capability may be used to unseal other capabilities.  The
+	 * 'address' range is in the sealing type namespace and not in the
+	 * memory namespace.
+	 */
+	CheriPermissionUnseal = 9,
+	/**
+	 * This capability may be used to seal other capabilities.  The
+	 * 'address' range is in the sealing type namespace and not in the
+	 * memory namespace.
+	 */
+	CheriPermissionSeal = 10,
+	/**
+	 * Software defined permission bit, no architectural meaning.
+	 */
+	CheriPermissionUser0 = 11
+};
+
+/**
+ * The codes used in the cause field of the mtval CSR when the processor
+ * takes a CHERI exception.
+ */
+enum CHERICauseCode
+{
+	/**
+	 * No exception. This value is passed to the error handler after a
+	 * forced unwind in a called compartment.
+	 */
+	CheriCauseCodeNone = 0,
+	/**
+	 * Attempted to use a capability outside its bounds.
+	 */
+	CheriCauseCodeBoundsViolation = 1,
+	/**
+	 * Attempted to use an untagged capability to authorize something.
+	 */
+	CheriCauseCodeTagViolation = 2,
+	/**
+	 * Attempted to use a sealed capability to authorize something.
+	 */
+	CheriCauseCodeSealViolation = 3,
+	/**
+	 * Attempted to jump to a capability without `Permission::Execute`.
+	 */
+	CheriCauseCodePermitExecuteViolation = 0x11,
+	/**
+	 * Attempted to load via a capability without `Permission::Load`.
+	 */
+	CheriCauseCodePermitLoadViolation = 0x12,
+	/**
+	 * Attempted to store via a capability without `Permission::Store`.
+	 */
+	CheriCauseCodePermitStoreViolation = 0x13,
+	/**
+	 * Attempted to store a tagged capability via a capability without
+	 * `Permission::LoadStoreCapability`.
+	 */
+	CheriCauseCodePermitStoreCapabilityViolation = 0x15,
+	/**
+	 * Attempted to store a tagged capability without `Permission::Global`
+	 * via capability without `Permission::StoreLocal`.
+	 */
+	CheriCauseCodePermitStoreLocalCapabilityViolation = 0x16,
+	/**
+	 * Attempted to access a restricted CSR or SCR with PCC without
+	 * `Permission::AccessSystemRegisters`.
+	 */
+	CheriCauseCodePermitAccessSystemRegistersViolation = 0x18,
+	/**
+	 * Used to represent a value that has no valid meaning in hardware.
+	 */
+	CheriCauseCodeInvalid = -1
+};
+
+/**
+ * Register numbers as reported in cap idx field of  `mtval` CSR when
+ * a CHERI exception is taken. Values less than 32 refer to general
+ * purpose registers and others to SCRs (of these, only PCC can actually
+ * cause an exception).
+ */
+enum CHERIRegisterNumber
+{
+	/**
+	 * The zero register, which always contains the `NULL` capability.
+	 */
+	CheriRegisterNumberCzr = 0x0,
+	/**
+	 * `$c1` / `$cra` used by the ABI as the return address.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCra = 0x1,
+	/**
+	 * `$c2` / `$csp` used by the ABI as the stack pointer.
+	 * Preserved across calls.
+	 */
+	CheriRegisterNumberCsp = 0x2,
+	/**
+	 * `$c3` / `$cgp` used by the ABI as the global pointer.
+	 * Not allocatable by the compiler, set by the switcher on compartment
+	 * entry.
+	 */
+	CheriRegisterNumberCgp = 0x3,
+	/**
+	 * `$c4` / `$ctp` used by the ABI as the thread pointer.
+	 * Currently unused by the compiler.
+	 * Not preserved across compartment calls.
+	 */
+	CheriRegisterNumberCtp = 0x4,
+	/**
+	 * `$c5` / `$ct0` used by the ABI as temporary register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCT0 = 0x5,
+	/**
+	 * `$c6` / `$ct1` used by the ABI as temporary register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCT1 = 0x6,
+	/**
+	 * `$c7` / `$ct2` used by the ABI as temporary register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCT2 = 0x7,
+	/**
+	 * `$c8` / `$cs0` used by the ABI as a callee-saved register.
+	 * Preserved across calls.
+	 */
+	CheriRegisterNumberCS0 = 0x8,
+	/**
+	 * `$c9` / `$cs1` used by the ABI as a callee-saved register.
+	 * Preserved across calls.
+	 */
+	CheriRegisterNumberCS1 = 0x9,
+	/**
+	 * `$c10` / `$ca0` used by the ABI as an argument register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCA0 = 0xa,
+	/**
+	 * `$c11` / `$ca1` used by the ABI as an argument register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCA1 = 0xb,
+	/**
+	 * `$c12` / `$ca2` used by the ABI as an argument register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCA2 = 0xc,
+	/**
+	 * `$c13` / `$ca3` used by the ABI as an argument register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCA3 = 0xd,
+	/**
+	 * `$c14` / `$ca4` used by the ABI as an argument register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCA4 = 0xe,
+	/**
+	 * `$c15` / `$ca5` used by the ABI as an argument register.
+	 * Not preserved across calls.
+	 */
+	CheriRegisterNumberCA5 = 0xf,
+	/**
+	 * The Program Counter Capability.
+	 *
+	 * Special capability register used to authorize instruction fetch. The
+	 * address is that of the faulting instruction. Also used for accessing
+	 * read-only globals.
+	 */
+	CheriRegisterNumberPcc = 0x20,
+	/**
+	 * Machine-mode Trap Code Capability.
+	 *
+	 * Special capability register that
+	 * is installed in PCC when the CPU takes a trap. The address has the
+	 * same semantics as the RISC-V `mtvec` CSR. Only accessible when PCC
+	 * has the AccessSystemRegisters permission.
+	 */
+	CheriRegisterNumberMtcc = 0x3c,
+	/**
+	 * Machine-mode Tusted Data Capability.
+	 *
+	 * Special capability register that contains the memory root capability
+	 * on boot. Only accessible when PCC has the AccessSystemRegisters
+	 * permission.  Use by the RTOS to store a capability to the trusted
+	 * stack.
+	 */
+	CheriRegisterNumberMtdc = 0x3d,
+	/**
+	 * Machine-mode Scratch Capability. Special capabiltiy register that
+	 * contains the sealing root capability on boot. Only accessible when
+	 * PCC has the AccessSystemRegisters permission.
+	 */
+	CheriRegisterNumberMScratchC = 0x3e,
+	/**
+	 * Machine-mode Exception Program Counter Capability. Special capability
+	 * register that contains the PCC of the faulting instruction on trap.
+	 * The address has the same semantics as the RISC-V `mepc` CSR. Only
+	 * accessible when PCC has the AccessSystemRegisters permission.
+	 */
+	CheriRegisterNumberMepcc = 0x3f,
+	/**
+	 * Indicates a value that is not used by the hardware to refer to a
+	 * register.
+	 */
+	CheriRegisterNumberInvalid = -1
+};
+
+/**
  * Checks that `ptr` is valid, unsealed, has at least `rawPermissions`, and has
  * at least `space` bytes after the current offset.
  *

--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -22,64 +22,64 @@ namespace CHERI
 		 * Capability refers to global memory (this capability may be stored
 		 * anywhere).
 		 */
-		Global = 0,
+		Global = CheriPermissionGlobal,
 		/**
 		 * Global capabilities can be loaded through this capability.  Without
 		 *  this permission, any capability loaded via this capability will
 		 *  have `Global` and `LoadGlobal` removed.
 		 */
-		LoadGlobal = 1,
+		LoadGlobal = CheriPermissionLoadGlobal,
 		/**
 		 * Capability may be used to store.  Any store via a capability without
 		 * this permission will trap.
 		 */
-		Store = 2,
+		Store = CheriPermissionStore,
 		/**
 		 * Capabilities with store permission may be loaded through this
 		 * capability.  Without this, any loaded capability will have
 		 * `LoadMutable` and `Store` removed.
 		 */
-		LoadMutable = 3,
+		LoadMutable = CheriPermissionLoadMutable,
 		/**
 		 * This capability may be used to store capabilities that do not have
 		 * `Global` permission.
 		 */
-		StoreLocal = 4,
+		StoreLocal = CheriPermissionStoreLocal,
 		/**
 		 * This capability can be used to load.
 		 */
-		Load = 5,
+		Load = CheriPermissionLoad,
 		/**
 		 * Any load and store permissions on this capability convey the right to
 		 * load or store capabilities in addition to data.
 		 */
-		LoadStoreCapability = 6,
+		LoadStoreCapability = CheriPermissionLoadStoreCapability,
 		/**
 		 * If installed as the program counter capability, running code may
 		 * access privileged system registers.
 		 */
-		AccessSystemRegisters = 7,
+		AccessSystemRegisters = CheriPermissionAccessSystemRegisters,
 		/**
 		 * This capability may be used as a jump target and used to execute
 		 * instructions.
 		 */
-		Execute = 8,
+		Execute = CheriPermissionExecute,
 		/**
 		 * This capability may be used to unseal other capabilities.  The
 		 * 'address' range is in the sealing type namespace and not in the
 		 * memory namespace.
 		 */
-		Unseal = 9,
+		Unseal = CheriPermissionUnseal,
 		/**
 		 * This capability may be used to seal other capabilities.  The
 		 * 'address' range is in the sealing type namespace and not in the
 		 * memory namespace.
 		 */
-		Seal = 10,
+		Seal = CheriPermissionSeal,
 		/**
 		 * Software defined permission bit, no architectural meaning.
 		 */
-		User0 = 11
+		User0 = CheriPermissionUser0
 	};
 
 	/**
@@ -1231,50 +1231,53 @@ namespace CHERI
 		 * No exception. This value is passed to the error handler after a
 		 * forced unwind in a called compartment.
 		 */
-		None = 0,
+		None = CheriCauseCodeNone,
 		/**
 		 * Attempted to use a capability outside its bounds.
 		 */
-		BoundsViolation = 1,
+		BoundsViolation = CheriCauseCodeBoundsViolation,
 		/**
 		 * Attempted to use an untagged capability to authorize something.
 		 */
-		TagViolation = 2,
+		TagViolation = CheriCauseCodeTagViolation,
 		/**
 		 * Attempted to use a sealed capability to authorize something.
 		 */
-		SealViolation = 3,
+		SealViolation = CheriCauseCodeSealViolation,
 		/**
 		 * Attempted to jump to a capability without `Permission::Execute`.
 		 */
-		PermitExecuteViolation = 0x11,
+		PermitExecuteViolation = CheriCauseCodePermitExecuteViolation,
 		/**
 		 * Attempted to load via a capability without `Permission::Load`.
 		 */
-		PermitLoadViolation = 0x12,
+		PermitLoadViolation = CheriCauseCodePermitLoadViolation,
 		/**
 		 * Attempted to store via a capability without `Permission::Store`.
 		 */
-		PermitStoreViolation = 0x13,
+		PermitStoreViolation = CheriCauseCodePermitStoreViolation,
 		/**
 		 * Attempted to store a tagged capability via a capability without
 		 * `Permission::LoadStoreCapability`.
 		 */
-		PermitStoreCapabilityViolation = 0x15,
+		PermitStoreCapabilityViolation =
+		  CheriCauseCodePermitStoreCapabilityViolation,
 		/**
 		 * Attempted to store a tagged capability without `Permission::Global`
 		 * via capability without `Permission::StoreLocal`.
 		 */
-		PermitStoreLocalCapabilityViolation = 0x16,
+		PermitStoreLocalCapabilityViolation =
+		  CheriCauseCodePermitStoreLocalCapabilityViolation,
 		/**
 		 * Attempted to access a restricted CSR or SCR with PCC without
 		 * `Permission::AccessSystemRegisters`.
 		 */
-		PermitAccessSystemRegistersViolation = 0x18,
+		PermitAccessSystemRegistersViolation =
+		  CheriCauseCodePermitAccessSystemRegistersViolation,
 		/**
 		 * Used to represent a value that has no valid meaning in hardware.
 		 */
-		Invalid = -1
+		Invalid = CheriCauseCodeInvalid,
 	};
 
 	/**
@@ -1288,84 +1291,84 @@ namespace CHERI
 		/**
 		 * The zero register, which always contains the `NULL` capability.
 		 */
-		CZR = 0x0,
+		CZR = CheriRegisterNumberCzr,
 		/**
 		 * `$c1` / `$cra` used by the ABI as the return address.
 		 * Not preserved across calls.
 		 */
-		CRA = 0x1,
+		CRA = CheriRegisterNumberCra,
 		/**
 		 * `$c2` / `$csp` used by the ABI as the stack pointer.
 		 * Preserved across calls.
 		 */
-		CSP = 0x2,
+		CSP = CheriRegisterNumberCsp,
 		/**
 		 * `$c3` / `$cgp` used by the ABI as the global pointer.
 		 * Not allocatable by the compiler, set by the switcher on compartment
 		 * entry.
 		 */
-		CGP = 0x3,
+		CGP = CheriRegisterNumberCgp,
 		/**
 		 * `$c4` / `$ctp` used by the ABI as the thread pointer.
 		 * Currently unused by the compiler.
 		 * Not preserved across compartment calls.
 		 */
-		CTP = 0x4,
+		CTP = CheriRegisterNumberCtp,
 		/**
 		 * `$c5` / `$ct0` used by the ABI as temporary register.
 		 * Not preserved across calls.
 		 */
-		CT0 = 0x5,
+		CT0 = CheriRegisterNumberCT0,
 		/**
 		 * `$c6` / `$ct1` used by the ABI as temporary register.
 		 * Not preserved across calls.
 		 */
-		CT1 = 0x6,
+		CT1 = CheriRegisterNumberCT1,
 		/**
 		 * `$c7` / `$ct2` used by the ABI as temporary register.
 		 * Not preserved across calls.
 		 */
-		CT2 = 0x7,
+		CT2 = CheriRegisterNumberCT2,
 		/**
 		 * `$c8` / `$cs0` used by the ABI as a callee-saved register.
 		 * Preserved across calls.
 		 */
-		CS0 = 0x8,
+		CS0 = CheriRegisterNumberCS0,
 		/**
 		 * `$c9` / `$cs1` used by the ABI as a callee-saved register.
 		 * Preserved across calls.
 		 */
-		CS1 = 0x9,
+		CS1 = CheriRegisterNumberCS1,
 		/**
 		 * `$c10` / `$ca0` used by the ABI as an argument register.
 		 * Not preserved across calls.
 		 */
-		CA0 = 0xa,
+		CA0 = CheriRegisterNumberCA0,
 		/**
 		 * `$c11` / `$ca1` used by the ABI as an argument register.
 		 * Not preserved across calls.
 		 */
-		CA1 = 0xb,
+		CA1 = CheriRegisterNumberCA1,
 		/**
 		 * `$c12` / `$ca2` used by the ABI as an argument register.
 		 * Not preserved across calls.
 		 */
-		CA2 = 0xc,
+		CA2 = CheriRegisterNumberCA2,
 		/**
 		 * `$c13` / `$ca3` used by the ABI as an argument register.
 		 * Not preserved across calls.
 		 */
-		CA3 = 0xd,
+		CA3 = CheriRegisterNumberCA3,
 		/**
 		 * `$c14` / `$ca4` used by the ABI as an argument register.
 		 * Not preserved across calls.
 		 */
-		CA4 = 0xe,
+		CA4 = CheriRegisterNumberCA4,
 		/**
 		 * `$c15` / `$ca5` used by the ABI as an argument register.
 		 * Not preserved across calls.
 		 */
-		CA5 = 0xf,
+		CA5 = CheriRegisterNumberCA5,
 		/**
 		 * The Program Counter Capability.
 		 *
@@ -1373,7 +1376,7 @@ namespace CHERI
 		 * address is that of the faulting instruction. Also used for accessing
 		 * read-only globals.
 		 */
-		PCC = 0x20,
+		PCC = CheriRegisterNumberPcc,
 		/**
 		 * Machine-mode Trap Code Capability.
 		 *
@@ -1382,7 +1385,7 @@ namespace CHERI
 		 * same semantics as the RISC-V `mtvec` CSR. Only accessible when PCC
 		 * has the AccessSystemRegisters permission.
 		 */
-		MTCC = 0x3c,
+		MTCC = CheriRegisterNumberMtcc,
 		/**
 		 * Machine-mode Tusted Data Capability.
 		 *
@@ -1391,25 +1394,25 @@ namespace CHERI
 		 * permission.  Use by the RTOS to store a capability to the trusted
 		 * stack.
 		 */
-		MTDC = 0x3d,
+		MTDC = CheriRegisterNumberMtdc,
 		/**
 		 * Machine-mode Scratch Capability. Special capabiltiy register that
 		 * contains the sealing root capability on boot. Only accessible when
 		 * PCC has the AccessSystemRegisters permission.
 		 */
-		MScratchC = 0x3e,
+		MScratchC = CheriRegisterNumberMScratchC,
 		/**
 		 * Machine-mode Exception Program Counter Capability. Special capability
 		 * register that contains the PCC of the faulting instruction on trap.
 		 * The address has the same semantics as the RISC-V `mepc` CSR. Only
 		 * accessible when PCC has the AccessSystemRegisters permission.
 		 */
-		MEPCC = 0x3f,
+		MEPCC = CheriRegisterNumberMepcc,
 		/**
 		 * Indicates a value that is not used by the hardware to refer to a
 		 * register.
 		 */
-		Invalid = -1
+		Invalid = CheriRegisterNumberInvalid,
 	};
 
 	/**

--- a/tests/crash_recovery-test.cc
+++ b/tests/crash_recovery-test.cc
@@ -10,9 +10,18 @@
 int               crashes = 0;
 std::atomic<bool> expectFault;
 
+static void test_irqs_are_enabled()
+{
+	void *r = __builtin_return_address(0);
+	TEST(__builtin_cheri_type_get(r) == CheriSealTypeReturnSentryEnabling,
+	     "Calling context has IRQs disabled");
+}
+
 extern "C" enum ErrorRecoveryBehaviour
 compartment_error_handler(struct ErrorState *frame, size_t mcause, size_t mtval)
 {
+	test_irqs_are_enabled();
+
 	crashes++;
 	if (mcause == 0x2)
 	{


### PR DESCRIPTION
The core change here is the addition of _two instructions_ to the switcher.  There's a change to our crash_recovery test that makes sure we're doing the right thing (and which fails when those two new instructions are not present).  And because that wanted to use a symbolic name for one number that was previously somewhat buried, there's a lot of shuffling of symbolic names for things, to hopefully make similar things easier in the future.