### PR TITLE
scheduler dynamic object deallocation must use the token APIs

### DIFF
--- a/sdk/core/scheduler/common.h
+++ b/sdk/core/scheduler/common.h
@@ -51,9 +51,16 @@ namespace
 	 * Subclasses must implement a static `sealing_type` method that returns
 	 * the sealing key.
 	 */
-	template<bool IsDynamic>
+	template<bool IsDynamicArg>
 	struct Handle
 	{
+		/**
+		 * Some Handle types must reside in static memory, and some may be built
+		 * on the fly, and in particular in the shared heap, at runtime.  Is
+		 * this type among the latter?
+		 */
+		static constexpr bool IsDynamic = IsDynamicArg;
+
 		/**
 		 * Unseal `unsafePointer` as a pointer to an object of the specified
 		 * type.  Returns nullptr if `unsafePointer` is not a valid sealed

--- a/tests/multiwaiter-test.cc
+++ b/tests/multiwaiter-test.cc
@@ -126,6 +126,7 @@ int test_multiwaiter()
 	     "Queue reports ready to receive but should be empty.");
 	TEST(events[1].value == 1, "Futex reports no wake");
 
-	multiwaiter_delete(MALLOC_CAPABILITY, mw);
+	TEST_EQUAL(
+	  multiwaiter_delete(MALLOC_CAPABILITY, mw), 0, "Failed to clean up");
 	return 0;
 }


### PR DESCRIPTION
The scheduler compartment offers a small menagerie of dedicated object types to the system though the (static and dynamic) software capability mechanisms.  The private internals of these objects are subtypes of the [`Handle`](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/2625f2de6ddd8773c4a59ab5fb6ab5ba2d371b54/sdk/core/scheduler/common.h#L54-L91) `struct`.  `Handle`s know how to `unseal` themselves with a fair bit of paranoia, by invoking `token_obj_unseal_dynamic` or `token_obj_unseal_static` with the per-type sealing type (b9f206a7c9b138e762b51f539d085a4d7377a516 eliminated the use of a dedicated hardware sealing type for the scheduler's use in favor of the static/dynamic partition.)  The scheduler has an internal affordance making the use of `Handle`s particularly convenient: [`typed_op`](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/2625f2de6ddd8773c4a59ab5fb6ab5ba2d371b54/sdk/core/scheduler/main.cc#L344-L371), which unseals a `Handle` and passes the unsealed, checked-downcast pointer to a callback.  This works great for almost all uses.

Unfortunately, when a dynamic object reaches the end of its life, the scheduler attempts to use `typed_op` to get the underlying allocation to be released: https://github.com/CHERIoT-Platform/cheriot-rtos/blob/2625f2de6ddd8773c4a59ab5fb6ab5ba2d371b54/sdk/core/scheduler/main.cc#L376-L393 .  This cannot function correctly to actually deallocate the object: the unsealed portion of a (dynamic) software capability is but a part of the whole underlying allocation, and while `heap_free` permits dropping a *claim* with a subset capability, it does not permit actually releasing the object.

We must therefore use the token APIs to destroy the object in question.