### PR TITLE
treewide: clang format and tidy for the new compiler

### DIFF
--- a/examples/02.hello_compartment/hello.cc
+++ b/examples/02.hello_compartment/hello.cc
@@ -4,7 +4,7 @@
 #include "hello.h"
 // This header adds an error handler that writes to the UART on error.
 // Uncomment it and see that the compartmentalisation policy no longer passes.
-//#include <fail-simulator-on-error.h>
+// #include <fail-simulator-on-error.h>
 
 /// Thread entry point.
 void __cheri_compartment("hello") entry()

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -157,19 +157,17 @@ namespace displacement_proxy
 {
 
 	template<auto F, typename D>
-	concept Decoder = requires(D d)
-	{
+	concept Decoder = requires(D d) {
 		{
 			F(d)
-			} -> std::same_as<size_t>;
+		} -> std::same_as<size_t>;
 	};
 
 	template<auto F, typename D>
-	concept Encoder = requires(size_t s)
-	{
+	concept Encoder = requires(size_t s) {
 		{
 			F(s)
-			} -> std::same_as<D>;
+		} -> std::same_as<D>;
 	};
 
 	/**
@@ -177,7 +175,7 @@ namespace displacement_proxy
 	 * a proxy for a pointer.
 	 */
 	template<typename T, typename D, bool Positive, auto Decode, auto Encode>
-	requires Decoder<Decode, D> && Encoder<Encode, D>
+	    requires Decoder<Decode, D> && Encoder<Encode, D>
 	class Proxy
 	{
 		CHERI::Capability<void> ctx;
@@ -286,8 +284,7 @@ namespace displacement_proxy
  *       - Collected in a treebin ring, using either/both the TChunk linkages
  *         or/and the MChunk::ring links present in body().
  */
-struct __packed __aligned(MallocAlignment)
-MChunkHeader
+struct __packed __aligned(MallocAlignment) MChunkHeader
 {
 	/**
 	 * Each chunk has a 16-bit metadata field that is used to store a small
@@ -589,8 +586,7 @@ using ChunkFreeLink = ds::linked_list::cell::PtrAddr;
  * feed an unsafe_remove'd MChunk to such a function or to simply build a new
  * MChunk header in the heap.
  */
-class __packed __aligned(MallocAlignment)
-MChunk
+class __packed __aligned(MallocAlignment) MChunk
 {
 	friend class MChunkAssertions;
 	friend class TChunk;
@@ -710,8 +706,7 @@ static inline size_t align_offset(CHERI::Capability<void> a)
  * Since we have enough room (large/tree chunks are at least 65 bytes), we just
  * put full capabilities here, and the format probably won't change, ever.
  */
-class __packed __aligned(MallocAlignment)
-TChunk
+class __packed __aligned(MallocAlignment) TChunk
 {
 	friend class TChunkAssertions;
 	friend class MState;
@@ -1505,7 +1500,7 @@ class MState
 	 */
 	static bool __always_inline capaligned_range_do(void  *start,
 	                                                size_t size,
-	                                                bool (*fn)(void **))
+	                                                bool   (*fn)(void **))
 	{
 		Debug::Assert((size & (sizeof(void *) - 1)) == 0,
 		              "Cap range is not aligned");

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -187,11 +187,11 @@ namespace
 	 *
 	 */
 	template<typename T = Revocation::Revoker>
-	bool wait_for_background_revoker(
-	  Timeout                   *timeout,
-	  uint32_t                   epoch,
-	  LockGuard<decltype(lock)> &g,
-	  T &r = revoker) requires(Revocation::SupportsInterruptNotification<T>)
+	bool wait_for_background_revoker(Timeout                   *timeout,
+	                                 uint32_t                   epoch,
+	                                 LockGuard<decltype(lock)> &g,
+	                                 T                         &r = revoker)
+	    requires(Revocation::SupportsInterruptNotification<T>)
 	{
 		// Release the lock before sleeping
 		g.unlock();
@@ -212,11 +212,11 @@ namespace
 	 *
 	 */
 	template<typename T = Revocation::Revoker>
-	bool wait_for_background_revoker(
-	  Timeout                   *timeout,
-	  uint32_t                   epoch,
-	  LockGuard<decltype(lock)> &g,
-	  T &r = revoker) requires(!Revocation::SupportsInterruptNotification<T>)
+	bool wait_for_background_revoker(Timeout                   *timeout,
+	                                 uint32_t                   epoch,
+	                                 LockGuard<decltype(lock)> &g,
+	                                 T                         &r = revoker)
+	    requires(!Revocation::SupportsInterruptNotification<T>)
 	{
 		// Yield while until a revocation pass has finished.
 		while (!revoker.has_revocation_finished_for_epoch<true>(epoch))

--- a/sdk/core/allocator/revoker.h
+++ b/sdk/core/allocator/revoker.h
@@ -23,21 +23,22 @@ namespace Revocation
 	 * provided by the board search.
 	 */
 	template<typename T>
-	concept IsHardwareRevokerDevice = requires(T v, uint32_t epoch)
-	{
-		{v.init()};
+	concept IsHardwareRevokerDevice = requires(T v, uint32_t epoch) {
+		{
+			v.init()
+		};
 		{
 			v.system_epoch_get()
-			} -> std::same_as<uint32_t>;
+		} -> std::same_as<uint32_t>;
 		{
 			v.template has_revocation_finished_for_epoch<true>(epoch)
-			} -> std::same_as<uint32_t>;
+		} -> std::same_as<uint32_t>;
 		{
 			v.template has_revocation_finished_for_epoch<false>(epoch)
-			} -> std::same_as<uint32_t>;
+		} -> std::same_as<uint32_t>;
 		{
 			v.system_bg_revoker_kick()
-			} -> std::same_as<void>;
+		} -> std::same_as<void>;
 	};
 
 	/**
@@ -47,14 +48,12 @@ namespace Revocation
 	 * timeout expired.
 	 */
 	template<typename T>
-	concept SupportsInterruptNotification = requires(T        v,
-	                                                 Timeout *timeout,
-	                                                 uint32_t epoch)
-	{
-		{
-			v.wait_for_completion(timeout, epoch)
-			} -> std::same_as<bool>;
-	};
+	concept SupportsInterruptNotification =
+	  requires(T v, Timeout *timeout, uint32_t epoch) {
+		  {
+			  v.wait_for_completion(timeout, epoch)
+		  } -> std::same_as<bool>;
+	  };
 
 	/**
 	 * Class for interacting with the shadow bitmap.  This bitmap controls the
@@ -275,7 +274,7 @@ namespace Revocation
 	         size_t TCMBaseAddr,
 	         template<typename, size_t>
 	         typename Revoker>
-	requires IsHardwareRevokerDevice<Revoker<WordT, TCMBaseAddr>>
+	    requires IsHardwareRevokerDevice<Revoker<WordT, TCMBaseAddr>>
 	class HardwareAccelerator : public Bitmap<WordT, TCMBaseAddr>,
 	                            public Revoker<WordT, TCMBaseAddr>
 	{

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -147,20 +147,21 @@ namespace
 	// The switcher assembly includes the types of import table entries and
 	// trusted stacks.  This enumeration and the assembly must be kept in sync.
 	// This will fail if the enumeration value changes.
-	static_assert(int(SealedImportTableEntries) == 9,
+	static_assert(static_cast<int>(SealedImportTableEntries) == 9,
 	              "If this fails, update switcher/entry.S to the new value");
-	static_assert(int(SealedTrustedStacks) == 10,
+	static_assert(static_cast<int>(SealedTrustedStacks) == 10,
 	              "If this fails, update switcher/entry.S to the new value");
 
 	// The allocator and static sealing types must be contiguous so that the
 	// token library can hold a permit-unseal capability for both.
-	static_assert(int(Allocator) + 1 == int(StaticToken),
+	static_assert(static_cast<int>(Allocator) + 1 ==
+	                static_cast<int>(StaticToken),
 	              "Allocator and StaticToken must be consecutive");
 
 	// The token library includes the types for allocator and statically sealed
 	// objects.  This enumeration and the assembly must be kept in sync.  This
 	// will fail if the enumeration value changes.
-	static_assert(int(Allocator) == 11,
+	static_assert(static_cast<int>(Allocator) == 11,
 	              "If this fails, update token_unseal.S to the new value");
 
 	// We currently have a 3-bit hardware otype, with different sealing spaces
@@ -347,13 +348,14 @@ namespace
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc99-designator"
 		constexpr SealingType Sentries[] = {
-		  [int(InterruptStatus::Enabled)]   = SentryEnabling,
-		  [int(InterruptStatus::Disabled)]  = SentryDisabling,
-		  [int(InterruptStatus::Inherited)] = SentryInheriting};
+		  [static_cast<int>(InterruptStatus::Enabled)]   = SentryEnabling,
+		  [static_cast<int>(InterruptStatus::Disabled)]  = SentryDisabling,
+		  [static_cast<int>(InterruptStatus::Inherited)] = SentryInheriting};
 #pragma clang diagnostic pop
-		Debug::Invariant(
-		  unsigned(status) < 3, "Invalid interrupt status {}", int(status));
-		size_t otype = size_t{Sentries[int(status)]};
+		Debug::Invariant(static_cast<unsigned>(status) < 3,
+		                 "Invalid interrupt status {}",
+		                 static_cast<int>(status));
+		size_t otype = size_t{Sentries[static_cast<int>(status)]};
 		void  *key   = build<void, Root::Type::Seal>(otype, 1);
 		return ptr.seal(key);
 	}
@@ -367,10 +369,11 @@ namespace
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc99-designator"
 		constexpr SealingType Sentries[] = {
-		  [int(InterruptStatus::Enabled)]  = ReturnSentryEnabling,
-		  [int(InterruptStatus::Disabled)] = ReturnSentryDisabling};
+		  [static_cast<int>(InterruptStatus::Enabled)] = ReturnSentryEnabling,
+		  [static_cast<int>(InterruptStatus::Disabled)] =
+		    ReturnSentryDisabling};
 #pragma clang diagnostic pop
-		size_t otype = size_t{Sentries[int(Status)]};
+		size_t otype = size_t{Sentries[static_cast<int>(Status)]};
 		void  *key   = build<void, Root::Type::Seal>(otype, 1);
 		return ptr.seal(key);
 	}

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -248,7 +248,8 @@ namespace
 	         Root::Type    Type        = Root::Type::RWGlobal,
 	         PermissionSet Permissions = Root::Permissions<Type>,
 	         bool          Precise     = true>
-	Capability<T> build(auto &&range) requires(RawAddressRange<decltype(range)>)
+	Capability<T> build(auto &&range)
+	    requires(RawAddressRange<decltype(range)>)
 	{
 		return build<T, Type, Permissions, Precise>(range.start(),
 		                                            range.size());
@@ -261,9 +262,8 @@ namespace
 	template<typename T                = void,
 	         Root::Type    Type        = Root::Type::RWGlobal,
 	         PermissionSet Permissions = Root::Permissions<Type>>
-	Capability<T>
-	build(auto    &&range,
-	      ptraddr_t address) requires(RawAddressRange<decltype(range)>)
+	Capability<T> build(auto &&range, ptraddr_t address)
+	    requires(RawAddressRange<decltype(range)>)
 	{
 		return build<T, Type, Permissions>(
 		  range.start(), range.size(), address);
@@ -379,9 +379,8 @@ namespace
 	 * Helper to determine whether an object, given by a start address and size,
 	 * is completely contained within a specified range.
 	 */
-	bool contains(const auto &range,
-	              ptraddr_t   addr,
-	              size_t      size) requires(RawAddressRange<decltype(range)>)
+	bool contains(const auto &range, ptraddr_t addr, size_t size)
+	    requires(RawAddressRange<decltype(range)>)
 	{
 		return (range.start() <= addr) &&
 		       (range.start() + range.size() >= addr + size);
@@ -393,8 +392,8 @@ namespace
 	 * object must be completely contained within the range.
 	 */
 	template<typename T = char>
-	bool contains(const auto &range,
-	              ptraddr_t   addr) requires(RawAddressRange<decltype(range)>)
+	bool contains(const auto &range, ptraddr_t addr)
+	    requires(RawAddressRange<decltype(range)>)
 	{
 		return contains(range, addr, sizeof(T));
 	}
@@ -444,8 +443,8 @@ namespace
 	 * of type `T` from a virtual address range.
 	 */
 	template<typename T, bool Precise = true>
-	ContiguousPtrRange<T>
-	build_range(const auto &range) requires(RawAddressRange<decltype(range)>)
+	ContiguousPtrRange<T> build_range(const auto &range)
+	    requires(RawAddressRange<decltype(range)>)
 	{
 		Capability<T> start = build<T,
 		                            Root::Type::RWGlobal,
@@ -668,8 +667,8 @@ namespace
                             auto exportEntry = build<ExportEntry>(
                               compartment.exportTable, typeAddress);
                             Debug::Invariant(
-							   exportEntry->is_sealing_type(),
-							   "Sealed object points to invalid sealing type");
+                              exportEntry->is_sealing_type(),
+                              "Sealed object points to invalid sealing type");
                             *sealingType = exportEntry->functionStart;
                             return true;
                         }
@@ -863,8 +862,7 @@ namespace
 		for (size_t i = 0; const auto &config : image.threads())
 		{
 			Debug::log("Creating thread {}", i);
-			auto findCompartment = [&]() -> auto &
-			{
+			auto findCompartment = [&]() -> auto & {
 				for (auto &compartment : image.compartments())
 				{
 					Debug::log("Looking in export table {}+{}",
@@ -1000,8 +998,7 @@ namespace
 
 		// Find the library compartment that contains an address in its code or
 		// data section.
-		auto findCompartment = [&](ptraddr_t address) -> auto &
-		{
+		auto findCompartment = [&](ptraddr_t address) -> auto & {
 			Debug::log("Capreloc address is {}", address);
 			for (auto &compartment : image.libraries_and_compartments())
 			{

--- a/sdk/core/loader/debug.hh
+++ b/sdk/core/loader/debug.hh
@@ -27,11 +27,10 @@ namespace
 
 		/// Concept for something that can be lazily called to produce a bool.
 		template<typename T>
-		concept LazyAssertion = requires(T v)
-		{
+		concept LazyAssertion = requires(T v) {
 			{
 				v()
-				} -> IsBool;
+			} -> IsBool;
 		};
 	} // namespace DebugConcepts
 
@@ -248,7 +247,7 @@ namespace
 		 * Append an enumerated type value.
 		 */
 		template<typename T>
-		requires DebugConcepts::IsEnum<T>
+		    requires DebugConcepts::IsEnum<T>
 		void append(T e)
 		{
 			// `magic_enum::enum_name` requires cap relocs, so don't use it in
@@ -482,7 +481,8 @@ namespace
 			 * Constructor, performs the assertion check.
 			 */
 			template<typename T>
-			requires DebugConcepts::IsBool<T> __always_inline
+			    requires DebugConcepts::IsBool<T>
+			__always_inline
 			Assert(T           condition,
 			       const char *fmt,
 			       Args... args,
@@ -513,7 +513,8 @@ namespace
 			 * where the assertion condition has side effects.
 			 */
 			template<typename T>
-			requires DebugConcepts::LazyAssertion<T> __always_inline
+			    requires DebugConcepts::LazyAssertion<T>
+			__always_inline
 			Assert(T         &&condition,
 			       const char *fmt,
 			       Args... args,

--- a/sdk/core/loader/debug.hh
+++ b/sdk/core/loader/debug.hh
@@ -150,7 +150,7 @@ namespace
 			}
 			std::array<char, 10> buf;
 			const char           Digits[] = "0123456789";
-			for (int i = int(buf.size() - 1); i >= 0; i--)
+			for (int i = static_cast<int>(buf.size() - 1); i >= 0; i--)
 			{
 				buf.at(static_cast<size_t>(i)) = Digits[s % 10];
 				s /= 10;
@@ -180,7 +180,7 @@ namespace
 			const char          Hexdigits[] = "0123456789abcdef";
 			// Length of string including null terminator
 			static_assert(sizeof(Hexdigits) == 0x11);
-			for (long i = long(buf.size() - 1); i >= 0; i--)
+			for (long i = static_cast<long>(buf.size() - 1); i >= 0; i--)
 			{
 				buf.at(static_cast<size_t>(i)) = Hexdigits[s & 0xf];
 				s >>= 4;

--- a/sdk/core/loader/types.h
+++ b/sdk/core/loader/types.h
@@ -1067,11 +1067,11 @@ namespace loader
 		/**
 		 * The mask to isolate the bits that describe interrupt status.
 		 */
-		static constexpr uint8_t InterruptStatusMask = uint8_t(0b11)
-		                                               << InterruptStatusShift;
+		static constexpr uint8_t InterruptStatusMask =
+		  static_cast<uint8_t>(0b11) << InterruptStatusShift;
 
 		static constexpr uint8_t InterruptStatusSwitcherMask =
-		  uint8_t(0b10) << InterruptStatusShift;
+		  static_cast<uint8_t>(0b10) << InterruptStatusShift;
 
 		/*
 		 * The switcher tests the high bit of the InterruptStatus word of
@@ -1080,11 +1080,13 @@ namespace loader
 		 * that its understanding is correct.
 		 */
 		static_assert(
-		  ((int(InterruptStatus::Enabled) << InterruptStatusShift) &
+		  ((static_cast<int>(InterruptStatus::Enabled)
+		    << InterruptStatusShift) &
 		   InterruptStatusSwitcherMask) == 0,
 		  "Switcher interpretation of InterruptStatus no longer correct");
 		static_assert(
-		  ((int(InterruptStatus::Disabled) << InterruptStatusShift) &
+		  ((static_cast<int>(InterruptStatus::Disabled)
+		    << InterruptStatusShift) &
 		   InterruptStatusSwitcherMask) != 0,
 		  "Switcher interpretation of InterruptStatus no longer correct");
 
@@ -1096,7 +1098,8 @@ namespace loader
 		 * their first word initialised to point to this, the loader will
 		 * set them up to instead hold the value of the sealing key.
 		 */
-		static constexpr uint8_t SealingTypeEntry = uint8_t(0b100000);
+		static constexpr uint8_t SealingTypeEntry =
+		  static_cast<uint8_t>(0b100000);
 
 		static_assert((InterruptStatusMask & SealingTypeEntry) == 0);
 
@@ -1129,7 +1132,7 @@ namespace loader
 		{
 			uint8_t status =
 			  (flags & InterruptStatusMask) >> InterruptStatusShift;
-			return InterruptStatus(status);
+			return static_cast<InterruptStatus>(status);
 		}
 
 		/**

--- a/sdk/core/loader/types.h
+++ b/sdk/core/loader/types.h
@@ -273,21 +273,21 @@ namespace loader
 	 * Helper concept for determining if something is an address.
 	 */
 	template<typename T>
-	concept IsAddress = std::same_as<T, ptraddr_t> ||
-	  std::same_as<T, ptraddr_t &> || std::same_as<T, const ptraddr_t &>;
+	concept IsAddress =
+	  std::same_as<T, ptraddr_t> || std::same_as<T, ptraddr_t &> ||
+	  std::same_as<T, const ptraddr_t &>;
 
 	/**
 	 * Concept for a raw address range.  This exposes a range of addresses.
 	 */
 	template<typename T>
-	concept RawAddressRange = requires(T range)
-	{
+	concept RawAddressRange = requires(T range) {
 		{
 			range.size()
-			} -> IsAddress;
+		} -> IsAddress;
 		{
 			range.start()
-			} -> IsAddress;
+		} -> IsAddress;
 	};
 
 	/**

--- a/sdk/core/scheduler/multiwait.h
+++ b/sdk/core/scheduler/multiwait.h
@@ -196,11 +196,11 @@ namespace
 			}
 			void *memory = nullptr;
 			SObj  sealed = token_sealed_unsealed_alloc(
-			   timeout,
-			   heapCapability,
-			   sealing_type(),
-			   sizeof(MultiWaiterInternal) + (length * sizeof(EventWaiter)),
-			   &memory);
+              timeout,
+              heapCapability,
+              sealing_type(),
+              sizeof(MultiWaiterInternal) + (length * sizeof(EventWaiter)),
+              &memory);
 			if (!memory)
 			{
 				error = -ENOMEM;

--- a/sdk/core/scheduler/plic.h
+++ b/sdk/core/scheduler/plic.h
@@ -24,16 +24,25 @@ namespace
 	using SourceID = uint32_t;
 
 	template<typename T, size_t MaxIntrID, typename SourceID, typename Priority>
-	concept IsPlic = requires(T v, SourceID id, Priority p)
-	{
-		{v.interrupt_enable(id)};
-		{v.interrupt_disable(id)};
-		{v.interrupt_disable(id)};
-		{v.priority_set(id, p)};
+	concept IsPlic = requires(T v, SourceID id, Priority p) {
+		{
+			v.interrupt_enable(id)
+		};
+		{
+			v.interrupt_disable(id)
+		};
+		{
+			v.interrupt_disable(id)
+		};
+		{
+			v.priority_set(id, p)
+		};
 		{
 			v.interrupt_claim()
-			} -> std::same_as<std::optional<SourceID>>;
-		{v.interrupt_complete(id)};
+		} -> std::same_as<std::optional<SourceID>>;
+		{
+			v.interrupt_complete(id)
+		};
 	};
 
 	/*

--- a/sdk/core/scheduler/plic.h
+++ b/sdk/core/scheduler/plic.h
@@ -151,7 +151,8 @@ namespace
 		{
 			for (size_t i = 0; i < NumberOfInterrupts; i++)
 			{
-				if (ConfiguredInterrupts[i].number == uint32_t(source))
+				if (ConfiguredInterrupts[i].number ==
+				    static_cast<uint32_t>(source))
 				{
 					if constexpr (CompleteInterruptIfEdgeTriggered)
 					{

--- a/sdk/core/scheduler/thread.h
+++ b/sdk/core/scheduler/thread.h
@@ -184,9 +184,9 @@ namespace
 		  : threadId(threadid),
 		    priority(priority),
 		    OriginalPriority(priority),
-		    expiryTime(-1),
+
 		    state(ThreadState::Suspended),
-		    isYielding(false),
+
 		    sleepQueue(nullptr),
 		    tStackPtr(tstack)
 		{
@@ -566,7 +566,7 @@ namespace
 		ThreadImpl **sleepQueue;
 		/// If suspended, when will this thread expire. The maximum value is
 		/// special-cased to mean blocked indefinitely.
-		uint64_t expiryTime;
+		uint64_t expiryTime{static_cast<uint64_t>(-1)};
 
 		/// The number of cycles that this thread has been scheduled for.
 		uint64_t cycles;
@@ -654,7 +654,7 @@ namespace
 		 * expires, as long as no other threads are runnable or sleeping with
 		 * shorter timeouts.
 		 */
-		bool isYielding : 1;
+		bool isYielding : 1 {false};
 	};
 
 	using Thread = ThreadImpl<ThreadPrioNum>;

--- a/sdk/core/scheduler/timer.h
+++ b/sdk/core/scheduler/timer.h
@@ -159,7 +159,8 @@ namespace
 					{
 						Debug::log("Woke thread {} {} cycles early",
 						           head->id_get(),
-						           int64_t(head->expiryTime) - now);
+						           static_cast<int64_t>(head->expiryTime) -
+						             now);
 						head->ready(Thread::WakeReason::Timer);
 					}
 				}

--- a/sdk/core/scheduler/timer.h
+++ b/sdk/core/scheduler/timer.h
@@ -16,10 +16,13 @@ namespace
 	 * Concept for the interface to setting the system timer.
 	 */
 	template<typename T>
-	concept IsTimer = requires(uint32_t cycles)
-	{
-		{T::init()};
-		{T::setnext(cycles)};
+	concept IsTimer = requires(uint32_t cycles) {
+		{
+			T::init()
+		};
+		{
+			T::setnext(cycles)
+		};
 	};
 
 	static_assert(

--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -993,7 +993,8 @@ namespace CHERI
 		 * Implicit cast to the raw pointer type.
 		 */
 		template<typename U = T>
-		requires(!std::same_as<U, void>) operator U *()
+		    requires(!std::same_as<U, void>)
+		operator U *()
 		{
 			return ptr;
 		}
@@ -1026,7 +1027,8 @@ namespace CHERI
 		 * Dereference operator.
 		 */
 		template<typename U = T>
-		requires(!std::same_as<U, void>) U &operator*()
+		    requires(!std::same_as<U, void>)
+		U &operator*()
 		{
 			return *ptr;
 		}
@@ -1073,7 +1075,8 @@ namespace CHERI
 		 * Subscript operator.
 		 */
 		template<typename U = T>
-		requires(!std::same_as<U, void>) U &operator[](size_t index)
+		    requires(!std::same_as<U, void>)
+		U &operator[](size_t index)
 		{
 			return ptr[index];
 		}
@@ -1119,16 +1122,11 @@ namespace CHERI
 	 * library smart pointers, etc.
 	 */
 	template<typename T>
-	concept IsSmartPointerLike = requires(T b)
-	{
+	concept IsSmartPointerLike = requires(T b) {
 		{
 			b.get()
-			} -> IsPointer;
-	}
-	&&requires(T b)
-	{
-		b = b.get();
-	};
+		} -> IsPointer;
+	} && requires(T b) { b = b.get(); };
 
 	/**
 	 * Checks that `ptr` is valid, unsealed, has at least `Permissions`,
@@ -1156,15 +1154,11 @@ namespace CHERI
 	template<PermissionSet Permissions = PermissionSet{Permission::Load},
 	         bool          CheckStack  = true,
 	         bool          EnforceStrictPermissions = false>
-	__always_inline inline bool check_pointer(
-	  auto  &ptr,
-	  size_t space = sizeof(
-	    std::remove_pointer<
-	      decltype(ptr)>)) requires(std::
-	                                  is_pointer_v<
-	                                    std::remove_cvref_t<decltype(ptr)>> ||
-	                                IsSmartPointerLike<
-	                                  std::remove_cvref_t<decltype(ptr)>>)
+	__always_inline inline bool
+	check_pointer(auto  &ptr,
+	              size_t space = sizeof(std::remove_pointer<decltype(ptr)>))
+	    requires(std::is_pointer_v<std::remove_cvref_t<decltype(ptr)>> ||
+	             IsSmartPointerLike<std::remove_cvref_t<decltype(ptr)>>)
 	{
 		// We can skip a stack check if we've asked for Global because the
 		// stack does not have this permission.

--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -157,7 +157,7 @@ namespace CHERI
 			 */
 			constexpr Permission operator*()
 			{
-				return Permission(__builtin_ffs(permissions) - 1);
+				return static_cast<Permission>(__builtin_ffs(permissions) - 1);
 			}
 
 			/**

--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -233,7 +233,7 @@
 	__attribute__((section(".sealed_objects"), used))                          \
 	__if_cxx(inline) struct __##name##_type                                    \
 	  name = /* NOLINT(bugprone-macro-parentheses) */                          \
-	  {(uint32_t)&__sealing_key_##compartment##_##keyName,                     \
+	  {(uint32_t) & __sealing_key_##compartment##_##keyName,                   \
 	   0,                                                                      \
 	   {initialiser, ##__VA_ARGS__}}
 

--- a/sdk/include/debug.h
+++ b/sdk/include/debug.h
@@ -10,19 +10,20 @@
  *
  * Should not be used directly.
  */
-#	define CHERIOT_DEBUG_MAP_ARGUMENT(x)                                                \
-		{                                                                                \
-			(uintptr_t)(x), _Generic((x),                                              \
-                    _Bool: DebugFormatArgumentBool,                                               \
-                    char: DebugFormatArgumentCharacter,                                           \
-                    short: DebugFormatArgumentSignedNumber32,                                \
-                    unsigned short: DebugFormatArgumentUnsignedNumber32,                            \
-                    int: DebugFormatArgumentSignedNumber32,                                \
-                    unsigned int: DebugFormatArgumentUnsignedNumber32,                            \
-                    signed long long: DebugFormatArgumentSignedNumber64,                          \
-                    unsigned long long: DebugFormatArgumentUnsignedNumber64,                      \
-                    char *: DebugFormatArgumentCString, \
-					default: DebugFormatArgumentPointer) \
+#	define CHERIOT_DEBUG_MAP_ARGUMENT(x)                                      \
+		{                                                                      \
+			(uintptr_t)(x),                                                    \
+			  _Generic((x),                                                    \
+			  _Bool: DebugFormatArgumentBool,                                  \
+			  char: DebugFormatArgumentCharacter,                              \
+			  short: DebugFormatArgumentSignedNumber32,                        \
+			  unsigned short: DebugFormatArgumentUnsignedNumber32,             \
+			  int: DebugFormatArgumentSignedNumber32,                          \
+			  unsigned int: DebugFormatArgumentUnsignedNumber32,               \
+			  signed long long: DebugFormatArgumentSignedNumber64,             \
+			  unsigned long long: DebugFormatArgumentUnsignedNumber64,         \
+			  char *: DebugFormatArgumentCString,                              \
+			  default: DebugFormatArgumentPointer)                             \
 		}
 
 /**

--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -27,11 +27,10 @@ namespace DebugConcepts
 
 	/// Concept for something that can be lazily called to produce a bool.
 	template<typename T>
-	concept LazyAssertion = requires(T v)
-	{
+	concept LazyAssertion = requires(T v) {
 		{
 			v()
-			} -> IsBool;
+		} -> IsBool;
 	};
 
 	template<typename T>
@@ -87,8 +86,8 @@ struct DebugWriter
  * magic_enum to provide a string and then a numeric value.
  */
 template<typename T>
-void debug_enum_helper(uintptr_t    value,
-                       DebugWriter &writer) requires DebugConcepts::IsEnum<T>
+void debug_enum_helper(uintptr_t value, DebugWriter &writer)
+    requires DebugConcepts::IsEnum<T>
 {
 	writer.write(magic_enum::enum_name<T>(static_cast<T>(value)));
 	writer.write('(');
@@ -654,7 +653,8 @@ namespace
 			 * Constructor, performs the assertion check.
 			 */
 			template<typename T>
-			requires DebugConcepts::IsBool<T> __always_inline
+			    requires DebugConcepts::IsBool<T>
+			__always_inline
 			Assert(T           condition,
 			       const char *fmt,
 			       Args... args,
@@ -685,7 +685,8 @@ namespace
 			 * where the assertion condition has side effects.
 			 */
 			template<typename T>
-			requires DebugConcepts::LazyAssertion<T> __always_inline
+			    requires DebugConcepts::LazyAssertion<T>
+			__always_inline
 			Assert(T         &&condition,
 			       const char *fmt,
 			       Args... args,

--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -412,7 +412,7 @@ __always_inline inline void map_debug_argument(DebugFormatArgument *arguments,
  */
 template<typename... Args>
 __always_inline inline void
-make_debug_arguments_list(DebugFormatArgument *arguments, Args... args)
+make_debug_arguments_list(DebugFormatArgument *arguments, Args &...args)
 {
 	if constexpr (sizeof...(Args) > 0)
 	{

--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -91,7 +91,7 @@ void debug_enum_helper(uintptr_t value, DebugWriter &writer)
 {
 	writer.write(magic_enum::enum_name<T>(static_cast<T>(value)));
 	writer.write('(');
-	writer.write(uint32_t(value));
+	writer.write(static_cast<uint32_t>(value));
 	writer.write(')');
 }
 

--- a/sdk/include/ds/pointer.h
+++ b/sdk/include/ds/pointer.h
@@ -47,40 +47,39 @@ namespace ds::pointer
 		 */
 		template<typename P, typename T>
 		concept Proxies = std::same_as<T, typename P::Type> &&
-		  requires(P &proxy, P &proxy2, T *ptr)
-		{
-			/* Probe for operator=(T*) */
-			{
-				proxy = ptr
-				} -> std::same_as<P &>;
+		                  requires(P &proxy, P &proxy2, T *ptr) {
+			                  /* Probe for operator=(T*) */
+			                  {
+				                  proxy = ptr
+			                  } -> std::same_as<P &>;
 
-			/* Probe for operator T*() */
-			{
-				ptr == proxy
-				} -> std::same_as<bool>;
+			                  /* Probe for operator T*() */
+			                  {
+				                  ptr == proxy
+			                  } -> std::same_as<bool>;
 
-			/* TODO: How to probe for operator-> ? */
+			                  /* TODO: How to probe for operator-> ? */
 
-			/* Probe for operator==(T*) */
-			{
-				proxy == ptr
-				} -> std::same_as<bool>;
+			                  /* Probe for operator==(T*) */
+			                  {
+				                  proxy == ptr
+			                  } -> std::same_as<bool>;
 
-			/* Probe for operator==(P&) */
-			{
-				proxy == proxy2
-				} -> std::same_as<bool>;
+			                  /* Probe for operator==(P&) */
+			                  {
+				                  proxy == proxy2
+			                  } -> std::same_as<bool>;
 
-			/* Probe for operator<=>(T*) */
-			{
-				proxy <=> ptr
-				} -> std::same_as<std::strong_ordering>;
+			                  /* Probe for operator<=>(T*) */
+			                  {
+				                  proxy <=> ptr
+			                  } -> std::same_as<std::strong_ordering>;
 
-			/* Probe for operator<=>(P) */
-			{
-				proxy <=> proxy2
-				} -> std::same_as<std::strong_ordering>;
-		};
+			                  /* Probe for operator<=>(P) */
+			                  {
+				                  proxy <=> proxy2
+			                  } -> std::same_as<std::strong_ordering>;
+		                  };
 
 		/**
 		 * Pointer references are pointer proxies, shockingly enough.

--- a/sdk/include/ds/xoroshiro.h
+++ b/sdk/include/ds/xoroshiro.h
@@ -66,7 +66,7 @@ namespace ds::xoroshiro
 				{
 					for (int b = 0; b < 64; b++)
 					{
-						if (Jump[i] & uint64_t(1) << b)
+						if (Jump[i] & static_cast<uint64_t>(1) << b)
 						{
 							s0 ^= x;
 							s1 ^= y;

--- a/sdk/include/ds/xoroshiro.h
+++ b/sdk/include/ds/xoroshiro.h
@@ -124,7 +124,8 @@ namespace ds::xoroshiro
 			/**
 			 * Jump.  If supported, this is equivalent to 2^64 calls to next().
 			 */
-			void jump() requires(Jump0 != 0) && (Jump1 != 0)
+			void jump()
+			    requires(Jump0 != 0) && (Jump1 != 0)
 			{
 				jump(Jump0, Jump1);
 			}
@@ -133,7 +134,8 @@ namespace ds::xoroshiro
 			 * Jump a *really* long way.  If supported, this is equivalent to
 			 * 2^96 calls to next().
 			 */
-			void long_jump() requires(LongJump0 != 0) && (LongJump1 != 0)
+			void long_jump()
+			    requires(LongJump0 != 0) && (LongJump1 != 0)
 			{
 				jump(LongJump0, LongJump1);
 			}

--- a/sdk/include/function_wrapper.hh
+++ b/sdk/include/function_wrapper.hh
@@ -83,8 +83,8 @@ class FunctionWrapper<R(Args...)>
 	 * This is a non-owning reference, delete its copy and move
 	 * constructors to avoid accidental copies.
 	 */
-	FunctionWrapper(FunctionWrapper &)  = delete;
-	FunctionWrapper(FunctionWrapper &&) = delete;
+	FunctionWrapper(FunctionWrapper &)             = delete;
+	FunctionWrapper(FunctionWrapper &&)            = delete;
 	FunctionWrapper &operator=(FunctionWrapper &&) = delete;
 
 	/**

--- a/sdk/include/futex.h
+++ b/sdk/include/futex.h
@@ -6,15 +6,17 @@
 #include <stdint.h>
 #include <timeout.h>
 
-enum [[clang::flag_enum]] FutexWaitFlags{
-  /// No flags
-  FutexNone = 0,
-  /**
-   * This futex uses priority inheritance.  The low 16 bits of the futex word
-   * are assumed to hold the thread ID of the thread that currently holds the
-   * lock.
-   */
-  FutexPriorityInheritance = (1 << 0)};
+enum [[clang::flag_enum]] FutexWaitFlags
+{
+	/// No flags
+	FutexNone = 0,
+	/**
+	 * This futex uses priority inheritance.  The low 16 bits of the futex word
+	 * are assumed to hold the thread ID of the thread that currently holds the
+	 * lock.
+	 */
+	FutexPriorityInheritance = (1 << 0)
+};
 
 /**
  * Compare the value at `address` to `expected` and, if they match, sleep the

--- a/sdk/include/locks.hh
+++ b/sdk/include/locks.hh
@@ -102,7 +102,8 @@ class FlagLockGeneric
 	 * documentation of `flaglock_priority_inheriting_get_owner_thread_id`
 	 * for more information.
 	 */
-	__always_inline uint16_t get_owner_thread_id() requires(IsPriorityInherited)
+	__always_inline uint16_t get_owner_thread_id()
+	    requires(IsPriorityInherited)
 	{
 		return flaglock_priority_inheriting_get_owner_thread_id(&state);
 	}
@@ -235,18 +236,20 @@ using FlagLock                  = FlagLockGeneric<false>;
 using FlagLockPriorityInherited = FlagLockGeneric<true>;
 
 template<typename T>
-concept Lockable = requires(T l)
-{
-	{l.lock()};
-	{l.unlock()};
+concept Lockable = requires(T l) {
+	{
+		l.lock()
+	};
+	{
+		l.unlock()
+	};
 };
 
 template<typename T>
-concept TryLockable = Lockable<T> && requires(T l, Timeout *t)
-{
+concept TryLockable = Lockable<T> && requires(T l, Timeout *t) {
 	{
 		l.try_lock(t)
-		} -> std::same_as<bool>;
+	} -> std::same_as<bool>;
 };
 
 static_assert(TryLockable<NoLock>);
@@ -275,8 +278,8 @@ class LockGuard
 	}
 
 	/// Constructor, attempts to acquire the lock with a timeout.
-	[[nodiscard]] explicit LockGuard(Lock &lock, Timeout *timeout) requires(
-	  TryLockable<Lock>)
+	[[nodiscard]] explicit LockGuard(Lock &lock, Timeout *timeout)
+	    requires(TryLockable<Lock>)
 	  : wrappedLock(&lock), isOwned(false)
 	{
 		try_lock(timeout);
@@ -326,7 +329,8 @@ class LockGuard
 	 * it with the specified timeout. This must be called with the lock
 	 * unlocked.  Returns true if the lock has been acquired, false otherwise.
 	 */
-	bool try_lock(Timeout *timeout) requires(TryLockable<Lock>)
+	bool try_lock(Timeout *timeout)
+	    requires(TryLockable<Lock>)
 	{
 		LockDebug::Assert(!isOwned, "Trying to lock an already-locked lock");
 		isOwned = wrappedLock->try_lock(timeout);

--- a/sdk/include/multiwaiter.h
+++ b/sdk/include/multiwaiter.h
@@ -44,11 +44,13 @@ enum EventWaiterKind
 	EventWaiterFutex
 };
 
-enum [[clang::flag_enum]] EventWaiterEventChannelFlags{
-  /// Automatically clear the bits we waited on.
-  EventWaiterEventChannelClearOnExit = (1 << 24),
-  /// Notify when all bits were set.
-  EventWaiterEventChannelWaitAll = (1 << 26)};
+enum [[clang::flag_enum]] EventWaiterEventChannelFlags
+{
+	/// Automatically clear the bits we waited on.
+	EventWaiterEventChannelClearOnExit = (1 << 24),
+	/// Notify when all bits were set.
+	EventWaiterEventChannelWaitAll = (1 << 26)
+};
 
 /**
  * Structure describing a change to the set of managed event sources for an

--- a/sdk/include/platform/arty-a7/platform-ethernet.hh
+++ b/sdk/include/platform/arty-a7/platform-ethernet.hh
@@ -420,10 +420,10 @@ class KunyanEthernet
 	mdio_write(uint8_t phyAddress, PHYRegister registerAddress, uint16_t data)
 	{
 		mdio_wait_for_ready();
-		auto    &mdioAddress = mmio_register<RegisterOffset::MDIOAddress>();
-		auto    &mdioWrite   = mmio_register<RegisterOffset::MDIODataWrite>();
-		uint32_t writeCommand =
-		  (0 << 10) | (phyAddress << 5) | uint32_t(registerAddress);
+		auto    &mdioAddress  = mmio_register<RegisterOffset::MDIOAddress>();
+		auto    &mdioWrite    = mmio_register<RegisterOffset::MDIODataWrite>();
+		uint32_t writeCommand = (0 << 10) | (phyAddress << 5) |
+		                        static_cast<uint32_t>(registerAddress);
 		mdioAddress = writeCommand;
 		mdioWrite   = data;
 		mdio_start_transaction();
@@ -437,7 +437,7 @@ class KunyanEthernet
 		mdio_wait_for_ready();
 		auto    &mdioAddress = mmio_register<RegisterOffset::MDIOAddress>();
 		uint32_t readCommand =
-		  (1 << 10) | (phyAddress << 5) | uint8_t(registerAddress);
+		  (1 << 10) | (phyAddress << 5) | static_cast<uint8_t>(registerAddress);
 		mdioAddress = readCommand;
 		mdio_start_transaction();
 		mdio_wait_for_ready();

--- a/sdk/include/platform/concepts/entropy.h
+++ b/sdk/include/platform/concepts/entropy.h
@@ -7,15 +7,14 @@
  * Concept for an Ethernet adaptor.
  */
 template<typename T>
-concept IsEntropySource = requires(T source)
-{
+concept IsEntropySource = requires(T source) {
 	/**
 	 * Must export a flag indicating whether this is a cryptographically
 	 * secure random number.
 	 */
 	{
 		T::IsSecure
-		} -> std::convertible_to<const bool>;
+	} -> std::convertible_to<const bool>;
 
 	/**
 	 * Must return a random number.  All bits of the value type are assumed to
@@ -24,7 +23,7 @@ concept IsEntropySource = requires(T source)
 	 */
 	{
 		source()
-		} -> std::same_as<typename T::ValueType>;
+	} -> std::same_as<typename T::ValueType>;
 
 	/**
 	 * Must provide a method that reseeds the entropy source.  If this is a
@@ -32,5 +31,7 @@ concept IsEntropySource = requires(T source)
 	 * may be an empty function.  There are no constraints on the return type
 	 * of this.
 	 */
-	{source.reseed()};
+	{
+		source.reseed()
+	};
 };

--- a/sdk/include/platform/concepts/ethernet.hh
+++ b/sdk/include/platform/concepts/ethernet.hh
@@ -11,17 +11,16 @@
  * This is not required to be copyable.
  */
 template<typename T>
-concept ReceivedEthernetFrame = requires(T frame)
-{
+concept ReceivedEthernetFrame = requires(T frame) {
 	{
 		frame->length
-		} -> std::convertible_to<uint16_t>;
+	} -> std::convertible_to<uint16_t>;
 	{
 		frame->buffer
-		} -> std::convertible_to<const uint8_t *>;
+	} -> std::convertible_to<const uint8_t *>;
 	{
 		frame->buffer
-		} -> std::convertible_to<bool>;
+	} -> std::convertible_to<bool>;
 };
 
 /**
@@ -31,14 +30,13 @@ template<typename T>
 concept EthernetAdaptor = requires(T                      adaptor,
                                    const uint8_t         *buffer,
                                    uint16_t               length,
-                                   std::array<uint8_t, 6> macAddress)
-{
+                                   std::array<uint8_t, 6> macAddress) {
 	/**
 	 * The default MAC address for this adaptor.  Must return a 6-byte array.
 	 */
 	{
 		T::mac_address_default()
-		} -> std::same_as<std::array<uint8_t, 6>>;
+	} -> std::same_as<std::array<uint8_t, 6>>;
 	/**
 	 * Is the default MAC address unique?  If the device (e.g. soft MAC)
 	 * doesn't have its own hardware MAC address then callers may prefer to
@@ -46,22 +44,26 @@ concept EthernetAdaptor = requires(T                      adaptor,
 	 */
 	{
 		T::has_unique_mac_address()
-		} -> std::convertible_to<bool>;
+	} -> std::convertible_to<bool>;
 	/**
 	 * Set the MAC address of this adaptor.
 	 */
-	{adaptor.mac_address_set(macAddress)};
+	{
+		adaptor.mac_address_set(macAddress)
+	};
 	/**
 	 * Set the MAC address of this adaptor to the default value.
 	 */
-	{adaptor.mac_address_set()};
+	{
+		adaptor.mac_address_set()
+	};
 
 	/**
 	 * Check if PHY link is up.
 	 */
 	{
 		adaptor.phy_link_status()
-		} -> std::convertible_to<bool>;
+	} -> std::convertible_to<bool>;
 
 	/**
 	 * Receive a frame.  Returns an optional value (convertible to bool) that
@@ -70,7 +72,7 @@ concept EthernetAdaptor = requires(T                      adaptor,
 	 */
 	{
 		adaptor.receive_frame()
-		} -> ReceivedEthernetFrame;
+	} -> ReceivedEthernetFrame;
 
 	/**
 	 * Send a frame identified by a base and length.  Returns true if the frame
@@ -85,7 +87,7 @@ concept EthernetAdaptor = requires(T                      adaptor,
 		  buffer, length, [](const uint8_t *buffer, uint16_t length) {
 			  return true;
 		  })
-		} -> std::same_as<bool>;
+	} -> std::same_as<bool>;
 
 	/**
 	 * Read the current interrupt counter for receive interrupts.  If this
@@ -94,7 +96,7 @@ concept EthernetAdaptor = requires(T                      adaptor,
 	 */
 	{
 		adaptor.receive_interrupt_value()
-		} -> std::same_as<uint32_t>;
+	} -> std::same_as<uint32_t>;
 
 	/**
 	 * Called after `receive_frame` fails to return new frames to block until a
@@ -105,5 +107,5 @@ concept EthernetAdaptor = requires(T                      adaptor,
 	 */
 	{
 		adaptor.receive_interrupt_complete(nullptr, 0)
-		} -> std::same_as<int>;
+	} -> std::same_as<int>;
 };

--- a/sdk/include/platform/generic-riscv/platform-timer.hh
+++ b/sdk/include/platform/generic-riscv/platform-timer.hh
@@ -52,7 +52,7 @@ class StandardClint : private utils::NoCopyNoMove
 			timeHigh = *timerHigh;
 			timeLow  = *pmtimer;
 		} while (timeHigh != *timerHigh);
-		return (uint64_t(timeHigh) << 32) | timeLow;
+		return (static_cast<uint64_t>(timeHigh) << 32) | timeLow;
 	}
 
 	/**

--- a/sdk/include/platform/generic-riscv/platform-uart.hh
+++ b/sdk/include/platform/generic-riscv/platform-uart.hh
@@ -10,19 +10,22 @@
  * Concept for checking that a UART driver exposes the right interface.
  */
 template<typename T>
-concept IsUart = requires(volatile T *v, uint8_t byte)
-{
-	{v->init()};
+concept IsUart = requires(volatile T *v, uint8_t byte) {
+	{
+		v->init()
+	};
 	{
 		v->can_write()
-		} -> std::same_as<bool>;
+	} -> std::same_as<bool>;
 	{
 		v->can_read()
-		} -> std::same_as<bool>;
+	} -> std::same_as<bool>;
 	{
 		v->blocking_read()
-		} -> std::same_as<uint8_t>;
-	{v->blocking_write(byte)};
+	} -> std::same_as<uint8_t>;
+	{
+		v->blocking_write(byte)
+	};
 };
 
 /**

--- a/sdk/include/platform/sunburst/platform-ethernet.hh
+++ b/sdk/include/platform/sunburst/platform-ethernet.hh
@@ -133,161 +133,171 @@ class Ksz8851Ethernet
 	/**
 	 * Flag bits of the TransmitControl register.
 	 */
-	enum [[clang::flag_enum]] TransmitControl : uint16_t{
-	  TransmitEnable                 = 1 << 0,
-	  TransmitCrcEnable              = 1 << 1,
-	  TransmitPaddingEnable          = 1 << 2,
-	  TransmitFlowControlEnable      = 1 << 3,
-	  FlushTransmitQueue             = 1 << 4,
-	  TransmitChecksumGenerationIp   = 1 << 5,
-	  TransmitChecksumGenerationTcp  = 1 << 6,
-	  TransmitChecksumGenerationIcmp = 1 << 9,
+	enum [[clang::flag_enum]] TransmitControl : uint16_t
+	{
+		TransmitEnable                 = 1 << 0,
+		TransmitCrcEnable              = 1 << 1,
+		TransmitPaddingEnable          = 1 << 2,
+		TransmitFlowControlEnable      = 1 << 3,
+		FlushTransmitQueue             = 1 << 4,
+		TransmitChecksumGenerationIp   = 1 << 5,
+		TransmitChecksumGenerationTcp  = 1 << 6,
+		TransmitChecksumGenerationIcmp = 1 << 9,
 	};
 
 	/**
 	 * Flag bits of the ReceiveControl1 register.
 	 */
-	enum [[clang::flag_enum]] ReceiveControl1 : uint16_t{
-	  ReceiveEnable                                        = 1 << 0,
-	  ReceiveInverseFilter                                 = 1 << 1,
-	  ReceiveAllEnable                                     = 1 << 4,
-	  ReceiveUnicastEnable                                 = 1 << 5,
-	  ReceiveMulticastEnable                               = 1 << 6,
-	  ReceiveBroadcastEnable                               = 1 << 7,
-	  ReceiveMulticastAddressFilteringWithMacAddressEnable = 1 << 8,
-	  ReceiveErrorFrameEnable                              = 1 << 9,
-	  ReceiveFlowControlEnable                             = 1 << 10,
-	  ReceivePhysicalAddressFilteringWithMacAddressEnable  = 1 << 11,
-	  ReceiveIpFrameChecksumCheckEnable                    = 1 << 12,
-	  ReceiveTcpFrameChecksumCheckEnable                   = 1 << 13,
-	  ReceiveUdpFrameChecksumCheckEnable                   = 1 << 14,
-	  FlushReceiveQueue                                    = 1 << 15,
+	enum [[clang::flag_enum]] ReceiveControl1 : uint16_t
+	{
+		ReceiveEnable                                        = 1 << 0,
+		ReceiveInverseFilter                                 = 1 << 1,
+		ReceiveAllEnable                                     = 1 << 4,
+		ReceiveUnicastEnable                                 = 1 << 5,
+		ReceiveMulticastEnable                               = 1 << 6,
+		ReceiveBroadcastEnable                               = 1 << 7,
+		ReceiveMulticastAddressFilteringWithMacAddressEnable = 1 << 8,
+		ReceiveErrorFrameEnable                              = 1 << 9,
+		ReceiveFlowControlEnable                             = 1 << 10,
+		ReceivePhysicalAddressFilteringWithMacAddressEnable  = 1 << 11,
+		ReceiveIpFrameChecksumCheckEnable                    = 1 << 12,
+		ReceiveTcpFrameChecksumCheckEnable                   = 1 << 13,
+		ReceiveUdpFrameChecksumCheckEnable                   = 1 << 14,
+		FlushReceiveQueue                                    = 1 << 15,
 	};
 
 	/**
 	 * Flag bits of the ReceiveControl2 register.
 	 */
-	enum [[clang::flag_enum]] ReceiveControl2 : uint16_t{
-	  ReceiveSourceAddressFiltering            = 1 << 0,
-	  ReceiveIcmpFrameChecksumEnable           = 1 << 1,
-	  UdpLiteFrameEnable                       = 1 << 2,
-	  ReceiveIpv4Ipv6UdpFrameChecksumEqualZero = 1 << 3,
-	  ReceiveIpv4Ipv6FragmentFramePass         = 1 << 4,
-	  DataBurst4Bytes                          = 0b000 << 5,
-	  DataBurst8Bytes                          = 0b001 << 5,
-	  DataBurst16Bytes                         = 0b010 << 5,
-	  DataBurst32Bytes                         = 0b011 << 5,
-	  DataBurstSingleFrame                     = 0b100 << 5,
+	enum [[clang::flag_enum]] ReceiveControl2 : uint16_t
+	{
+		ReceiveSourceAddressFiltering            = 1 << 0,
+		ReceiveIcmpFrameChecksumEnable           = 1 << 1,
+		UdpLiteFrameEnable                       = 1 << 2,
+		ReceiveIpv4Ipv6UdpFrameChecksumEqualZero = 1 << 3,
+		ReceiveIpv4Ipv6FragmentFramePass         = 1 << 4,
+		DataBurst4Bytes                          = 0b000 << 5,
+		DataBurst8Bytes                          = 0b001 << 5,
+		DataBurst16Bytes                         = 0b010 << 5,
+		DataBurst32Bytes                         = 0b011 << 5,
+		DataBurstSingleFrame                     = 0b100 << 5,
 	};
 
 	/**
 	 * Flag bits of the ReceiveFrameHeaderStatus register.
 	 */
-	enum [[clang::flag_enum]] ReceiveFrameHeaderStatus : uint16_t{
-	  ReceiveCrcError                = 1 << 0,
-	  ReceiveRuntFrame               = 1 << 1,
-	  ReceiveFrameTooLong            = 1 << 2,
-	  ReceiveFrameType               = 1 << 3,
-	  ReceiveMiiError                = 1 << 4,
-	  ReceiveUnicastFrame            = 1 << 5,
-	  ReceiveMulticastFrame          = 1 << 6,
-	  ReceiveBroadcastFrame          = 1 << 7,
-	  ReceiveUdpFrameChecksumStatus  = 1 << 10,
-	  ReceiveTcpFrameChecksumStatus  = 1 << 11,
-	  ReceiveIpFrameChecksumStatus   = 1 << 12,
-	  ReceiveIcmpFrameChecksumStatus = 1 << 13,
-	  ReceiveFrameValid              = 1 << 15,
+	enum [[clang::flag_enum]] ReceiveFrameHeaderStatus : uint16_t
+	{
+		ReceiveCrcError                = 1 << 0,
+		ReceiveRuntFrame               = 1 << 1,
+		ReceiveFrameTooLong            = 1 << 2,
+		ReceiveFrameType               = 1 << 3,
+		ReceiveMiiError                = 1 << 4,
+		ReceiveUnicastFrame            = 1 << 5,
+		ReceiveMulticastFrame          = 1 << 6,
+		ReceiveBroadcastFrame          = 1 << 7,
+		ReceiveUdpFrameChecksumStatus  = 1 << 10,
+		ReceiveTcpFrameChecksumStatus  = 1 << 11,
+		ReceiveIpFrameChecksumStatus   = 1 << 12,
+		ReceiveIcmpFrameChecksumStatus = 1 << 13,
+		ReceiveFrameValid              = 1 << 15,
 	};
 
 	/**
 	 * Flag bits of the ReceiveQueueCommand register.
 	 */
-	enum [[clang::flag_enum]] ReceiveQueueCommand : uint16_t{
-	  ReleaseReceiveErrorFrame            = 1 << 0,
-	  StartDmaAccess                      = 1 << 3,
-	  AutoDequeueReceiveQueueFrameEnable  = 1 << 4,
-	  ReceiveFrameCountThresholdEnable    = 1 << 5,
-	  ReceiveDataByteCountThresholdEnable = 1 << 6,
-	  ReceiveDurationTimerThresholdEnable = 1 << 7,
-	  ReceiveIpHeaderTwoByteOffsetEnable  = 1 << 9,
-	  ReceiveFrameCountThresholdStatus    = 1 << 10,
-	  ReceiveDataByteCountThresholdstatus = 1 << 11,
-	  ReceiveDurationTimerThresholdStatus = 1 << 12,
+	enum [[clang::flag_enum]] ReceiveQueueCommand : uint16_t
+	{
+		ReleaseReceiveErrorFrame            = 1 << 0,
+		StartDmaAccess                      = 1 << 3,
+		AutoDequeueReceiveQueueFrameEnable  = 1 << 4,
+		ReceiveFrameCountThresholdEnable    = 1 << 5,
+		ReceiveDataByteCountThresholdEnable = 1 << 6,
+		ReceiveDurationTimerThresholdEnable = 1 << 7,
+		ReceiveIpHeaderTwoByteOffsetEnable  = 1 << 9,
+		ReceiveFrameCountThresholdStatus    = 1 << 10,
+		ReceiveDataByteCountThresholdstatus = 1 << 11,
+		ReceiveDurationTimerThresholdStatus = 1 << 12,
 	};
 
 	/**
 	 * Flag bits of the TransmitQueueCommand register.
 	 */
-	enum [[clang::flag_enum]] TransmitQueueCommand : uint16_t{
-	  ManualEnqueueTransmitQueueFrameEnable = 1 << 0,
-	  TransmitQueueMemoryAvailableMonitor   = 1 << 1,
-	  AutoEnqueueTransmitQueueFrameEnable   = 1 << 2,
+	enum [[clang::flag_enum]] TransmitQueueCommand : uint16_t
+	{
+		ManualEnqueueTransmitQueueFrameEnable = 1 << 0,
+		TransmitQueueMemoryAvailableMonitor   = 1 << 1,
+		AutoEnqueueTransmitQueueFrameEnable   = 1 << 2,
 	};
 
 	/**
 	 * Flag bits of the TransmitFrameDataPointer and ReceiveFrameDataPointer
 	 * register.
 	 */
-	enum [[clang::flag_enum]] FrameDataPointer : uint16_t{
-	  /**
-	   * When this bit is set, the frame data pointer register increments
-	   * automatically on accesses to the data register.
-	   */
-	  FrameDataPointerAutoIncrement = 1 << 14,
+	enum [[clang::flag_enum]] FrameDataPointer : uint16_t
+	{
+		/**
+		 * When this bit is set, the frame data pointer register increments
+		 * automatically on accesses to the data register.
+		 */
+		FrameDataPointerAutoIncrement = 1 << 14,
 	};
 
 	/**
 	 * Flags bits of the InterruptStatus and InterruptEnable registers.
 	 */
-	enum [[clang::flag_enum]] Interrupt : uint16_t{
-	  EnergyDetectInterrupt             = 1 << 2,
-	  LinkupDetectInterrupt             = 1 << 3,
-	  ReceiveMagicPacketDetectInterrupt = 1 << 4,
-	  ReceiveWakeupFrameDetectInterrupt = 1 << 5,
-	  TransmitSpaceAvailableInterrupt   = 1 << 6,
-	  ReceiveProcessStoppedInterrupt    = 1 << 7,
-	  TransmitProcessStoppedInterrupt   = 1 << 8,
-	  ReceiveOverrunInterrupt           = 1 << 11,
-	  ReceiveInterrupt                  = 1 << 13,
-	  TransmitInterrupt                 = 1 << 14,
-	  LinkChangeInterruptStatus         = 1 << 15,
+	enum [[clang::flag_enum]] Interrupt : uint16_t
+	{
+		EnergyDetectInterrupt             = 1 << 2,
+		LinkupDetectInterrupt             = 1 << 3,
+		ReceiveMagicPacketDetectInterrupt = 1 << 4,
+		ReceiveWakeupFrameDetectInterrupt = 1 << 5,
+		TransmitSpaceAvailableInterrupt   = 1 << 6,
+		ReceiveProcessStoppedInterrupt    = 1 << 7,
+		TransmitProcessStoppedInterrupt   = 1 << 8,
+		ReceiveOverrunInterrupt           = 1 << 11,
+		ReceiveInterrupt                  = 1 << 13,
+		TransmitInterrupt                 = 1 << 14,
+		LinkChangeInterruptStatus         = 1 << 15,
 	};
 
 	/**
 	 * Flags bits of the Port1Control register.
 	 */
-	enum [[clang::flag_enum]] Port1Control : uint16_t{
-	  Advertised10BTHalfDuplexCapability  = 1 << 0,
-	  Advertised10BTFullDuplexCapability  = 1 << 1,
-	  Advertised100BTHalfDuplexCapability = 1 << 2,
-	  Advertised100BTFullDuplexCapability = 1 << 3,
-	  AdvertisedFlowControlCapability     = 1 << 4,
-	  ForceDuplex                         = 1 << 5,
-	  ForceSpeed                          = 1 << 6,
-	  AutoNegotiationEnable               = 1 << 7,
-	  ForceMDIX                           = 1 << 9,
-	  DisableAutoMDIMDIX                  = 1 << 10,
-	  RestartAutoNegotiation              = 1 << 13,
-	  TransmitterDisable                  = 1 << 14,
-	  LedOff                              = 1 << 15,
+	enum [[clang::flag_enum]] Port1Control : uint16_t
+	{
+		Advertised10BTHalfDuplexCapability  = 1 << 0,
+		Advertised10BTFullDuplexCapability  = 1 << 1,
+		Advertised100BTHalfDuplexCapability = 1 << 2,
+		Advertised100BTFullDuplexCapability = 1 << 3,
+		AdvertisedFlowControlCapability     = 1 << 4,
+		ForceDuplex                         = 1 << 5,
+		ForceSpeed                          = 1 << 6,
+		AutoNegotiationEnable               = 1 << 7,
+		ForceMDIX                           = 1 << 9,
+		DisableAutoMDIMDIX                  = 1 << 10,
+		RestartAutoNegotiation              = 1 << 13,
+		TransmitterDisable                  = 1 << 14,
+		LedOff                              = 1 << 15,
 	};
 
 	/**
 	 * Flags bits of the Port1Status register.
 	 */
-	enum [[clang::flag_enum]] Port1Status : uint16_t{
-	  Partner10BTHalfDuplexCapability  = 1 << 0,
-	  Partner10BTFullDuplexCapability  = 1 << 1,
-	  Partner100BTHalfDuplexCapability = 1 << 2,
-	  Partner100BTFullDuplexCapability = 1 << 3,
-	  PartnerFlowControlCapability     = 1 << 4,
-	  LinkGood                         = 1 << 5,
-	  AutoNegotiationDone              = 1 << 6,
-	  MDIXStatus                       = 1 << 7,
-	  OperationDuplex                  = 1 << 9,
-	  OperationSpeed                   = 1 << 10,
-	  PolarityReverse                  = 1 << 13,
-	  HPMDIX                           = 1 << 15,
+	enum [[clang::flag_enum]] Port1Status : uint16_t
+	{
+		Partner10BTHalfDuplexCapability  = 1 << 0,
+		Partner10BTFullDuplexCapability  = 1 << 1,
+		Partner100BTHalfDuplexCapability = 1 << 2,
+		Partner100BTFullDuplexCapability = 1 << 3,
+		PartnerFlowControlCapability     = 1 << 4,
+		LinkGood                         = 1 << 5,
+		AutoNegotiationDone              = 1 << 6,
+		MDIXStatus                       = 1 << 7,
+		OperationDuplex                  = 1 << 9,
+		OperationSpeed                   = 1 << 10,
+		PolarityReverse                  = 1 << 13,
+		HPMDIX                           = 1 << 15,
 	};
 
 	/**

--- a/sdk/include/platform/sunburst/platform-i2c.hh
+++ b/sdk/include/platform/sunburst/platform-i2c.hh
@@ -182,105 +182,113 @@ struct OpenTitanI2c
 	};
 
 	/// Control Register Fields
-	enum [[clang::flag_enum]] : uint32_t{
-	  /// Enable Host I2C functionality
-	  ControlEnableHost = 1 << 0,
-	  /// Enable Target I2C functionality
-	  ControlEnableTarget = 1 << 1,
-	  /// Enable I2C line loopback test If line loopback is enabled, the
-	  /// internal design sees ACQ and RX data as "1"
-	  ControlLineLoopback = 1 << 2,
-	  /// Enable NACKing the address on a stretch timeout. This is a target
-	  /// mode feature. If enabled, a stretch timeout will cause the device to
-	  /// NACK the address byte. If disabled, it will ACK instead.
-	  ControlNackAddressAfterTimeout = 1 << 3,
-	  /// Enable ACK Control Mode, which works with the `targetAckControl`
-	  /// register to allow software to control upper-layer (N)ACKing.
-	  ControlAckControlEnable = 1 << 4,
-	  /// Enable the bus monitor in multi-controller mode.
-	  ControlMultiControllerMonitorEnable = 1 << 5,
-	  /// If set, causes a read transfer addressed to the this target to set
-	  /// the corresponding bit in the `targetEvents` register. While the
-	  /// `transmitPending` field is 1, subsequent read transactions will
-	  /// stretch the clock, even if there is data in the Transmit FIFO.
-	  ControlTransmitStretchEnable = 1 << 6,
+	enum [[clang::flag_enum]] : uint32_t
+	{
+		/// Enable Host I2C functionality
+		ControlEnableHost = 1 << 0,
+		/// Enable Target I2C functionality
+		ControlEnableTarget = 1 << 1,
+		/// Enable I2C line loopback test If line loopback is enabled, the
+		/// internal design sees ACQ and RX data as "1"
+		ControlLineLoopback = 1 << 2,
+		/// Enable NACKing the address on a stretch timeout. This is a target
+		/// mode feature. If enabled, a stretch timeout will cause the device to
+		/// NACK the address byte. If disabled, it will ACK instead.
+		ControlNackAddressAfterTimeout = 1 << 3,
+		/// Enable ACK Control Mode, which works with the `targetAckControl`
+		/// register to allow software to control upper-layer (N)ACKing.
+		ControlAckControlEnable = 1 << 4,
+		/// Enable the bus monitor in multi-controller mode.
+		ControlMultiControllerMonitorEnable = 1 << 5,
+		/// If set, causes a read transfer addressed to the this target to set
+		/// the corresponding bit in the `targetEvents` register. While the
+		/// `transmitPending` field is 1, subsequent read transactions will
+		/// stretch the clock, even if there is data in the Transmit FIFO.
+		ControlTransmitStretchEnable = 1 << 6,
 	};
 
 	/// Status Register Fields
-	enum [[clang::flag_enum]] : uint32_t{
-	  /// Host mode Format FIFO is full
-	  StatusFormatFull = 1 << 0,
-	  /// Host mode Receive FIFO is full
-	  StatusReceiveFull = 1 << 1,
-	  /// Host mode Format FIFO is empty
-	  StatusFormatEmpty = 1 << 2,
-	  /// Host functionality is idle. No Host transaction is in progress
-	  StatusHostIdle = 1 << 3,
-	  /// Target functionality is idle. No Target transaction is in progress
-	  StatusTargetIdle = 1 << 4,
-	  /// Host mode Receive FIFO is empty
-	  SmatusReceiveEmpty = 1 << 5,
-	  /// Target mode Transmit FIFO is full
-	  StatusTransmitFull = 1 << 6,
-	  /// Target mode Acquired FIFO is full
-	  StatusAcquiredFull = 1 << 7,
-	  /// Target mode Transmit FIFO is empty
-	  StatusTransmitEmpty = 1 << 8,
-	  /// Target mode Acquired FIFO is empty
-	  StatusAcquiredEmpty = 1 << 9,
-	  /// Target mode stretching at (N)ACK phase due to zero count
-	  /// in the `targetAckControl` register.
-	  StatusAckControlStretch = 1 << 10,
+	enum [[clang::flag_enum]] : uint32_t
+	{
+		/// Host mode Format FIFO is full
+		StatusFormatFull = 1 << 0,
+		/// Host mode Receive FIFO is full
+		StatusReceiveFull = 1 << 1,
+		/// Host mode Format FIFO is empty
+		StatusFormatEmpty = 1 << 2,
+		/// Host functionality is idle. No Host transaction is in progress
+		StatusHostIdle = 1 << 3,
+		/// Target functionality is idle. No Target transaction is in progress
+		StatusTargetIdle = 1 << 4,
+		/// Host mode Receive FIFO is empty
+		SmatusReceiveEmpty = 1 << 5,
+		/// Target mode Transmit FIFO is full
+		StatusTransmitFull = 1 << 6,
+		/// Target mode Acquired FIFO is full
+		StatusAcquiredFull = 1 << 7,
+		/// Target mode Transmit FIFO is empty
+		StatusTransmitEmpty = 1 << 8,
+		/// Target mode Acquired FIFO is empty
+		StatusAcquiredEmpty = 1 << 9,
+		/// Target mode stretching at (N)ACK phase due to zero count
+		/// in the `targetAckControl` register.
+		StatusAckControlStretch = 1 << 10,
 	};
 
 	/// FormatData Register Fields
-	enum [[clang::flag_enum]] : uint32_t{
-	  /// Issue a START condition before transmitting BYTE.
-	  FormatDataStart = 1 << 8,
-	  /// Issue a STOP condition after this operation
-	  FormatDataStop = 1 << 9,
-	  /// Read BYTE bytes from I2C. (256 if BYTE==0)
-	  FormatDataReadBytes = 1 << 10,
-	  /**
-	   * Do not NACK the last byte read, let the read
-	   * operation continue
-	   */
-	  FormatDataReadCount = 1 << 11,
-	  /// Do not signal an exception if the current byte is not ACK’d
-	  FormatDataNakOk = 1 << 12,
+	enum [[clang::flag_enum]] : uint32_t
+	{
+		/// Issue a START condition before transmitting BYTE.
+		FormatDataStart = 1 << 8,
+		/// Issue a STOP condition after this operation
+		FormatDataStop = 1 << 9,
+		/// Read BYTE bytes from I2C. (256 if BYTE==0)
+		FormatDataReadBytes = 1 << 10,
+		/**
+		 * Do not NACK the last byte read, let the read
+		 * operation continue
+		 */
+		FormatDataReadCount = 1 << 11,
+		/// Do not signal an exception if the current byte is not ACK’d
+		FormatDataNakOk = 1 << 12,
 	};
 
 	/// FifoControl Register Fields
-	enum [[clang::flag_enum]] : uint32_t{
-	  /// Receive fifo reset. Write 1 to the register resets it. Read returns 0
-	  FifoControlReceiveReset = 1 << 0,
-	  /// Format fifo reset. Write 1 to the register resets it. Read returns 0
-	  FifoControlFormatReset = 1 << 1,
-	  /// Acquired FIFO reset. Write 1 to the register resets it. Read returns 0
-	  FifoControlAcquiredReset = 1 << 7,
-	  /// Transmit FIFO reset. Write 1 to the register resets it. Read returns 0
-	  FifoControlTransmitReset = 1 << 8,
+	enum [[clang::flag_enum]] : uint32_t
+	{
+		/// Receive fifo reset. Write 1 to the register resets it. Read returns
+		/// 0
+		FifoControlReceiveReset = 1 << 0,
+		/// Format fifo reset. Write 1 to the register resets it. Read returns 0
+		FifoControlFormatReset = 1 << 1,
+		/// Acquired FIFO reset. Write 1 to the register resets it. Read returns
+		/// 0
+		FifoControlAcquiredReset = 1 << 7,
+		/// Transmit FIFO reset. Write 1 to the register resets it. Read returns
+		/// 0
+		FifoControlTransmitReset = 1 << 8,
 	};
 
 	/// ControllerEvents Register Fields
-	enum [[clang::flag_enum]] : uint32_t{
-	  /// Controller FSM is halted due to receiving an unexpected NACK.
-	  ControllerEventsNack = 1 << 0,
-	  /**
-	   * Controller FSM is halted due to a Host-Mode active transaction being
-	   * ended by the `hostNackHandlerTimeout` mechanism.
-	   */
-	  ControllerEventsUnhandledNackTimeout = 1 << 1,
-	  /**
-	   * Controller FSM is halted due to a Host-Mode active transaction being
-	   * terminated because of a bus timeout activated by `timeoutControl`.
-	   */
-	  ControllerEventsBusTimeout = 1 << 2,
-	  /**
-	   * Controller FSM is halted due to a Host-Mode active transaction being
-	   * terminated because of lost arbitration.
-	   */
-	  ControllerEventsArbitrationLost = 1 << 3,
+	enum [[clang::flag_enum]] : uint32_t
+	{
+		/// Controller FSM is halted due to receiving an unexpected NACK.
+		ControllerEventsNack = 1 << 0,
+		/**
+		 * Controller FSM is halted due to a Host-Mode active transaction being
+		 * ended by the `hostNackHandlerTimeout` mechanism.
+		 */
+		ControllerEventsUnhandledNackTimeout = 1 << 1,
+		/**
+		 * Controller FSM is halted due to a Host-Mode active transaction being
+		 * terminated because of a bus timeout activated by `timeoutControl`.
+		 */
+		ControllerEventsBusTimeout = 1 << 2,
+		/**
+		 * Controller FSM is halted due to a Host-Mode active transaction being
+		 * terminated because of lost arbitration.
+		 */
+		ControllerEventsArbitrationLost = 1 << 3,
 	};
 
 	// Referred to as 'RX FIFO' in the documentation

--- a/sdk/include/platform/sunburst/platform-rgbctrl.hh
+++ b/sdk/include/platform/sunburst/platform-rgbctrl.hh
@@ -33,23 +33,25 @@ struct SonataRgbLedController
 	uint32_t status;
 
 	/// Control Register Fields
-	enum [[clang::flag_enum]] ControlFields : uint32_t{
-	  /// Write 1 to set RGB LEDs to specified colours.
-	  ControlSet = 1 << 0,
-	  /**
-	   * Write 1 to turn off RGB LEDs.
-	   * Write to ControlSet to turn on again.
-	   */
-	  ControlOff = 1 << 1,
+	enum [[clang::flag_enum]] ControlFields : uint32_t
+	{
+		/// Write 1 to set RGB LEDs to specified colours.
+		ControlSet = 1 << 0,
+		/**
+		 * Write 1 to turn off RGB LEDs.
+		 * Write to ControlSet to turn on again.
+		 */
+		ControlOff = 1 << 1,
 	};
 
 	/// Status Register Fields
-	enum [[clang::flag_enum]] StatusFields : uint32_t{
-	  /**
-	   * When asserted controller is idle and new colours can be set,
-	   * otherwise writes to regLed0, regLed1, and control are ignored.
-	   */
-	  StatusIdle = 1 << 0,
+	enum [[clang::flag_enum]] StatusFields : uint32_t
+	{
+		/**
+		 * When asserted controller is idle and new colours can be set,
+		 * otherwise writes to regLed0, regLed1, and control are ignored.
+		 */
+		StatusIdle = 1 << 0,
 	};
 
 	/**

--- a/sdk/include/platform/sunburst/platform-spi.hh
+++ b/sdk/include/platform/sunburst/platform-spi.hh
@@ -7,25 +7,25 @@
 namespace SonataSpi
 {
 	/// Sonata SPI Interrupts
-	typedef enum [[clang::flag_enum]]
-	: uint32_t{
-	    /// Raised when a SPI operation completes and the block has become idle.
-	    InterruptComplete = 1 << 4,
-	    /*
-	     * Asserted whilst the transmit FIFO level is at or below the
-	     * transmit watermark.
-	     */
-	    InterruptTransmitWatermark = 1 << 3,
-	    /// Asserted whilst the transmit FIFO is empty.
-	    InterruptTransmitEmpty = 1 << 2,
-	    /*
-	     * Asserted whilst the receive FIFO level is at or above the receive
-	     * watermark.
-	     */
-	    InterruptReceiveWatermark = 1 << 1,
-	    /// Asserted whilst the receive FIFO is full.
-	    InterruptReceiveFull = 1 << 0,
-	  } Interrupt;
+	typedef enum [[clang::flag_enum]] : uint32_t
+	{
+		/// Raised when a SPI operation completes and the block has become idle.
+		InterruptComplete = 1 << 4,
+		/*
+		 * Asserted whilst the transmit FIFO level is at or below the
+		 * transmit watermark.
+		 */
+		InterruptTransmitWatermark = 1 << 3,
+		/// Asserted whilst the transmit FIFO is empty.
+		InterruptTransmitEmpty = 1 << 2,
+		/*
+		 * Asserted whilst the receive FIFO level is at or above the receive
+		 * watermark.
+		 */
+		InterruptReceiveWatermark = 1 << 1,
+		/// Asserted whilst the receive FIFO is full.
+		InterruptReceiveFull = 1 << 0,
+	} Interrupt;
 
 	/// Configuration Register Fields
 	enum : uint32_t

--- a/sdk/include/platform/sunburst/platform-spi.hh
+++ b/sdk/include/platform/sunburst/platform-spi.hh
@@ -313,7 +313,7 @@ namespace SonataSpi
 				{
 					// Wait for at least one byte to be available in the RX FIFO
 					while ((status & StatusRxFifoLevel) == 0) {}
-					data[i] = uint8_t(receiveFifo);
+					data[i] = static_cast<uint8_t>(receiveFifo);
 				}
 			}
 		}

--- a/sdk/include/platform/sunburst/platform-uart.hh
+++ b/sdk/include/platform/sunburst/platform-uart.hh
@@ -75,36 +75,37 @@ struct OpenTitanUart
 	uint32_t timeoutControl;
 
 	/// OpenTitan UART Interrupts
-	typedef enum [[clang::flag_enum]]
-	: uint32_t{
-	    /// Raised if the transmit FIFO is empty.
-	    InterruptTransmitEmpty = 1 << 8,
-	    /// Raised if the receiver has detected a parity error.
-	    InterruptReceiveParityErr = 1 << 7,
-	    /// Raised if the receive FIFO has characters remaining in the FIFO
-	    /// without being
-	    /// retreived for the programmed time period.
-	    InterruptReceiveTimeout = 1 << 6,
-	    /// Raised if break condition has been detected on receive.
-	    InterruptReceiveBreakErr = 1 << 5,
-	    /// Raised if a framing error has been detected on receive.
-	    InterruptReceiveFrameErr = 1 << 4,
-	    /// Raised if the receive FIFO has overflowed.
-	    InterruptReceiveOverflow = 1 << 3,
-	    /// Raised if the transmit FIFO has emptied and no transmit is ongoing.
-	    InterruptTransmitDone = 1 << 2,
-	    /// Raised if the receive FIFO is past the high-water mark.
-	    InterruptReceiveWatermark = 1 << 1,
-	    /// Raised if the transmit FIFO is past the high-water mark.
-	    InterruptTransmitWatermark = 1 << 0,
-	  } OpenTitanUartInterrupt;
+	typedef enum [[clang::flag_enum]] : uint32_t
+	{
+		/// Raised if the transmit FIFO is empty.
+		InterruptTransmitEmpty = 1 << 8,
+		/// Raised if the receiver has detected a parity error.
+		InterruptReceiveParityErr = 1 << 7,
+		/// Raised if the receive FIFO has characters remaining in the FIFO
+		/// without being
+		/// retreived for the programmed time period.
+		InterruptReceiveTimeout = 1 << 6,
+		/// Raised if break condition has been detected on receive.
+		InterruptReceiveBreakErr = 1 << 5,
+		/// Raised if a framing error has been detected on receive.
+		InterruptReceiveFrameErr = 1 << 4,
+		/// Raised if the receive FIFO has overflowed.
+		InterruptReceiveOverflow = 1 << 3,
+		/// Raised if the transmit FIFO has emptied and no transmit is ongoing.
+		InterruptTransmitDone = 1 << 2,
+		/// Raised if the receive FIFO is past the high-water mark.
+		InterruptReceiveWatermark = 1 << 1,
+		/// Raised if the transmit FIFO is past the high-water mark.
+		InterruptTransmitWatermark = 1 << 0,
+	} OpenTitanUartInterrupt;
 
 	/// FIFO Control Register Fields
-	enum [[clang::flag_enum]] : uint32_t{
-	  /// Reset the transmit FIFO.
-	  FifoControlTransmitReset = 1 << 1,
-	  /// Reset the receive FIFO.
-	  FifoControlReceiveReset = 1 << 0,
+	enum [[clang::flag_enum]] : uint32_t
+	{
+		/// Reset the transmit FIFO.
+		FifoControlTransmitReset = 1 << 1,
+		/// Reset the receive FIFO.
+		FifoControlReceiveReset = 1 << 0,
 	};
 
 	/// Control Register Fields

--- a/sdk/include/platform/sunburst/platform-usbdev.hh
+++ b/sdk/include/platform/sunburst/platform-usbdev.hh
@@ -250,9 +250,9 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 	[[nodiscard]] uint64_t supply_buffers(uint64_t bufferBitmap) volatile
 	{
 		constexpr uint32_t SetupFullBit =
-		  uint32_t(UsbStatusField::AvailableSetupFull);
+		  static_cast<uint32_t>(UsbStatusField::AvailableSetupFull);
 		constexpr uint32_t OutFullBit =
-		  uint32_t(UsbStatusField::AvailableOutFull);
+		  static_cast<uint32_t>(UsbStatusField::AvailableOutFull);
 
 		for (uint8_t index = 0; index < BufferCount; index++)
 		{
@@ -286,7 +286,7 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 	 */
 	void interrupt_enable(UsbdevInterrupt interrupt) volatile
 	{
-		interruptEnable = interruptEnable | uint32_t(interrupt);
+		interruptEnable = interruptEnable | static_cast<uint32_t>(interrupt);
 	}
 
 	/**
@@ -294,7 +294,7 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 	 */
 	void interrupt_disable(UsbdevInterrupt interrupt) volatile
 	{
-		interruptEnable = interruptEnable & ~uint32_t(interrupt);
+		interruptEnable = interruptEnable & ~static_cast<uint32_t>(interrupt);
 	}
 
 	/**
@@ -310,8 +310,10 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 	 */
 	[[nodiscard]] int init(uint64_t &bufferBitmap) volatile
 	{
-		bufferBitmap = supply_buffers((uint64_t(1u) << BufferCount) - 1u);
-		phyConfig    = uint32_t(PhyConfigField::UseDifferentialReceiver);
+		bufferBitmap =
+		  supply_buffers((static_cast<uint64_t>(1u) << BufferCount) - 1u);
+		phyConfig =
+		  static_cast<uint32_t>(PhyConfigField::UseDifferentialReceiver);
 		return 0;
 	}
 
@@ -404,7 +406,8 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 		{
 			return -1;
 		}
-		usbControl = usbControl | uint32_t(UsbControlField::Enable);
+		usbControl =
+		  usbControl | static_cast<uint32_t>(UsbControlField::Enable);
 		return 0;
 	}
 
@@ -415,7 +418,8 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 	 */
 	void disconnect() volatile
 	{
-		usbControl = usbControl & ~uint32_t(UsbControlField::Enable);
+		usbControl =
+		  usbControl & ~static_cast<uint32_t>(UsbControlField::Enable);
 	}
 
 	/**
@@ -425,7 +429,7 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 	 */
 	[[nodiscard]] bool connected() volatile
 	{
-		return (usbControl & uint32_t(UsbControlField::Enable));
+		return (usbControl & static_cast<uint32_t>(UsbControlField::Enable));
 	}
 
 	/**
@@ -443,8 +447,9 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 		{
 			return -1; // Device addresses are only 7 bits long.
 		}
-		constexpr uint32_t Mask = uint32_t(UsbControlField::DeviceAddress);
-		usbControl              = (usbControl & ~Mask) | (address << 16);
+		constexpr uint32_t Mask =
+		  static_cast<uint32_t>(UsbControlField::DeviceAddress);
+		usbControl = (usbControl & ~Mask) | (address << 16);
 		return 0;
 	}
 
@@ -463,8 +468,9 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 	[[nodiscard]] int retrieve_collected_packet(uint8_t &endpointId,
 	                                            uint8_t &bufferId) volatile
 	{
-		constexpr uint32_t BufferIdMask = uint32_t(ConfigInField::BufferId);
-		uint32_t           sent         = inSent;
+		constexpr uint32_t BufferIdMask =
+		  static_cast<uint32_t>(ConfigInField::BufferId);
+		uint32_t sent = inSent;
 
 		// Clear the first encountered packet sent indication.
 		for (endpointId = 0; endpointId < MaxEndpoints; endpointId++)
@@ -504,9 +510,10 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 			usbdev_transfer(buffer(bufferId), data, size, true);
 		}
 
-		constexpr uint32_t ReadyBit = uint32_t(ConfigInField::Ready);
-		configIn[endpointId]        = bufferId | (size << 8);
-		configIn[endpointId]        = configIn[endpointId] | ReadyBit;
+		constexpr uint32_t ReadyBit =
+		  static_cast<uint32_t>(ConfigInField::Ready);
+		configIn[endpointId] = bufferId | (size << 8);
+		configIn[endpointId] = configIn[endpointId] | ReadyBit;
 	}
 
 	/// The information associated with a received packet
@@ -516,22 +523,28 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 		/// The endpoint ID the received packet was received on
 		constexpr uint8_t endpoint_id()
 		{
-			return (info & uint32_t(ReceiveBufferField::EndpointId)) >> 20;
+			return (info &
+			        static_cast<uint32_t>(ReceiveBufferField::EndpointId)) >>
+			       20;
 		}
 		/// The size of the received packet
 		constexpr uint16_t size()
 		{
-			return (info & uint32_t(ReceiveBufferField::Size)) >> 8;
+			return (info & static_cast<uint32_t>(ReceiveBufferField::Size)) >>
+			       8;
 		}
 		/// Whether the received packet was a setup packet
 		constexpr bool is_setup()
 		{
-			return (info & uint32_t(ReceiveBufferField::Setup)) != 0;
+			return (info & static_cast<uint32_t>(ReceiveBufferField::Setup)) !=
+			       0;
 		}
 		/// The buffer ID used to store the received packet
 		constexpr uint8_t buffer_id()
 		{
-			return (info & uint32_t(ReceiveBufferField::BufferId)) >> 0;
+			return (info &
+			        static_cast<uint32_t>(ReceiveBufferField::BufferId)) >>
+			       0;
 		}
 	};
 
@@ -546,7 +559,7 @@ class OpenTitanUsbdev : private utils::NoCopyNoMove
 	 */
 	[[nodiscard]] std::optional<ReceiveBufferInfo> packet_take() volatile
 	{
-		if (!(usbStatus & uint32_t(UsbStatusField::ReceiveDepth)))
+		if (!(usbStatus & static_cast<uint32_t>(UsbStatusField::ReceiveDepth)))
 		{
 			return {}; // No packets received
 		}

--- a/sdk/include/thread_pool.h
+++ b/sdk/include/thread_pool.h
@@ -163,11 +163,11 @@ namespace thread_pool
 			// type.
 			Timeout t{UnlimitedTimeout};
 			void   *sealed = token_sealed_unsealed_alloc(
-			    &t,
-			    MALLOC_CAPABILITY,
-			    detail::sealing_key_for_type<LambdaType>(),
-			    sizeof(lambda),
-			    &buffer);
+              &t,
+              MALLOC_CAPABILITY,
+              detail::sealing_key_for_type<LambdaType>(),
+              sizeof(lambda),
+              &buffer);
 			/*
 			 * Copy the lambda into the new allocation.
 			 *

--- a/sdk/include/token.h
+++ b/sdk/include/token.h
@@ -203,7 +203,7 @@ token_allocate(Timeout *timeout, struct SObjStruct *heapCapability, SKey key)
 	 */
 	void *unsealed = nullptr;
 	SObj  sealed   = token_sealed_unsealed_alloc(
-	     timeout, heapCapability, key, sizeof(T), &unsealed);
+      timeout, heapCapability, key, sizeof(T), &unsealed);
 	return {static_cast<T *>(unsealed), Sealed<T>{sealed}};
 }
 

--- a/sdk/include/utils.hh
+++ b/sdk/include/utils.hh
@@ -38,12 +38,12 @@ namespace utils
 	class NoCopyNoMove
 	{
 		public:
-		NoCopyNoMove()                     = default;
-		NoCopyNoMove(const NoCopyNoMove &) = delete;
+		NoCopyNoMove()                                = default;
+		NoCopyNoMove(const NoCopyNoMove &)            = delete;
 		NoCopyNoMove &operator=(const NoCopyNoMove &) = delete;
 		NoCopyNoMove(NoCopyNoMove &&)                 = delete;
-		NoCopyNoMove &operator=(NoCopyNoMove &&) = delete;
-		~NoCopyNoMove()                          = default;
+		NoCopyNoMove &operator=(NoCopyNoMove &&)      = delete;
+		~NoCopyNoMove()                               = default;
 	};
 
 	/**

--- a/sdk/lib/compartment_helpers/claim_fast.cc
+++ b/sdk/lib/compartment_helpers/claim_fast.cc
@@ -12,7 +12,7 @@ int heap_claim_fast(Timeout *timeout, const void *ptr, const void *ptr2)
 	void   **hazards = switcher_thread_hazard_slots();
 	auto    *epochCounter{const_cast<
       cheriot::atomic<uint32_t> *>(SHARED_OBJECT_WITH_PERMISSIONS(
-	     cheriot::atomic<uint32_t>, allocator_epoch, true, false, false, false))};
+      cheriot::atomic<uint32_t>, allocator_epoch, true, false, false, false))};
 	uint32_t epoch  = epochCounter->load();
 	int      values = 2;
 	// Skip processing pointers that don't refer to heap memory.

--- a/sdk/lib/cxxrt/guard.cc
+++ b/sdk/lib/cxxrt/guard.cc
@@ -33,7 +33,7 @@ namespace
 		/// The high half (second on a little-endian system).
 		uint32_t high;
 		/// The bit used for the lock (the high bit on a little-endian system)
-		static constexpr uint32_t LockBit = uint32_t(1) << 31;
+		static constexpr uint32_t LockBit = static_cast<uint32_t>(1) << 31;
 
 		public:
 		/**

--- a/sdk/lib/debug/debug.cc
+++ b/sdk/lib/debug/debug.cc
@@ -113,7 +113,7 @@ namespace
 			}
 			std::array<char, 10> buf;
 			const char           Digits[] = "0123456789";
-			for (int i = int(buf.size() - 1); i >= 0; i--)
+			for (int i = static_cast<int>(buf.size() - 1); i >= 0; i--)
 			{
 				buf[static_cast<size_t>(i)] = Digits[s % 10];
 				s /= 10;
@@ -146,7 +146,7 @@ namespace
 			}
 			std::array<char, 20> buf;
 			const char           Digits[] = "0123456789";
-			for (int i = int(buf.size() - 1); i >= 0; i--)
+			for (int i = static_cast<int>(buf.size() - 1); i >= 0; i--)
 			{
 				buf[static_cast<size_t>(i)] = Digits[s % 10];
 				s /= 10;
@@ -176,7 +176,7 @@ namespace
 			const char          Hexdigits[] = "0123456789abcdef";
 			// Length of string including null terminator
 			static_assert(sizeof(Hexdigits) == 0x11);
-			for (long i = long(buf.size() - 1); i >= 0; i--)
+			for (long i = static_cast<long>(buf.size() - 1); i >= 0; i--)
 			{
 				buf.at(static_cast<size_t>(i)) = Hexdigits[s & 0xf];
 				s >>= 4;

--- a/sdk/lib/event_group/event_group.cc
+++ b/sdk/lib/event_group/event_group.cc
@@ -38,7 +38,7 @@ int eventgroup_create(Timeout     *timeout,
                       EventGroup **outGroup)
 {
 	auto threads = thread_count();
-	if (threads == uint16_t(-1))
+	if (threads == static_cast<uint16_t>(-1))
 	{
 		return -ERANGE;
 	}

--- a/tests.extra/hardware_revoker_IRQs/top.cc
+++ b/tests.extra/hardware_revoker_IRQs/top.cc
@@ -5,11 +5,31 @@ using Debug = ConditionalDebug<true, "top">;
 
 #if __has_include(<platform-hardware_revoker.hh>)
 #	include <platform-hardware_revoker.hh>
+
+using Revoker = HardwareRevoker<uint32_t, REVOKABLE_MEMORY_START>;
+
+#elif defined(CLANG_TIDY)
+
+struct Revoker
+{
+	static constexpr bool IsAsynchronous = true;
+
+	uint32_t system_epoch_get()
+	{
+		return 0;
+	}
+	int wait_for_completion(Timeout *, uint32_t)
+	{
+		return 0;
+	}
+	void system_bg_revoker_kick() {}
+	void init() {}
+};
+
 #else
 #	error No platform-hardware_revoker.hh found, are you building for the right platform?
 #endif
 
-using Revoker = HardwareRevoker<uint32_t, REVOKABLE_MEMORY_START>;
 static_assert(Revoker::IsAsynchronous, "This test is for async revokers");
 
 void __cheri_compartment("top") entry()

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -372,11 +372,11 @@ namespace
             ssize_t claimSize = heap_claim(SECOND_HEAP, alloc);
             claimCount++;
             TEST((allocSize <= claimSize) &&
-			            (claimSize <= allocSize + CHERIOTHeapMinChunkSize),
-			          "{}-byte allocation claimed as {} bytes (claim number {})",
-			          allocSize,
-			          claimSize,
-			          claimCount);
+                   (claimSize <= allocSize + CHERIOTHeapMinChunkSize),
+                 "{}-byte allocation claimed as {} bytes (claim number {})",
+                 allocSize,
+                 claimSize,
+                 claimCount);
 		};
 		claim();
 		int ret = heap_free(SECOND_HEAP, alloc);

--- a/tests/compartment_calls.h
+++ b/tests/compartment_calls.h
@@ -40,7 +40,7 @@ __cheri_compartment("compartment_calls_inner") int compartment_call_inner(
   int        x6);
 __cheri_compartment("compartment_calls_inner") int test_incorrect_export_table(
   __cheri_callback void (*fn)(),
-  bool *outTestFailed);
+  bool                 *outTestFailed);
 __cheri_compartment(
   "compartment_calls_inner_with_"
   "handler") int test_incorrect_export_table_with_handler(__cheri_callback int (*fn)());

--- a/tests/compartment_calls_inner.cc
+++ b/tests/compartment_calls_inner.cc
@@ -98,7 +98,7 @@ int compartment_call_inner(int        x0,
 }
 
 int test_incorrect_export_table(__cheri_callback void (*fn)(),
-                                bool *outTestFailed)
+                                bool                 *outTestFailed)
 {
 	/*
 	 * Trigger a cross-compartment call with an invalid export entry.

--- a/tests/stack_integrity_thread.cc
+++ b/tests/stack_integrity_thread.cc
@@ -144,7 +144,7 @@ int set_csp_permissions_on_fault(PermissionSet newPermissions)
 	return -EINVAL;
 }
 
-int set_csp_permissions_on_call(PermissionSet newPermissions,
+int set_csp_permissions_on_call(PermissionSet        newPermissions,
                                 __cheri_callback int (*fn)())
 {
 	CALL_CHERI_CALLBACK(fn, "candperm csp, csp, %1\n", newPermissions.as_raw());
@@ -180,7 +180,7 @@ int self_recursion(__cheri_callback int (*fn)())
 }
 
 int exhaust_trusted_stack(__cheri_callback int (*fn)(),
-                          bool *outLeakedSwitcherCapability)
+                          bool                *outLeakedSwitcherCapability)
 {
 	return self_recursion(fn);
 }

--- a/tests/stack_tests.h
+++ b/tests/stack_tests.h
@@ -6,14 +6,14 @@ using namespace CHERI;
 
 __cheri_compartment("stack_integrity_thread") int exhaust_trusted_stack(
   __cheri_callback int (*fn)(),
-  bool *outLeakedSwitcherCapability);
+  bool                *outLeakedSwitcherCapability);
 __cheri_compartment("stack_integrity_thread") int exhaust_thread_stack();
 __cheri_compartment("stack_integrity_thread") int exhaust_thread_stack_spill(
   __cheri_callback int (*fn)());
 __cheri_compartment("stack_integrity_thread") int set_csp_permissions_on_fault(
   PermissionSet newPermissions);
 __cheri_compartment("stack_integrity_thread") int set_csp_permissions_on_call(
-  PermissionSet newPermissions,
+  PermissionSet        newPermissions,
   __cheri_callback int (*fn)());
 __cheri_compartment("stack_integrity_thread") int test_stack_invalid_on_fault();
 __cheri_compartment("stack_integrity_thread") int test_stack_invalid_on_call(

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -111,8 +111,9 @@ int __cheri_compartment("test_runner") run_tests()
 		           "Iterator of PermissionSet failed");
 	}
 	// These need to be checked visually
-	debug_log("Trying to print 8-bit integer: {}", uint8_t(0x12));
-	debug_log("Trying to print unsigned 8-bit integer: {}", int8_t(34));
+	debug_log("Trying to print 8-bit integer: {}", static_cast<uint8_t>(0x12));
+	debug_log("Trying to print unsigned 8-bit integer: {}",
+	          static_cast<int8_t>(34));
 	debug_log("Trying to print char: {}", 'c');
 	debug_log("Trying to print 32-bit integer: {}", 12345);
 	debug_log("Trying to print 64-bit integer: {}", 123456789012345LL);


### PR DESCRIPTION
This gets CI closer to passing, but I am not sure what to do about

> sdk/include/debug.hh:419:3: warning: Address of stack memory associated with local variable 'args' is still referred to by the stack variable 'arguments' upon returning to the caller.  This will be a dangling reference [clang-analyzer-core.StackAddressEscape]       