### PR TITLE
Improve a comment and fix heap_can_free.

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -923,10 +923,14 @@ __cheriot_minimum_stack(0x1c0) ssize_t
 	return 0;
 }
 
-__cheriot_minimum_stack(0xf0) int heap_can_free(SObj  heapCapability,
-                                                void *rawPointer)
+__cheriot_minimum_stack(0x260) int heap_can_free(SObj  heapCapability,
+                                                 void *rawPointer)
 {
-	STACK_CHECK(0xf0);
+	// This function requires much less space, but we claim that we require as
+	// much as `heap_free` so that a call to `heap_free` will not fail due to
+	// insufficient stack immediately after `heap_can_Free` has said that it's
+	// fine.
+	STACK_CHECK(0x260);
 	LockGuard g{lock};
 	return heap_free_internal(heapCapability, rawPointer, false);
 }
@@ -934,6 +938,7 @@ __cheriot_minimum_stack(0xf0) int heap_can_free(SObj  heapCapability,
 __cheriot_minimum_stack(0x260) int heap_free(SObj  heapCapability,
                                              void *rawPointer)
 {
+	// If this value changes, update `heap_can_free` as well.
 	STACK_CHECK(0x260);
 	LockGuard g{lock};
 	int       ret = heap_free_internal(heapCapability, rawPointer, true);

--- a/sdk/include/queue.h
+++ b/sdk/include/queue.h
@@ -102,11 +102,11 @@ int __cheri_libcall queue_create(Timeout              *timeout,
  * and makes them fail to acquire the lock, before deallocating the underlying
  * allocation.
  *
- * This must be called on an unrestricted queue handle (*not* one returned by
- * `queue_make_receive_handle` or `queue_make_send_handle`).
+ * Returns 0 on success. This can fail only if deallocation would fail and will,
+ * in these cases, return the same error codes as `heap_free`.
  *
- * Returns 0 on success. On failure, returns `-EPERM` if the queue handle is
- * restricted (see comment above).
+ * This function will check the heap capability first and so will avoid
+ * upgrading the locks if freeing the queue would fail.
  */
 int __cheri_libcall queue_destroy(struct SObjStruct   *heapCapability,
                                   struct MessageQueue *handle);


### PR DESCRIPTION
Previously `heap_can_free` would succeed in a situation where `heap_free` would fail with an insufficient-stack error.