### PR TITLE
Fix some error cases in run-sonata.sh.

### DIFF
--- a/scripts/includes/helper_find_llvm_install.sh
+++ b/scripts/includes/helper_find_llvm_install.sh
@@ -32,7 +32,7 @@ find_llvm_tool_required() {
 	LLVM_TOOL=$(find_llvm_tool $1)
 
 	if [ ! -x ${LLVM_TOOL} ] ; then
-		echo Unable to locate $1, please set TOOLS_PATH to the directory containing the LLVM toolchain.
+		echo Unable to locate $1, please set TOOLS_PATH to the directory containing the LLVM toolchain. >&2
 		exit 1
 	fi
 

--- a/scripts/run-sonata.sh
+++ b/scripts/run-sonata.sh
@@ -9,10 +9,10 @@ SCRIPT_DIRECTORY="$(dirname "$(realpath "$0")")"
 
 OBJCOPY=$(find_llvm_tool_required llvm-objcopy)
 
-command -v uf2conv > /dev/null
-if [ ! $? ] ; then
+if ! command -v uf2conv > /dev/null ; then
 	echo "uf2conv not found.  On macOS / Linux systems with Python3 installed, you can install it with:"
 	echo "python3 -m pip install --pre -U git+https://github.com/makerdiary/uf2utils.git@main"
+	exit 1
 fi
 
 # Convert the ELF file to a binary file


### PR DESCRIPTION
1) In helper_find_llvm_install the error message was captured by $() so not visible, so print it to stderr instead.
2) Since set -e is on if command -v uf2conv failed the script would exit without printing an error.
