### PR TITLE
Add run script for sonata v1.

### DIFF
--- a/scripts/run-sonata-1.0.sh
+++ b/scripts/run-sonata-1.0.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+FIRMWARE_ELF=$1
+
+SCRIPT_DIRECTORY="$(dirname "$(realpath "$0")")"
+. ${SCRIPT_DIRECTORY}/includes/helper_find_llvm_install.sh
+
+STRIP=$(find_llvm_tool_required llvm-strip)
+
+if ! command -v uf2conv > /dev/null ; then
+	echo "uf2conv not found.  On macOS / Linux systems with Python3 installed, you can install it with:"
+	echo "python3 -m pip install --pre -U git+https://github.com/makerdiary/uf2utils.git@main"
+	exit 1
+fi
+
+# Strip the ELF file
+${STRIP} ${FIRMWARE_ELF} -o ${FIRMWARE_ELF}.strip
+# Convert the stripped elf to a UF2 (Microsoft USB Flashing Format) file
+uf2conv ${FIRMWARE_ELF}.strip -b0x00000000 -f0x6CE29E60 -co ${FIRMWARE_ELF}.slot1.uf2
+
+# Try to copy the firmware to the SONATA drive, if we can find one.
+try_copy()
+{
+	if [ -f $1/SONATA/OPTIONS.TXT ] ; then
+		cp ${FIRMWARE_ELF}.slot1.uf2 $1/SONATA/firmware.uf2
+		echo "Firmware copied to $1/SONATA/"
+		exit
+	fi
+}
+
+# Try some common mount points
+try_copy /Volumes/
+try_copy /run/media/$USER/
+try_copy /run/media/
+try_copy /mnt/
+
+cp ${FIRMWARE_ELF}.slot1.uf2 firmware.uf2
+
+echo "Please copy $(pwd)/firmware.uf2 to the SONATA drive to load."

--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -103,7 +103,7 @@
     "tickrate_hz" : 100,
     "revoker" : "hardware",
     "stack_high_water_mark" : true,
-    "simulator" : "${sdk}/../scripts/run-sonata.sh",
+    "simulator" : "${sdk}/../scripts/run-sonata-1.0.sh",
     "simulation": false,
     "interrupts": [
         {


### PR DESCRIPTION
This is very similar to the previous script except we strip the ELF instead of using objcopy -O bin and uf2conv uses the address for fw slot1 and sets the correct magic value.
Would to also generate uf2 files for slots 2 and 3 at the same time if desired.
