### PR TITLE
sonata-prerelease: revoker IRQ is edge triggered

### DIFF
--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -80,7 +80,8 @@
         {
             "name": "RevokerInterrupt",
             "number": 1,
-            "priority": 2
+            "priority": 2,
+            "edge_triggered": true
         },
         {
             "name": "EthernetInterrupt",

--- a/sdk/boards/sonata-simulator.json
+++ b/sdk/boards/sonata-simulator.json
@@ -76,7 +76,8 @@
         {
             "name": "RevokerInterrupt",
             "number": 1,
-            "priority": 2
+            "priority": 2,
+            "edge_triggered": true
         },
         {
             "name": "EthernetInterrupt",


### PR DESCRIPTION
Replay #384 for a related platform.  With this in place, I can get the revoker IRQ test to pass on the 1.0 hardware.
```
top: At startup, revocation epoch is 0x0; waiting...
top: After wait: for 0x0, result true, epoch now is 0x2, wait elapsed 0x0 remaining 0x32
top: After wait: for 0x2, result true, epoch now is 0x4, wait elapsed 0x0 remaining 0x32
top: After wait: for 0x4, result true, epoch now is 0x6, wait elapsed 0x0 remaining 0x32
top: After wait: for 0x6, result true, epoch now is 0x8, wait elapsed 0x0 remaining 0x32
top: After wait: for 0x8, result true, epoch now is 0xa, wait elapsed 0x1 remaining 0x31
top: After wait: for 0xa, result true, epoch now is 0xc, wait elapsed 0x0 remaining 0x32
top: After wait: for 0xc, result true, epoch now is 0xe, wait elapsed 0x0 remaining 0x32
top: After wait: for 0xe, result true, epoch now is 0x10, wait elapsed 0x0 remaining 0x32
top: After wait: for 0x10, result true, epoch now is 0x12, wait elapsed 0x0 remaining 0x32
top: After wait: for 0x12, result true, epoch now is 0x14, wait elapsed 0x1 remaining 0x31
```