### PR TITLE
Allocator: expose minimum chunk size information, fix test

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -683,6 +683,8 @@ constexpr size_t MinChunkSize =
 // the minimum size of a chunk (excluding the header)
 constexpr size_t MinRequest = MinChunkSize - sizeof(MChunkHeader);
 
+static_assert(MinChunkSize == CHERIOTHeapMinChunkSize);
+
 // true if cap address a has acceptable alignment
 static inline bool is_aligned(CHERI::Capability<void> a)
 {


### PR DESCRIPTION
`allocator-test.cc` needs to account for underlying object sizes.  Expose the information it needs to do so and update documentation on heap interface functions.