### PR TITLE
Allow boards to specify CXFLAGS, and use that to disable machine outlining for Sonata.

### DIFF
--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -93,6 +93,7 @@
         "ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM=1",
         "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1"
     ],
+    "cxflags": "-enable-machine-outliner=never",
     "driver_includes" : [
         "../include/platform/sunburst",
         "../include/platform/ibex",

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -350,6 +350,13 @@ rule("firmware")
 			end)
 		end
 
+		-- Add cxflags to all dependencies.
+		local add_cxflags = function (cxflags)
+			visit_all_dependencies(function (target)
+				target:add('cxflags', cxflags, {force = true})
+			end)
+		end
+
 		local software_revoker = false
 		if board.revoker then
 			local temporal_defines = { "TEMPORAL_SAFETY" }
@@ -392,6 +399,11 @@ rule("firmware")
 		-- If this board defines any macros, add them to all targets
 		if board.defines then
 			add_defines(board.defines)
+		end
+
+		-- If this board defines any cxflags, add them to all targets
+		if board.cxflags then
+			add_cxflags(board.cxflags)
 		end
 
 		add_defines("CPU_TIMER_HZ=" .. math.floor(board.timer_hz))


### PR DESCRIPTION
Fixes https://github.com/CHERIoT-Platform/cheriot-rtos/issues/397