### PR TITLE
allocator-test: probe revocation in more places

### DIFF
--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -13,12 +13,6 @@ SECTIONS
 		*(.loader_start);
 	}
 
-	@thread_trusted_stacks@
-
-	__stack_space_start = .;
-	@thread_stacks@
-	__stack_space_end = .;
-
 	.compartment_export_tables : ALIGN(8)
 	{
 		# The scheduler and allocator's export tables are at the start.
@@ -83,8 +77,18 @@ SECTIONS
 	@software_revoker_code@
 
 	@pcc_ld@
-
 	__compart_pccs_end = .;
+
+	# Revoker scan region must be cap aligned
+	. = ALIGN(8);
+	__revoker_scan_start = .;
+	__stack_space_start = .;
+
+	@thread_trusted_stacks@
+
+	@thread_stacks@
+
+	__stack_space_end = .;
 
 	__compart_cgps = ALIGN(64);
 

--- a/sdk/include/platform/ibex/platform-hardware_revoker.hh
+++ b/sdk/include/platform/ibex/platform-hardware_revoker.hh
@@ -87,9 +87,9 @@ namespace Ibex
 			 * revoke capabilities everywhere from the start of compartment
 			 * globals to the end of the heap.
 			 */
-			extern char __compart_cgps, __export_mem_heap_end;
+			extern char __revoker_scan_start, __export_mem_heap_end;
 
-			auto  base   = LA_ABS(__compart_cgps);
+			auto  base   = LA_ABS(__revoker_scan_start);
 			auto  top    = LA_ABS(__export_mem_heap_end);
 			auto &device = revoker_device();
 			device.base  = base;


### PR DESCRIPTION
Explicitly test for revocation in all of globals, the stack, and the trusted stack.