### PR TITLE
Tidy simulation_exit

### DIFF
--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -31,9 +31,10 @@ using namespace CHERI;
 /**
  * Exit simulation, reporting the error code given as the argument.
  */
-void simulation_exit(uint32_t code)
+int scheduler_simulation_exit(uint32_t code)
 {
 	platform_simulation_exit(code);
+	return -EPROTO;
 }
 #endif
 
@@ -228,8 +229,10 @@ namespace sched
 		           static_cast<uint32_t>(capcause),
 		           badcap);
 
+#ifdef SIMULATION
 		// If we're in simulation, exit here
-		simulation_exit(1);
+		platform_simulation_exit(1);
+#endif
 
 		for (;;)
 		{
@@ -300,9 +303,11 @@ namespace sched
 				// Make the current thread non-runnable.
 				if (Thread::exit())
 				{
+#ifdef SIMULATION
 					// If we have no threads left (not counting the idle
 					// thread), exit.
-					simulation_exit(0);
+					platform_simulation_exit(0);
+#endif
 				}
 				// We cannot continue exiting this thread, make sure we will
 				// pick a new one.

--- a/sdk/include/fail-simulator-on-error.h
+++ b/sdk/include/fail-simulator-on-error.h
@@ -67,11 +67,14 @@ compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 		DebugErrorHandler::log("Unhandled error {} at {}", mcause, frame->pcc);
 	}
 
-	simulation_exit(1);
+#ifdef SIMULATION
 	/*
-	 * simulation_exit may fail (say, we're not on a simulator or there isn't
+	 * simulation exit may fail (say, we're not on a simulator or there isn't
 	 * enough stack space to invoke the function.  In that case, just fall back
 	 * to forcibly unwinding.
 	 */
+	(void)scheduler_simulation_exit(1);
+#endif
+
 	return ErrorRecoveryBehaviour::ForceUnwind;
 }

--- a/sdk/include/simulator.h
+++ b/sdk/include/simulator.h
@@ -3,14 +3,34 @@
 
 #pragma once
 #include <compartment.h>
+#include <errno.h>
 #include <stdint.h>
 
 #ifdef SIMULATION
 /**
  * Exit simulation, reporting the error code given as the argument.
  */
-[[cheri::interrupt_state(disabled)]] void __cheri_compartment("sched")
-  simulation_exit(uint32_t code = 0);
-#else
-static inline void simulation_exit(uint32_t code){};
+[[cheri::interrupt_state(disabled)]] int __cheri_compartment("sched")
+  scheduler_simulation_exit(uint32_t code __if_cxx(= 0));
 #endif
+
+/**
+ * Exit the simulation, if we can, or fall back to an infinite loop.
+ */
+static inline void __attribute__((noreturn))
+simulation_exit(uint32_t code __if_cxx(= 0))
+{
+#ifdef SIMULATION
+	/*
+	 * This fails only if either we are out of (trusted) stack space for the
+	 * cross-call or the platform is misconfigured.  If either of those happen,
+	 * fall back to infinite looping.
+	 */
+	(void)scheduler_simulation_exit(code);
+#endif
+
+	while (true)
+	{
+		yield();
+	}
+};

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -66,10 +66,7 @@ compartment_error_handler(struct ErrorState *frame, size_t mcause, size_t mtval)
 	if (mcause == 0x2)
 	{
 		debug_log("Test failure in test runner");
-#ifdef SIMULATION
 		simulation_exit(1);
-#endif
-		return ErrorRecoveryBehaviour::ForceUnwind;
 	}
 	debug_log("mcause: {}, pcc: {}", mcause, frame->pcc);
 	auto [reg, cause] = CHERI::extract_cheri_mtval(mtval);
@@ -162,13 +159,5 @@ void __cheri_compartment("test_runner") run_tests()
 
 	TEST(crashDetected == false, "One or more tests failed");
 
-	// Exit the simulator if we are running in simulation.
-#ifdef SIMULATION
 	simulation_exit();
-#endif
-	// Infinite loop if we're not in simulation.
-	while (true)
-	{
-		yield();
-	}
 }


### PR DESCRIPTION
Wrap the cross-call, which can fail, in a noreturn void wrapper that can't.  Tweak callers appropriately.  Have the scheduler internally use the platform layer everywhere.

More stuff pulled out of #379 for separate review.