### PR TITLE
GitHub CI: workflow_dispatch container input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ on:
     branches: [ main ]
   merge_group:
   workflow_dispatch:
+    inputs:
+      devcontainer:
+        description: 'Set to override default build container'
+        type: string
+        required: false
 
 jobs:
   run-tests:
@@ -27,7 +32,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/cheriot-platform/devcontainer:latest
+      image: ${{ inputs.devcontainer || 'ghcr.io/cheriot-platform/devcontainer:latest' }}
       options: --user 1001
     steps:
     - name: Checkout repository and submodules


### PR DESCRIPTION
This hopefully makes testing things in CI a little easier, though it does depend on one having the ability to push container images.  Anyway.

Here it is...
- Running a PR (without input parameters; ignore the failure and just see that it ran in `ghcr.io/cheriot-platform/devcontainer:latest`): https://github.com/nwf/cheriot-rtos/actions/runs/12584395387/job/35073959274?pr=2
- Running a `workflow_dispatch` with the optional parameter **un**specified: https://github.com/nwf/cheriot-rtos/actions/runs/12584331924/job/35073768089
- Running a `workflow_dispatch` with the optional parameter *specified*: https://github.com/nwf/cheriot-rtos/actions/runs/12584333916/job/35073774081