### PR TITLE
Fix a bug in thread exits.

### DIFF
--- a/sdk/core/scheduler/thread.h
+++ b/sdk/core/scheduler/thread.h
@@ -363,6 +363,7 @@ namespace
 		{
 			Debug::log("Thread exited, {} threads remaining", threadCount - 1);
 			current->list_remove(&priorityList[current->priority]);
+			current->priority_map_remove();
 			current->state = ThreadState::Exited;
 			return (--threadCount) == 0;
 		}


### PR DESCRIPTION
The priority map was not updated so if the highest-priority thread exited then the next thread would not become runnable.