### PR TITLE
Rename heap_claim_fast.

### DIFF
--- a/examples/04.temporal_safety/allocate.cc
+++ b/examples/04.temporal_safety/allocate.cc
@@ -84,9 +84,9 @@ void __cheri_compartment("allocate") entry()
 		Debug::log("heap quota: {}", heap_quota_remaining(MALLOC_CAPABILITY));
 	}
 
-	// Sub object with a fast claim
+	// Sub object with an ephemeral claim
 	{
-		Debug::log("----- Sub object with a fast claim -----");
+		Debug::log("----- Sub object with an ephemeral claim -----");
 		void *x = malloc(100);
 
 		CHERI::Capability y{x};
@@ -96,12 +96,12 @@ void __cheri_compartment("allocate") entry()
 		Debug::log("Sub Object: {}", y);
 		Debug::log("heap quota: {}", heap_quota_remaining(MALLOC_CAPABILITY));
 
-		// Add a fast claim for y
+		// Add an ephemeral claim for y
 		Timeout t{10};
-		heap_claim_fast(&t, y);
+		heap_claim_ephemeral(&t, y);
 
 		// In this freeing x will invalidate both x & y because free
-		// is a cross compartment call, which releases any fast claims.
+		// is a cross compartment call, which releases any ephemeral claims.
 		free(x);
 		Debug::log("After free");
 		Debug::log("Allocated : {}", x);
@@ -119,7 +119,7 @@ void __cheri_compartment("allocate") entry()
 		Debug::log("Allocated : {}", x);
 		Debug::log("heap quota: {}", heap_quota_remaining(MALLOC_CAPABILITY));
 
-		// Get the claimant compartment to make a fast claim
+		// Get the claimant compartment to make a ephemeral claim
 		make_claim(x);
 
 		// free x.  We get out quota back but x remains valid as

--- a/sdk/include/platform/arty-a7/platform-ethernet.hh
+++ b/sdk/include/platform/arty-a7/platform-ethernet.hh
@@ -755,7 +755,7 @@ class KunyanEthernet
 		// does not check the pointer which is coming from external
 		// untrusted components.
 		Timeout t{10};
-		if ((heap_claim_fast(&t, buffer) < 0) ||
+		if ((heap_claim_ephemeral(&t, buffer) < 0) ||
 		    (!CHERI::check_pointer<CHERI::PermissionSet{
 		       CHERI::Permission::Load}>(buffer, length)))
 		{

--- a/sdk/include/platform/sunburst/platform-ethernet.hh
+++ b/sdk/include/platform/sunburst/platform-ethernet.hh
@@ -734,7 +734,7 @@ class Ksz8851Ethernet
 		// does not check the pointer which is coming from external
 		// untrusted components.
 		Timeout t{10};
-		if ((heap_claim_fast(&t, buffer) < 0) ||
+		if ((heap_claim_ephemeral(&t, buffer) < 0) ||
 		    (!CHERI::check_pointer<CHERI::PermissionSet{
 		       CHERI::Permission::Load}>(buffer, length)))
 		{

--- a/sdk/lib/compartment_helpers/claim_fast.cc
+++ b/sdk/lib/compartment_helpers/claim_fast.cc
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <switcher.h>
 
-int heap_claim_fast(Timeout *timeout, const void *ptr, const void *ptr2)
+int heap_claim_ephemeral(Timeout *timeout, const void *ptr, const void *ptr2)
 {
 	void   **hazards = switcher_thread_hazard_slots();
 	auto    *epochCounter{const_cast<

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -465,7 +465,7 @@ namespace
 		static cheriot::atomic<int> state = 0;
 		async([=]() {
 			Timeout t{1};
-			int     claimed = heap_claim_fast(&t, ptr, ptr2);
+			int     claimed = heap_claim_ephemeral(&t, ptr, ptr2);
 			TEST(claimed == 0, "Heap claim failed: {}", claimed);
 			state = 1;
 			while (state.load() == 1) {}


### PR DESCRIPTION
CI will be happy here until we've updated the dev container, run clang-format, and rebased this PR.