### PR TITLE
Improve futex_wake behaviour.

### DIFF
--- a/sdk/include/platform/generic-riscv/platform-timer.hh
+++ b/sdk/include/platform/generic-riscv/platform-timer.hh
@@ -80,6 +80,18 @@ class StandardClint : private utils::NoCopyNoMove
 		*pmtimercmphigh = nextTime >> 32;
 	}
 
+	/**
+	 * Returns the time at which the next timer is scheduled.
+	 */
+	static uint64_t next()
+	{
+		volatile uint32_t *pmtimercmphigh = pmtimercmp + 1;
+		uint64_t           nextTimer      = *pmtimercmphigh;
+		nextTimer <<= 32;
+		nextTimer |= *pmtimercmp;
+		return nextTimer;
+	}
+
 	static void clear()
 	{
 		volatile uint32_t *pmtimercmphigh = pmtimercmp + 1;


### PR DESCRIPTION
The current code yields and schedules a new thread if any equal or higher-priority thread has become runnable.

The new code decomposes these cases.  If a new thread is runnable and should run now, the current thread yields.  If a new thread is runnable but is the same priority as the current thread, the scheduler ensures that a timer interrupt is ready but does not yield immediately.

This improves the test suite performance by around 2% and a producer-consumer microbenchmark by about 35%.