### PR TITLE
Add __multi3() to crt library

### DIFF
--- a/sdk/lib/crt/arith64.c
+++ b/sdk/lib/crt/arith64.c
@@ -25,6 +25,7 @@
 // - Add asm labels so that the compiler doesn't need to know the C++ type encodings for builtins.
 // - Use standard integer types.
 // - Add SPDX tags for license from the upstream repository (commit 426b7578ecfb5ce7c841e738613cff2a261214eb)
+// - Add the implementation of __multi3() 
 //
 // This file is *not* formatted, to make it easier to track changes from upstream (if there are any).
 
@@ -54,6 +55,7 @@ int __cheri_libcall __popcountsi2(arith64_u32 a) __asm__("__popcountsi2");
 int __cheri_libcall __popcountdi2(arith64_u64 a) __asm__("__popcountdi2");
 arith64_u64 __cheri_libcall __udivdi3(arith64_u64 a, arith64_u64 b) __asm__("__udivdi3");
 arith64_u64 __cheri_libcall __umoddi3(arith64_u64 a, arith64_u64 b) __asm__("__umoddi3");
+arith64_u64 __cheri_libcall __multi3(arith64_u64 a, arith64_u64 b) __asm__("__multi3");
 
 typedef union
 {
@@ -299,4 +301,10 @@ typedef union
     arith64_u64 r;
     __divmoddi4(a, b, &r);
     return r;
+}
+
+// Return the product of a and b
+[[clang::no_builtin]] arith64_u64 __multi3(arith64_u64 a, arith64_u64 b)
+{
+    return a * b;
 }

--- a/sdk/lib/crt/arith64.c
+++ b/sdk/lib/crt/arith64.c
@@ -55,7 +55,7 @@ int __cheri_libcall __popcountsi2(arith64_u32 a) __asm__("__popcountsi2");
 int __cheri_libcall __popcountdi2(arith64_u64 a) __asm__("__popcountdi2");
 arith64_u64 __cheri_libcall __udivdi3(arith64_u64 a, arith64_u64 b) __asm__("__udivdi3");
 arith64_u64 __cheri_libcall __umoddi3(arith64_u64 a, arith64_u64 b) __asm__("__umoddi3");
-arith64_u64 __cheri_libcall __multi3(arith64_u64 a, arith64_u64 b) __asm__("__multi3");
+arith64_s64 __cheri_libcall __multi3(arith64_s64 a, arith64_s64 b) __asm__("__multi3");
 
 typedef union
 {
@@ -304,7 +304,7 @@ typedef union
 }
 
 // Return the product of a and b
-[[clang::no_builtin]] arith64_u64 __multi3(arith64_u64 a, arith64_u64 b)
+[[clang::no_builtin]] arith64_s64 __multi3(arith64_s64 a, arith64_s64 b)
 {
     return a * b;
 }


### PR DESCRIPTION
The compiler believes that the x25519 layer in libhydrogen has a dependency on __multi3(), even though it can generate the code fine if asked directly to multiply two uint64_t values.    So we'll humour it by giving it that as an implemenation.  

Closes #352 