### PR TITLE
Eliminate use of #elifdef

### DIFF
--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -24,7 +24,7 @@ namespace
 		// On Sail, report the number of instructions, the cycle count is
 		// meaningless.
 		__asm__ volatile("csrr %0, minstret" : "=r"(cycles));
-#elifdef IBEX
+#elif defined(IBEX)
 		__asm__ volatile("csrr %0, mcycle" : "=r"(cycles));
 #else
 		__asm__ volatile("rdcycle %0" : "=r"(cycles));


### PR DESCRIPTION
This technically isn't in C++20, and clang-17 starts to enforce that restriction.
It's simple to remove it in this case, and doing so allows both clang-15 and clang-17
to work on the same codebase.
