### PR TITLE
ibex: the revoker IRQ is edge-triggered

### DIFF
--- a/sdk/boards/ibex-safe-simulator.json
+++ b/sdk/boards/ibex-safe-simulator.json
@@ -32,7 +32,8 @@
         {
             "name": "RevokerInterrupt",
             "number": 1,
-            "priority": 2
+            "priority": 2,
+            "edge_triggered": true
         }
     ],
     "defines" : [


### PR DESCRIPTION
With https://github.com/microsoft/cheriot-safe/pull/22 now getting the revoker's attempts to interrupt us through the PLIC to the core, it turns out we need to acknowledge the PLIC's attempts to poke us, or it will never do so again.

This won't matter for CI -- or, at least, its effects will not be visible -- until we rebuild the dev container with the aforementioned PR applied to its verilated Ibex(es) (Ibexen? Ibices?).