### PR TITLE
s/simulator/run_command/

### DIFF
--- a/sdk/boards/ibex-arty-a7-100.patch
+++ b/sdk/boards/ibex-arty-a7-100.patch
@@ -71,7 +71,7 @@
     },
     {
       "op": "remove",
-      "path": "/simulator"
+      "path": "/run_command"
     }
   ]
 }

--- a/sdk/boards/ibex-safe-simulator.json
+++ b/sdk/boards/ibex-safe-simulator.json
@@ -49,5 +49,5 @@
     "revoker" : "hardware",
     "stack_high_water_mark" : true,
     "simulation": true,
-    "simulator" : "${sdk}/../scripts/run-ibex-safe-sim.sh"
+    "run_command" : "${sdk}/../scripts/run-ibex-safe-sim.sh"
 }

--- a/sdk/boards/sail.json
+++ b/sdk/boards/sail.json
@@ -38,6 +38,6 @@
     "tickrate_hz" : 10,
     "revoker" : "software",
     "stack_high_water_mark" : true,
-    "simulator" : "cheriot_sim",
+    "run_command" : "cheriot_sim",
     "simulation": true
 }

--- a/sdk/boards/sonata-0.2.json
+++ b/sdk/boards/sonata-0.2.json
@@ -84,6 +84,6 @@
     "tickrate_hz" : 100,
     "revoker" : "software",
     "stack_high_water_mark" : true,
-    "simulator" : "${sdk}/../scripts/run-sonata.sh",
+    "run_command" : "${sdk}/../scripts/run-sonata.sh",
     "simulation": false
 }

--- a/sdk/boards/sonata-prerelease.json
+++ b/sdk/boards/sonata-prerelease.json
@@ -103,7 +103,7 @@
     "tickrate_hz" : 100,
     "revoker" : "hardware",
     "stack_high_water_mark" : true,
-    "simulator" : "${sdk}/../scripts/run-sonata-1.0.sh",
+    "run_command" : "${sdk}/../scripts/run-sonata-1.0.sh",
     "simulation": false,
     "interrupts": [
         {

--- a/sdk/boards/sonata-simulator.patch
+++ b/sdk/boards/sonata-simulator.patch
@@ -8,7 +8,7 @@
     },
     {
       "op": "replace",
-      "path": "/simulator",
+      "path": "/run_command",
       "value": "${sdk}/../scripts/run-sonata-sim.sh"
     }
   ]

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -413,10 +413,10 @@ rule("firmware")
 		import("core.project.config")
 		local boarddir, boardfile = board_file_for_target(target)
 		local board = load_board_file(json, boardfile)
-		if not board.simulator then
+		if (not board.run_command) and (not board.simulator) then
 			raise("board description " .. boardfile .. " does not define a run command")
 		end
-		local simulator = board.simulator
+		local simulator = board.run_command or board.simulator
 		simulator = string.gsub(simulator, "${(%w*)}", { sdk=scriptdir, board=boarddir })
 		local firmware = target:targetfile()
 		local directory = path.directory(firmware)


### PR DESCRIPTION
Having two board description nodes at the same level, one called simulator and one called simulation is error prone and will cause people to be confused.

The simulator node is also now poorly named.  On Sonata, for example, it doesn't run a simulation, it loads onto the board.  The same will likely happen with ASICs.

Given that it's both ambiguous and just plain wrong, replace it with run_command.

The xmake still works with simulator, if someone has an out-of-tree board file.  This will go away at some point.