### PR TITLE
Action updated from v3 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       options: --user 1001
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Build tests
@@ -80,7 +80,7 @@ jobs:
       options: --user 1001
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Run clang-format and clang-tidy


### PR DESCRIPTION
I believe v3 will be deprecated soon, so it's probably a good idea to update to v4 as long as this doesn't break anything.