### PR TITLE
Disable machine-outlining on sonata_simulator to fix CI.

### DIFF
--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -93,7 +93,7 @@
         "ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM=1",
         "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1"
     ],
-    "cxflags": "-enable-machine-outliner=never",
+    "cxflags": "-mllvm -enable-machine-outliner=never",
     "driver_includes" : [
         "../include/platform/sunburst",
         "../include/platform/ibex",

--- a/sdk/boards/sonata-simulator.json
+++ b/sdk/boards/sonata-simulator.json
@@ -61,6 +61,7 @@
         "ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM=1",
         "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1"
     ],
+    "cxflags": "-enable-machine-outliner=never",
     "driver_includes" : [
         "../include/platform/sunburst",
         "../include/platform/ibex",

--- a/sdk/boards/sonata-simulator.json
+++ b/sdk/boards/sonata-simulator.json
@@ -61,7 +61,7 @@
         "ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM=1",
         "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1"
     ],
-    "cxflags": "-enable-machine-outliner=never",
+    "cxflags": "-mllvm -enable-machine-outliner=never",
     "driver_includes" : [
         "../include/platform/sunburst",
         "../include/platform/ibex",


### PR DESCRIPTION
This is necessary because the sonata simulator has an old version of the ISA that is not compatible with outlining. It was already disabled for sonata-prerelease but the simulator was missed. We should re-enable when the sonata is upgraded.
