### PR TITLE
CI Clang Tidy Fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "image": "ghcr.io/cheriot-platform/devcontainer:latest",
   "remoteUser": "cheriot",
   "containerUser": "cheriot",
-  "onCreateCommand": "git config --global --add safe.directory /workspaces/cheriot-rtos && git submodule init && git submodule update && cd tests && xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands .. && cd .. && for I in ex*/[[:digit:]]* ; do echo $I ; cd $I ; xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands . && cd ../.. ; done",
+  "onCreateCommand": "git config --global --add safe.directory /workspaces/cheriot-rtos && git submodule update --init --recursive && for dir in tests tests.extra/*/ ex*/[[:digit:]]* ; do (echo Generating compile_commands.json for $dir; cd $dir && xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands); done",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "image": "ghcr.io/cheriot-platform/devcontainer:latest",
   "remoteUser": "cheriot",
   "containerUser": "cheriot",
-  "onCreateCommand": "git config --global --add safe.directory /workspaces/cheriot-rtos && git submodule update --init --recursive && for dir in tests tests.extra/*/ ex*/[[:digit:]]* ; do (echo Generating compile_commands.json for $dir; cd $dir && xmake f --sdk=/cheriot-tools/ && xmake project -k compile_commands); done",
+  "onCreateCommand": "git config --global --add safe.directory /workspaces/cheriot-rtos && git submodule update --init --recursive && ./scripts/generate_compile_commands.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
+    - name: Generate compiler_commands.json files
+      run: ./scripts/generate_compiler_commands.sh
     - name: Run clang-format and clang-tidy
       run: ./scripts/run_clang_tidy_format.sh /cheriot-tools/bin
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,20 @@
+# Common functions to include in multiple scripts
+
+function error() {
+    echo "Error: $1"
+    exit 1
+}
+
+function ensure_cheriot_rtos_root () {
+    [ -d sdk ] || error "Please run this script from the root of the cheriot-rtos repository."
+}
+
+function find_sdk () {
+    if [ -n "$1" ]; then
+        SDK="$(readlink -f $1)"
+    elif [ -d "/cheriot-tools/bin" ]; then
+        SDK=/cheriot-tools
+    else
+        error "No SDK found, please provide as first argument."
+    fi
+}

--- a/scripts/generate_compiler_commands.sh
+++ b/scripts/generate_compiler_commands.sh
@@ -1,0 +1,17 @@
+#!/bin/env bash
+
+# Generate compile commands files for all known projects in this repo
+
+
+. "$(dirname $0)"/common.sh
+
+ensure_cheriot_rtos_root
+
+find_sdk $1
+
+echo "Using SDK=$SDK"
+
+for dir in tests tests.extra/*/ ex*/[[:digit:]]* ; do 
+    echo Generating compile_commands.json for $dir
+    (cd $dir && xmake f --sdk="${SDK}" && xmake project -k compile_commands)
+done

--- a/scripts/run_clang_tidy_format.sh
+++ b/scripts/run_clang_tidy_format.sh
@@ -47,7 +47,7 @@ if ! git diff --exit-code ${HEADERS} ${SOURCES} ; then
 	exit 1
 fi
 
-rm -f tidy-*.fail
+rm -f tidy.fail-*
 # sh syntax is -c "string" [name [args ...]], so "tidy" here is the name and not included in "$@"
 echo ${HEADERS} ${SOURCES} | xargs -P${PARALLEL_JOBS} -n1 sh -c "${CLANG_TIDY} --extra-arg=-DCLANG_TIDY -export-fixes=\$(mktemp -p. tidy.fail-XXXX) \$@" tidy
 if [ $(find . -maxdepth 1 -name 'tidy.fail-*' -size +0 | wc -l) -gt 0 ] ; then

--- a/scripts/run_clang_tidy_format.sh
+++ b/scripts/run_clang_tidy_format.sh
@@ -43,7 +43,7 @@ echo Sources: ${SOURCES}
 rm -f tidy-*.fail
 
 # sh syntax is -c "string" [name [args ...]], so "tidy" here is the name and not included in "$@"
-echo ${HEADERS} ${SOURCES} | xargs -P${PARALLEL_JOBS} -n1 sh -c "${CLANG_TIDY} -export-fixes=\$(mktemp -p. tidy.fail-XXXX) \$@" tidy
+echo ${HEADERS} ${SOURCES} | xargs -P${PARALLEL_JOBS} -n1 sh -c "${CLANG_TIDY} --extra-arg=-DCLANG_TIDY -export-fixes=\$(mktemp -p. tidy.fail-XXXX) \$@" tidy
 if [ $(find . -maxdepth 1 -name 'tidy.fail-*' -size +0 | wc -l) -gt 0 ] ; then
 	# clang-tidy put non-empty output in one of the tidy-*.fail files
 	cat tidy.fail-*

--- a/scripts/run_clang_tidy_format.sh
+++ b/scripts/run_clang_tidy_format.sh
@@ -43,7 +43,7 @@ echo Sources: ${SOURCES}
 rm -f tidy-*.fail
 
 # sh syntax is -c "string" [name [args ...]], so "tidy" here is the name and not included in "$@"
-echo ${HEADERS} ${SOURCES} | xargs -P${PARALLEL_JOBS} -n5 sh -c "${CLANG_TIDY} -export-fixes=\$(mktemp -p. tidy.fail-XXXX) \$@" tidy
+echo ${HEADERS} ${SOURCES} | xargs -P${PARALLEL_JOBS} -n1 sh -c "${CLANG_TIDY} -export-fixes=\$(mktemp -p. tidy.fail-XXXX) \$@" tidy
 if [ $(find . -maxdepth 1 -name 'tidy.fail-*' -size +0 | wc -l) -gt 0 ] ; then
 	# clang-tidy put non-empty output in one of the tidy-*.fail files
 	cat tidy.fail-*


### PR DESCRIPTION
- **Generate compile_commands.json for tests.extra projects.**
- **Pass only one file for each clang-tidy invocation.**
- **Add script to generate compiler_commands.json for all projects**
- **Add -DCLANG_TIDY when running clang tidy.**
- **Run clang-format before clang-tidy as it is much quicker.**
- **Fix pattern used when removing old tidy.fail files.**
