### PR TITLE
Remove sched namespace in scheduler

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -1364,7 +1364,7 @@ extern "C" SchedulerEntryInfo loader_entry_point(const ImgHdr &imgHdr,
 	  build<ExportEntry>(
 	    imgHdr.scheduler().exportTable,
 	    LA_ABS(
-	      __export_scheduler__ZN5sched15exception_entryEP19TrustedStackGenericILj0EEjjj))
+	      __export_scheduler__Z15exception_entryP19TrustedStackGenericILj0EEjjj))
 	    ->functionStart;
 	auto schedExceptionEntry = build_pcc(imgHdr.scheduler());
 	schedExceptionEntry.address() += exceptionEntryOffset;
@@ -1460,8 +1460,7 @@ extern "C" SchedulerEntryInfo loader_entry_point(const ImgHdr &imgHdr,
 	// invoke the exception entry point.
 	auto exportEntry = build<ExportEntry>(
 	  imgHdr.scheduler().exportTable,
-	  LA_ABS(
-	    __export_scheduler__ZN5sched15scheduler_entryEPK16ThreadLoaderInfo));
+	  LA_ABS(__export_scheduler__Z15scheduler_entryPK16ThreadLoaderInfo));
 	schedPCC.address() += exportEntry->functionStart;
 
 	Debug::log("Will return to scheduler entry point: {}", schedPCC);

--- a/sdk/include/interrupt.h
+++ b/sdk/include/interrupt.h
@@ -72,7 +72,7 @@ struct InterruptCapabilityState
  */
 #define DECLARE_INTERRUPT_CAPABILITY(name)                                     \
 	DECLARE_STATIC_SEALED_VALUE(                                               \
-	  struct InterruptCapabilityState, sched, InterruptKey, name);
+	  struct InterruptCapabilityState, scheduler, InterruptKey, name);
 
 /**
  * Helper macro to define an interrupt capability.  The three arguments after


### PR DESCRIPTION
- **Fix scheduler compartment name used in DECLARE_INTERRUPT_CAPABILITY.**
- **Remove 'sched' namespace in scheduler.**
