### PR TITLE
Adopt compiler support for sealed capabilities

### DIFF
--- a/examples/05.sealing/caller.cc
+++ b/examples/05.sealing/caller.cc
@@ -10,7 +10,7 @@ using Debug = ConditionalDebug<true, "Caller compartment">;
 /// Thread entry point.
 void __cheri_compartment("caller") entry()
 {
-	auto *identifier = identifier_create(42);
+	SealedIdentifier identifier = identifier_create(42);
 	Debug::log("Allocated identifier to hold the value 42: {}", identifier);
 	Debug::log("Value is {}", identifier_value(identifier));
 	identifier_destroy(identifier);

--- a/examples/05.sealing/identifier.cc
+++ b/examples/05.sealing/identifier.cc
@@ -30,7 +30,7 @@ static auto key()
 /**
  * Create a new identifier holding the specified value.
  */
-Identifier *identifier_create(int value)
+SealedIdentifier identifier_create(int value)
 {
 	// Allocate the identifier object and get back both sealed and unsealed
 	// capabilities.
@@ -51,7 +51,7 @@ Identifier *identifier_create(int value)
 /**
  * Returns the value held in a identifier.
  */
-int identifier_value(Identifier *identifier)
+int identifier_value(SealedIdentifier identifier)
 {
 	// Unseal the identifier.
 	auto *unsealedIdentifier =
@@ -68,9 +68,8 @@ int identifier_value(Identifier *identifier)
 /**
  * Destroy the identifier provided as an argument.
  */
-void identifier_destroy(Identifier *identifier)
+void identifier_destroy(SealedIdentifier identifier)
 {
 	// The allocator does validity checks here, so we can skip them.
-	token_obj_destroy(
-	  MALLOC_CAPABILITY, key(), reinterpret_cast<SObj>(identifier));
+	token_obj_destroy(MALLOC_CAPABILITY, key(), identifier);
 }

--- a/examples/05.sealing/identifier.h
+++ b/examples/05.sealing/identifier.h
@@ -5,6 +5,10 @@
 
 struct Identifier;
 
-__cheri_compartment("identifier") Identifier *identifier_create(int value);
-__cheri_compartment("identifier") int identifier_value(Identifier *identifier);
-__cheri_compartment("identifier") void identifier_destroy(Identifier *);
+typedef CHERI_SEALED(Identifier *) SealedIdentifier;
+
+__cheri_compartment("identifier") SealedIdentifier identifier_create(int value);
+__cheri_compartment("identifier") int identifier_value(
+  SealedIdentifier identifier);
+__cheri_compartment("identifier") void identifier_destroy(
+  SealedIdentifier identifier);

--- a/sdk/core/loader/debug.hh
+++ b/sdk/core/loader/debug.hh
@@ -132,8 +132,8 @@ namespace
 		/**
 		 * Append a capability.
 		 */
-		template<typename T>
-		__always_inline void append(CHERI::Capability<T> capability)
+		template<typename T, bool IsSealed>
+		__always_inline void append(CHERI::Capability<T, IsSealed> capability)
 		{
 			append(static_cast<const void *>(capability.get()));
 		}

--- a/sdk/core/scheduler/common.h
+++ b/sdk/core/scheduler/common.h
@@ -67,9 +67,9 @@ namespace
 		 * pointer to an object of the correct type.
 		 */
 		template<typename T>
-		static T *unseal(void *unsafePointer)
+		static T *unseal(CHERI_SEALED(void *) unsafePointer)
 		{
-			return static_cast<Handle *>(unsafePointer)->unseal_as<T>();
+			return reinterpret_cast<Handle *>(unsafePointer)->unseal_as<T>();
 		}
 
 		/**
@@ -85,13 +85,13 @@ namespace
 			void *result;
 			if constexpr (IsDynamic)
 			{
-				result = token_obj_unseal_dynamic(T::sealing_type(),
-				                                  reinterpret_cast<SObj>(this));
+				result = token_obj_unseal_dynamic(
+				  T::sealing_type(), reinterpret_cast<CHERI_SEALED(T *)>(this));
 			}
 			else
 			{
-				result = token_obj_unseal_static(T::sealing_type(),
-				                                 reinterpret_cast<SObj>(this));
+				result = token_obj_unseal_static(
+				  T::sealing_type(), reinterpret_cast<CHERI_SEALED(T *)>(this));
 			}
 			return static_cast<T *>(result);
 		}

--- a/sdk/core/scheduler/loaderinfo.h
+++ b/sdk/core/scheduler/loaderinfo.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <__cheri_sealed.h>
 #include <cstddef>
 #include <cstdint>
 
@@ -15,7 +16,7 @@ struct ThreadLoaderInfo
 {
 	/// The trusted stack for this thread. This field should be sealed by
 	/// the loader and contain populated PCC, CGP and CSP caps.
-	TrustedStack *trustedStack;
+	CHERI_SEALED(TrustedStack *) trustedStack;
 	/// Thread priority. The higher the more prioritised.
 	uint16_t priority;
 };

--- a/sdk/core/scheduler/multiwait.h
+++ b/sdk/core/scheduler/multiwait.h
@@ -97,298 +97,297 @@ namespace
 	static_assert(
 	  sizeof(EventWaiter) == (2 * sizeof(void *)),
 	  "Each waited event should consume only two pointers worth of memory");
+} // namespace
+
+/**
+ * Multiwaiter object.  This contains space for all of the triggers.
+ */
+class MultiWaiterInternal : public Handle</*IsDynamic*/ true>
+{
+	public:
+	/**
+	 * Sealing type used by `Handle`.
+	 */
+	static SKey sealing_type()
+	{
+		return STATIC_SEALING_TYPE(MultiWaiterKey);
+	}
+
+	private:
+	/**
+	 * We place a limit on the number of waiters in an event queue to
+	 * bound the time spent traversing them.
+	 */
+	static constexpr size_t MaxMultiWaiterSize = 8;
 
 	/**
-	 * Multiwaiter object.  This contains space for all of the triggers.
+	 * The maximum number of events in this multiwaiter.
 	 */
-	class MultiWaiterInternal : public Handle</*IsDynamic*/ true>
+	const uint8_t Length;
+	/**
+	 * The current number of events in this multiwaiter.
+	 */
+	uint8_t usedLength = 0;
+
+	/**
+	 * Multiwaiters are added to a list in between being triggered
+	 */
+	MultiWaiterInternal *next = nullptr;
+
+	/**
+	 * The array of events that we're waiting for.  This is variable sized
+	 * and must be the last field of the structure.
+	 */
+	EventWaiter events[];
+
+	public:
+	/**
+	 * Returns an iterator to the event waiters that this multiwaiter
+	 * contains.
+	 */
+	EventWaiter *begin()
 	{
-		public:
-		/**
-		 * Sealing type used by `Handle`.
-		 */
-		static SKey sealing_type()
+		return events;
+	}
+
+	/**
+	 * Returns an end iterator to the event waiters that this multiwaiter
+	 * contains.
+	 */
+	EventWaiter *end()
+	{
+		return events + usedLength;
+	}
+
+	/**
+	 * Returns the maximum number of event waiters that this is permitted
+	 * to hold.
+	 */
+	size_t capacity()
+	{
+		return Length;
+	}
+
+	/**
+	 * Returns the number of event waiters that this holds.
+	 */
+	size_t size()
+	{
+		return usedLength;
+	}
+
+	/**
+	 * Factory method.  Creates a multiwaiter of the specified size.  On
+	 * failure, sets `error` to the errno constant corresponding to the
+	 * failure reason and return `nullptr`.
+	 *
+	 * The result is a *sealed* multiwaiter handle.
+	 */
+	static CHERI_SEALED(MultiWaiterInternal *)
+	  create(Timeout            *timeout,
+	         AllocatorCapability heapCapability,
+	         size_t              length,
+	         int                &error)
+	{
+		static_assert(sizeof(MultiWaiterInternal) <= 2 * sizeof(void *),
+		              "Header for event queue is too large");
+		if (length > MaxMultiWaiterSize)
 		{
-			return STATIC_SEALING_TYPE(MultiWaiterKey);
+			error = -EINVAL;
+			return {};
 		}
-
-		private:
-		/**
-		 * We place a limit on the number of waiters in an event queue to
-		 * bound the time spent traversing them.
-		 */
-		static constexpr size_t MaxMultiWaiterSize = 8;
-
-		/**
-		 * The maximum number of events in this multiwaiter.
-		 */
-		const uint8_t Length;
-		/**
-		 * The current number of events in this multiwaiter.
-		 */
-		uint8_t usedLength = 0;
-
-		/**
-		 * Multiwaiters are added to a list in between being triggered
-		 */
-		MultiWaiterInternal *next = nullptr;
-
-		/**
-		 * The array of events that we're waiting for.  This is variable sized
-		 * and must be the last field of the structure.
-		 */
-		EventWaiter events[];
-
-		public:
-		/**
-		 * Returns an iterator to the event waiters that this multiwaiter
-		 * contains.
-		 */
-		EventWaiter *begin()
+		void *memory = nullptr;
+		CHERI_SEALED(void *)
+		sealed = token_sealed_unsealed_alloc(timeout,
+		                                     heapCapability,
+		                                     sealing_type(),
+		                                     sizeof(MultiWaiterInternal) +
+		                                       (length * sizeof(EventWaiter)),
+		                                     &memory);
+		if (!memory)
 		{
-			return events;
+			error = -ENOMEM;
+			return nullptr;
 		}
+		new (memory) MultiWaiterInternal(length);
+		error = 0;
+		return static_cast<CHERI_SEALED(MultiWaiterInternal *)>(sealed);
+	}
 
-		/**
-		 * Returns an end iterator to the event waiters that this multiwaiter
-		 * contains.
-		 */
-		EventWaiter *end()
-		{
-			return events + usedLength;
-		}
-
-		/**
-		 * Returns the maximum number of event waiters that this is permitted
-		 * to hold.
-		 */
-		size_t capacity()
-		{
-			return Length;
-		}
-
-		/**
-		 * Returns the number of event waiters that this holds.
-		 */
-		size_t size()
-		{
-			return usedLength;
-		}
-
-		/**
-		 * Factory method.  Creates a multiwaiter of the specified size.  On
-		 * failure, sets `error` to the errno constant corresponding to the
-		 * failure reason and return `nullptr`.
-		 *
-		 * The result is a *sealed* multiwaiter handle.
-		 */
-		static SObj create(Timeout           *timeout,
-		                   struct SObjStruct *heapCapability,
-		                   size_t             length,
-		                   int               &error)
-		{
-			static_assert(sizeof(MultiWaiterInternal) <= 2 * sizeof(void *),
-			              "Header for event queue is too large");
-			if (length > MaxMultiWaiterSize)
-			{
-				error = -EINVAL;
-				return {};
-			}
-			void *memory = nullptr;
-			SObj  sealed = token_sealed_unsealed_alloc(
-              timeout,
-              heapCapability,
-              sealing_type(),
-              sizeof(MultiWaiterInternal) + (length * sizeof(EventWaiter)),
-              &memory);
-			if (!memory)
-			{
-				error = -ENOMEM;
-				return nullptr;
-			}
-			new (memory) MultiWaiterInternal(length);
-			error = 0;
-			return sealed;
-		}
-
-		/**
-		 * Tri-state return from `set_events`.
-		 */
-		enum class EventOperationResult
-		{
-			/// Failure, report an error.
-			Error,
-			/// Success and an event fired already.
-			Wake,
-			/// Success but no events fired, sleep until one does.
-			Sleep
-		};
-
-		/**
-		 * Set the events provided by the user.  The caller is responsible for
-		 * ensuring that `newEvents` is a valid and usable capability and that
-		 * `count` is within the capacity of this object.
-		 */
-		EventOperationResult set_events(EventWaiterSource *newEvents,
-		                                size_t             count)
-		{
-			// Has any event triggered yet?
-			bool eventTriggered = false;
-			// Reset the events that this contains.
-			for (size_t i = 0; i < count; i++)
-			{
-				void *ptr     = newEvents[i].eventSource;
-				auto *address = static_cast<uint32_t *>(ptr);
-				if (!check_pointer<PermissionSet{Permission::Load}>(address))
-				{
-					return EventOperationResult::Error;
-				}
-				eventTriggered |= events[i].reset(address, newEvents[i].value);
-			}
-			usedLength = count;
-			return eventTriggered ? EventOperationResult::Wake
-			                      : EventOperationResult::Sleep;
-		}
-
-		/**
-		 * Destructor, ensures that nothing is waiting on this.
-		 */
-		~MultiWaiterInternal()
-		{
-			// Remove from the pending-wake list
-			remove_from_pending_wake_list();
-			// If this is on any threads that it's waiting on.
-			Thread::walk_thread_list(threads, [&](Thread *thread) {
-				if (thread->multiWaiter == this)
-				{
-					thread->multiWaiter = nullptr;
-					thread->ready(Thread::WakeReason::Timer);
-				}
-			});
-		}
-
-		/**
-		 * Function to handle the end of a multi-wait operation.  This collects
-		 * all of the results from each of the events and propagates them to
-		 * the query list.  The caller is responsible for ensuring that
-		 * `newEvents` is valid.
-		 */
-		bool get_results(EventWaiterSource *newEvents, size_t count)
-		{
-			// Remove ourself from the list of waiters.
-			remove_from_pending_wake_list();
-			// Collect all events that have fired.
-			Debug::Assert(
-			  count <= Length, "Invalid length {} > {}", count, Length);
-			bool found = false;
-			for (size_t i = 0; i < count; i++)
-			{
-				newEvents[i].value = events[i].readyEvents;
-				found |= (events[i].readyEvents != 0);
-			}
-			return found;
-		}
-
-		/**
-		 * Helper that should be called whenever an event of type `T` is ready.
-		 * This will always notify any waiters that have already been woken but
-		 * have not yet returned.  The `maxWakes` parameter can be used to
-		 * restrict the number of threads that are woken as a result of this
-		 * call.
-		 */
-		template<typename T>
-		static uint32_t
-		wake_waiters(T        source,
-		             uint32_t info     = 0,
-		             uint32_t maxWakes = std::numeric_limits<uint32_t>::max())
-		{
-			// Trigger any multiwaiters whose threads have been woken but which
-			// have not yet been scheduled.
-			for (auto *mw = wokenMultiwaiters; mw != nullptr; mw = mw->next)
-			{
-				mw->trigger(source);
-			}
-			// Look at any threads that are waiting on multiwaiters.  This
-			// should happen after waking the multiwaiters so that we don't
-			// visit multiwaiters twice
-			uint32_t woken = 0;
-			Thread::walk_thread_list(
-			  threads,
-			  [&](Thread *thread) {
-				  if (thread->multiWaiter->trigger(source))
-				  {
-					  thread->ready(Thread::WakeReason::MultiWaiter);
-					  woken++;
-					  thread->multiWaiter->next = wokenMultiwaiters;
-					  wokenMultiwaiters         = thread->multiWaiter;
-				  }
-			  },
-			  [&]() { return woken >= maxWakes; });
-			return woken;
-		}
-
-		/**
-		 * Wait on this multi-waiter object until either the timeout expires or
-		 * one or more events have fired.
-		 */
-		void wait(Timeout *timeout)
-		{
-			Thread *currentThread      = Thread::current_get();
-			currentThread->multiWaiter = this;
-			currentThread->suspend(timeout, &MultiWaiterInternal::threads);
-			currentThread->multiWaiter = nullptr;
-		}
-
-		private:
-		/**
-		 * Helper to remove this object from the list maintained for
-		 * multiwaiters that have been triggered but whose threads have not yet
-		 * been scheduled.
-		 */
-		void remove_from_pending_wake_list()
-		{
-			MultiWaiterInternal **prev = &wokenMultiwaiters;
-			while ((prev != nullptr) && (*prev != nullptr) && ((*prev) != this))
-			{
-				prev = &((*prev)->next);
-			}
-			if (prev != nullptr)
-			{
-				*prev = next;
-			}
-			next = nullptr;
-		}
-		/**
-		 * Deliver an event from the source to all possible waiting events in
-		 * this set.  This returns true if any of the event sources matches
-		 * this multiwaiter and the thread should be awoken.
-		 */
-		template<typename T>
-		bool trigger(T source, uint32_t info = 0)
-		{
-			bool shouldWake = false;
-			for (auto &registeredSource : *this)
-			{
-				shouldWake |= registeredSource.trigger(source);
-			}
-			return shouldWake;
-		}
-
-		/**
-		 * Private constructor, called only from the factory method (`create`).
-		 */
-		MultiWaiterInternal(size_t length) : Length(length) {}
-
-		/**
-		 * Priority-sorted wait queue for threads that are blocked on a
-		 * multiwaiter.
-		 */
-		static inline Thread *threads;
-
-		/**
-		 * List of multiwaiters whose threads have been woken but not yet run.
-		 */
-		static inline MultiWaiterInternal *wokenMultiwaiters = nullptr;
+	/**
+	 * Tri-state return from `set_events`.
+	 */
+	enum class EventOperationResult
+	{
+		/// Failure, report an error.
+		Error,
+		/// Success and an event fired already.
+		Wake,
+		/// Success but no events fired, sleep until one does.
+		Sleep
 	};
 
-} // namespace
+	/**
+	 * Set the events provided by the user.  The caller is responsible for
+	 * ensuring that `newEvents` is a valid and usable capability and that
+	 * `count` is within the capacity of this object.
+	 */
+	EventOperationResult set_events(EventWaiterSource *newEvents, size_t count)
+	{
+		// Has any event triggered yet?
+		bool eventTriggered = false;
+		// Reset the events that this contains.
+		for (size_t i = 0; i < count; i++)
+		{
+			void *ptr     = newEvents[i].eventSource;
+			auto *address = static_cast<uint32_t *>(ptr);
+			if (!check_pointer<PermissionSet{Permission::Load}>(address))
+			{
+				return EventOperationResult::Error;
+			}
+			eventTriggered |= events[i].reset(address, newEvents[i].value);
+		}
+		usedLength = count;
+		return eventTriggered ? EventOperationResult::Wake
+		                      : EventOperationResult::Sleep;
+	}
+
+	/**
+	 * Destructor, ensures that nothing is waiting on this.
+	 */
+	~MultiWaiterInternal()
+	{
+		// Remove from the pending-wake list
+		remove_from_pending_wake_list();
+		// If this is on any threads that it's waiting on.
+		Thread::walk_thread_list(threads, [&](Thread *thread) {
+			if (thread->multiWaiter == this)
+			{
+				thread->multiWaiter = nullptr;
+				thread->ready(Thread::WakeReason::Timer);
+			}
+		});
+	}
+
+	/**
+	 * Function to handle the end of a multi-wait operation.  This collects
+	 * all of the results from each of the events and propagates them to
+	 * the query list.  The caller is responsible for ensuring that
+	 * `newEvents` is valid.
+	 */
+	bool get_results(EventWaiterSource *newEvents, size_t count)
+	{
+		// Remove ourself from the list of waiters.
+		remove_from_pending_wake_list();
+		// Collect all events that have fired.
+		Debug::Assert(count <= Length, "Invalid length {} > {}", count, Length);
+		bool found = false;
+		for (size_t i = 0; i < count; i++)
+		{
+			newEvents[i].value = events[i].readyEvents;
+			found |= (events[i].readyEvents != 0);
+		}
+		return found;
+	}
+
+	/**
+	 * Helper that should be called whenever an event of type `T` is ready.
+	 * This will always notify any waiters that have already been woken but
+	 * have not yet returned.  The `maxWakes` parameter can be used to
+	 * restrict the number of threads that are woken as a result of this
+	 * call.
+	 */
+	template<typename T>
+	static uint32_t
+	wake_waiters(T        source,
+	             uint32_t info     = 0,
+	             uint32_t maxWakes = std::numeric_limits<uint32_t>::max())
+	{
+		// Trigger any multiwaiters whose threads have been woken but which
+		// have not yet been scheduled.
+		for (auto *mw = wokenMultiwaiters; mw != nullptr; mw = mw->next)
+		{
+			mw->trigger(source);
+		}
+		// Look at any threads that are waiting on multiwaiters.  This
+		// should happen after waking the multiwaiters so that we don't
+		// visit multiwaiters twice
+		uint32_t woken = 0;
+		Thread::walk_thread_list(
+		  threads,
+		  [&](Thread *thread) {
+			  if (thread->multiWaiter->trigger(source))
+			  {
+				  thread->ready(Thread::WakeReason::MultiWaiter);
+				  woken++;
+				  thread->multiWaiter->next = wokenMultiwaiters;
+				  wokenMultiwaiters         = thread->multiWaiter;
+			  }
+		  },
+		  [&]() { return woken >= maxWakes; });
+		return woken;
+	}
+
+	/**
+	 * Wait on this multi-waiter object until either the timeout expires or
+	 * one or more events have fired.
+	 */
+	void wait(Timeout *timeout)
+	{
+		Thread *currentThread      = Thread::current_get();
+		currentThread->multiWaiter = this;
+		currentThread->suspend(timeout, &MultiWaiterInternal::threads);
+		currentThread->multiWaiter = nullptr;
+	}
+
+	private:
+	/**
+	 * Helper to remove this object from the list maintained for
+	 * multiwaiters that have been triggered but whose threads have not yet
+	 * been scheduled.
+	 */
+	void remove_from_pending_wake_list()
+	{
+		MultiWaiterInternal **prev = &wokenMultiwaiters;
+		while ((prev != nullptr) && (*prev != nullptr) && ((*prev) != this))
+		{
+			prev = &((*prev)->next);
+		}
+		if (prev != nullptr)
+		{
+			*prev = next;
+		}
+		next = nullptr;
+	}
+	/**
+	 * Deliver an event from the source to all possible waiting events in
+	 * this set.  This returns true if any of the event sources matches
+	 * this multiwaiter and the thread should be awoken.
+	 */
+	template<typename T>
+	bool trigger(T source, uint32_t info = 0)
+	{
+		bool shouldWake = false;
+		for (auto &registeredSource : *this)
+		{
+			shouldWake |= registeredSource.trigger(source);
+		}
+		return shouldWake;
+	}
+
+	/**
+	 * Private constructor, called only from the factory method (`create`).
+	 */
+	MultiWaiterInternal(size_t length) : Length(length) {}
+
+	/**
+	 * Priority-sorted wait queue for threads that are blocked on a
+	 * multiwaiter.
+	 */
+	static inline Thread *threads;
+
+	/**
+	 * List of multiwaiters whose threads have been woken but not yet run.
+	 */
+	static inline MultiWaiterInternal *wokenMultiwaiters = nullptr;
+};

--- a/sdk/core/scheduler/thread.h
+++ b/sdk/core/scheduler/thread.h
@@ -11,14 +11,14 @@
 #include <tick_macros.h>
 #include <utils.hh>
 
+// Forward declaration of MultiWaiter so that we can use a pointer to it in
+// thread structures.
+class MultiWaiterInternal;
+
 namespace
 {
 	/// The total number of thread priorities.
 	constexpr uint16_t ThreadPrioNum = 32U;
-
-	// Forward declaration of MultiWaiter so that we can use a pointer to it in
-	// thread structures.
-	class MultiWaiterInternal;
 
 	uint64_t expiry_time_for_timeout(uint32_t timeout);
 
@@ -78,7 +78,8 @@ namespace
 		 * sealed capability to the trusted stack of the new thread, ready to be
 		 * installed.
 		 */
-		static TrustedStack *schedule(TrustedStack *tstack)
+		static CHERI_SEALED(TrustedStack *)
+		  schedule(CHERI_SEALED(TrustedStack *) tstack)
 		{
 			ThreadImpl *th = current;
 
@@ -189,9 +190,11 @@ namespace
 		 * This is also a sealed handle from the switcher, which can only be
 		 * used for comparison.
 		 */
-		static inline TrustedStack *schedTStack;
+		static inline CHERI_SEALED(TrustedStack *) schedTStack;
 
-		ThreadImpl(TrustedStack *tstack, uint16_t threadid, uint16_t priority)
+		ThreadImpl(CHERI_SEALED(TrustedStack *) tstack,
+		           uint16_t threadid,
+		           uint16_t priority)
 		  : threadId(threadid),
 		    priority(priority),
 		    OriginalPriority(priority),
@@ -617,7 +620,11 @@ namespace
 			 */
 			MultiWaiterInternal *multiWaiter;
 		};
-		TrustedStack *tStackPtr;
+
+		/**
+		 * Sealed pointer to this thread's trusted stack and register-save area.
+		 */
+		CHERI_SEALED(TrustedStack *) tStackPtr;
 
 		private:
 		/**

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -2189,7 +2189,7 @@ __Z39switcher_handler_invocation_count_resetv:
 // for library export tables, but since they don't consume RAM after loading
 // it's not urgent.
 	.section	.compartment_export_table,"a",@progbits
-export_table_start:
+.p2align	3
 .space 20, 0
 
 /**

--- a/sdk/core/token_library/token_unseal.S
+++ b/sdk/core/token_library/token_unseal.S
@@ -112,13 +112,14 @@ __sealingkey_dynamic:
  * An in-assembler implementation of
  *
  * [[cheri::interrupt_state(disabled)]] void *__cheri_libcall
- * token_obj_unseal(struct SKeyStruct *, struct SObjStruct *);
+ * token_obj_unseal(struct SKeyStruct *, void* __sealed_capability);
  *
  * The name has been manually mangled as per the C++ rules.
  */
 	.hidden _Z16token_obj_unsealP10SKeyStructP10SObjStruct
 	.globl  _Z16token_obj_unsealP10SKeyStructP10SObjStruct
 _Z16token_obj_unsealP10SKeyStructP10SObjStruct:
+_Z16token_obj_unsealP10SKeyStructU19__sealed_capabilityPv:
 	LoadCapPCC ca2, __sealingkey_either
 
 	/*
@@ -142,6 +143,7 @@ _Z16token_obj_unsealP10SKeyStructP10SObjStruct:
 	.hidden  _Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct
 	.globl   _Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct
 _Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct:
+_Z23token_obj_unseal_staticP10SKeyStructU19__sealed_capabilityPv:
 	LoadCapPCC ca2, __sealingkey_static
 	j          .Ltoken_unseal_internal
 
@@ -156,6 +158,7 @@ _Z23token_obj_unseal_staticP10SKeyStructP10SObjStruct:
 	.hidden  _Z24token_obj_unseal_dynamicP10SKeyStructP10SObjStruct
 	.globl   _Z24token_obj_unseal_dynamicP10SKeyStructP10SObjStruct
 _Z24token_obj_unseal_dynamicP10SKeyStructP10SObjStruct:
+_Z24token_obj_unseal_dynamicP10SKeyStructU19__sealed_capabilityPv:
 	LoadCapPCC ca2, __sealingkey_dynamic
 	j          .Ltoken_unseal_internal
 
@@ -172,5 +175,24 @@ CHERIOT_EXPORT_LIBCALL \
 
 CHERIOT_EXPORT_LIBCALL \
   _Z24token_obj_unseal_dynamicP10SKeyStructP10SObjStruct, \
+  0 /* No stack usage */, \
+  0b00010010 /* IRQs deferred, zero two registers */
+
+// TODO: For now, we export these with both names.  Eventually the ones above
+// can be garbage collected.  This doesn't make much difference because the
+// export table entries use memory that we can reuse for heap later.
+
+CHERIOT_EXPORT_LIBCALL \
+  _Z16token_obj_unsealP10SKeyStructU19__sealed_capabilityPv, \
+  0 /* No stack usage */, \
+  0b00010010 /* IRQs deferred, zero two registers */
+
+CHERIOT_EXPORT_LIBCALL \
+  _Z23token_obj_unseal_staticP10SKeyStructU19__sealed_capabilityPv, \
+  0 /* No stack usage */, \
+  0b00010010 /* IRQs deferred, zero two registers */
+
+CHERIOT_EXPORT_LIBCALL \
+  _Z24token_obj_unseal_dynamicP10SKeyStructU19__sealed_capabilityPv, \
   0 /* No stack usage */, \
   0b00010010 /* IRQs deferred, zero two registers */

--- a/sdk/include/__cheri_sealed.h
+++ b/sdk/include/__cheri_sealed.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#ifndef __ASSEMBLER__
+/**
+ * Macro to allow sealing to work with old and new compilers.  With new
+ * compilers, this will expand to a sealed version of the pointer type provided
+ * as the argument.  For old compilers it will expand to the opaque type that
+ * older versions of CHERIoT RTOS used for all sealed objects.
+ *
+ * You can explicitly opt into the old behaviour by defining
+ * `CHERIOT_NO_SEALED_POINTERS`.
+ */
+#	ifndef CHERI_SEALED
+#		if __has_extension(cheri_sealed_pointers) &&                          \
+		  !defined(CHERIOT_NO_SEALED_POINTERS)
+#			define CHERI_SEALED(T) T __sealed_capability
+#		else
+struct SObjStruct;
+typedef struct SObjStruct *SObj;
+#			define CHERI_SEALED(T) struct SObjStruct *
+#		endif
+#	endif
+#endif

--- a/sdk/include/cheri-builtins.h
+++ b/sdk/include/cheri-builtins.h
@@ -1,8 +1,9 @@
 // Copyright Microsoft and CHERIoT Contributors.
 // SPDX-License-Identifier: MIT
 
-#ifndef _CHERI_BUILTINS_
-#define _CHERI_BUILTINS_
+#pragma once
+
+#include <__cheri_sealed.h>
 
 #define CHERI_PERM_GLOBAL (1U << 0)
 #define CHERI_PERM_LOAD_GLOBAL (1U << 1)
@@ -103,7 +104,7 @@ static inline __always_inline auto cheri_seal(auto *x, auto *y)
 	return __builtin_cheri_seal(x, y);
 }
 
-static inline __always_inline auto cheri_unseal(auto *x, auto *y)
+static inline __always_inline auto cheri_unseal(CHERI_SEALED(auto *) x, auto *y)
 {
 	return __builtin_cheri_unseal(x, y);
 }
@@ -216,8 +217,10 @@ static inline __always_inline auto cheri_round_representable_length(size_t len)
 #		define cheri_permissions_get(x) __builtin_cheri_perms_get(x)
 #		define cheri_permissions_and(x, y) __builtin_cheri_perms_and((x), (y))
 #		define cheri_type_get(x) __builtin_cheri_type_get(x)
-#		define cheri_seal(a, b) __builtin_cheri_seal((a), (b))
-#		define cheri_unseal(a, b) __builtin_cheri_unseal((a), (b))
+#		define cheri_seal(a, b)                                               \
+			(CHERI_SEALED((__typeof__((a)))) __builtin_cheri_seal((a), (b)))
+#		define cheri_unseal(a, b)                                             \
+			((__typeof__(*(a)) *)__builtin_cheri_unseal((a), (b)))
 #		define cheri_bounds_set(a, b) __builtin_cheri_bounds_set((a), (b))
 #		define cheri_bounds_set_exact(a, b)                                   \
 			__builtin_cheri_bounds_set_exact((a), (b))
@@ -230,5 +233,3 @@ static inline __always_inline auto cheri_round_representable_length(size_t len)
 #	endif // __ASSEMBLER__
 
 #endif
-
-#endif // _CHERI_BUILTINS_

--- a/sdk/include/cheri.h
+++ b/sdk/include/cheri.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <__cheri_sealed.h>
 #include <compartment-macros.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -399,11 +399,11 @@ struct DebugFormatArgumentAdaptor<T>
  * Specialisation for the CHERI capability wrapper class, prints the capability
  * in the same format as bare pointers.
  */
-template<typename T>
-struct DebugFormatArgumentAdaptor<CHERI::Capability<T>>
+template<typename T, bool Sealed>
+struct DebugFormatArgumentAdaptor<CHERI::Capability<T, Sealed>>
 {
 	__always_inline static DebugFormatArgument
-	construct(CHERI::Capability<T> value)
+	construct(CHERI::Capability<T, Sealed> value)
 	{
 		return {reinterpret_cast<uintptr_t>(
 		          static_cast<const volatile void *>(value)),

--- a/sdk/include/event.h
+++ b/sdk/include/event.h
@@ -20,7 +20,6 @@
 #include <timeout.h>
 
 struct EventGroup;
-struct SObjStruct;
 
 /**
  * Create a new event group, allocated using `heapCapability`.  The event group
@@ -31,7 +30,7 @@ struct SObjStruct;
  * allocated it returns `-ENOMEM`.
  */
 int __cheri_libcall eventgroup_create(struct Timeout     *timeout,
-                                      struct SObjStruct  *heapCapability,
+                                      AllocatorCapability heapCapability,
                                       struct EventGroup **outGroup);
 
 /**
@@ -106,8 +105,8 @@ int __cheri_libcall eventgroup_get(struct EventGroup *group, uint32_t *outBits);
  * Destroy an event group.  This forces all waiters to wake and frees the
  * underlying memory.
  */
-int __cheri_libcall eventgroup_destroy(struct SObjStruct *heapCapability,
-                                       struct EventGroup *group);
+int __cheri_libcall eventgroup_destroy(AllocatorCapability heapCapability,
+                                       struct EventGroup  *group);
 
 /**
  * Destroy an event group without tacking the lock.
@@ -115,5 +114,5 @@ int __cheri_libcall eventgroup_destroy(struct SObjStruct *heapCapability,
  * This API is inherently racy. Its main purpose is to cleanup the event group
  * in an error handler context, when taking lock may be impossible.
  */
-int __cheri_libcall eventgroup_destroy_force(struct SObjStruct *heapCapability,
-                                             struct EventGroup *group);
+int __cheri_libcall eventgroup_destroy_force(AllocatorCapability heapCapability,
+                                             struct EventGroup  *group);

--- a/sdk/include/interrupt.h
+++ b/sdk/include/interrupt.h
@@ -68,6 +68,11 @@ struct InterruptCapabilityState
 };
 
 /**
+ * Type for sealed capabilities that authorise access to interrupts.
+ */
+typedef CHERI_SEALED(struct InterruptCapabilityState *) InterruptCapability;
+
+/**
  * Helper macro to forward declare an interrupt capability.
  */
 #define DECLARE_INTERRUPT_CAPABILITY(name)                                     \
@@ -98,7 +103,6 @@ struct InterruptCapabilityState
   name, number, mayWait, mayComplete)                                          \
 	DECLARE_INTERRUPT_CAPABILITY(name);                                        \
 	DEFINE_INTERRUPT_CAPABILITY(name, number, mayWait, mayComplete)
-struct SObjStruct;
 
 /**
  * Request the futex associated with an interrupt.  The argument is a sealed
@@ -109,7 +113,7 @@ struct SObjStruct;
  * Returns `nullptr` on failure.
  */
 __cheri_compartment("scheduler") const uint32_t *interrupt_futex_get(
-  struct SObjStruct *);
+  InterruptCapability interruptcapability);
 
 /**
  * Acknowledge the end of handling an interrupt.  The argument is a sealed
@@ -120,4 +124,5 @@ __cheri_compartment("scheduler") const uint32_t *interrupt_futex_get(
  * Returns 0 on success or `-EPERM` if the argument does not authorise this
  * operation.
  */
-__cheri_compartment("scheduler") int interrupt_complete(struct SObjStruct *);
+__cheri_compartment("scheduler") int interrupt_complete(
+  InterruptCapability interruptcapability);

--- a/sdk/include/multiwaiter.h
+++ b/sdk/include/multiwaiter.h
@@ -57,26 +57,31 @@ struct EventWaiterSource
 };
 
 /**
- * Opqaue type for multiwaiter objects.  Callers will always see this as a
+ * Structure used for the MultiWaiter inside the scheduler.
+ */
+struct MultiWaiterInternal;
+
+/**
+ * Opaque type for multiwaiter objects.  Callers will always see this as a
  * sealed object.
  */
-struct MultiWaiter;
+typedef CHERI_SEALED(struct MultiWaiterInternal *) MultiWaiter;
 
 /**
  * Create a multiwaiter object.  This is a stateful object that can wait on at
  * most `maxItems` event sources.
  */
 [[cheri::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
-  multiwaiter_create(Timeout             *timeout,
-                     struct SObjStruct   *heapCapability,
-                     struct MultiWaiter **ret,
-                     size_t               maxItems);
+  multiwaiter_create(Timeout            *timeout,
+                     AllocatorCapability heapCapability,
+                     MultiWaiter        *ret,
+                     size_t              maxItems);
 
 /**
  * Destroy a multiwaiter object.
  */
 [[cheri::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
-  multiwaiter_delete(struct SObjStruct *heapCapability, struct MultiWaiter *mw);
+  multiwaiter_delete(AllocatorCapability heapCapability, MultiWaiter mw);
 
 /**
  * Wait for events.  The first argument is the multiwaiter to wait on.  New
@@ -92,6 +97,6 @@ struct MultiWaiter;
  */
 [[cheri::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
   multiwaiter_wait(Timeout                  *timeout,
-                   struct MultiWaiter       *waiter,
+                   MultiWaiter               waiter,
                    struct EventWaiterSource *events,
                    size_t                    newEventsCount);

--- a/sdk/include/queue.h
+++ b/sdk/include/queue.h
@@ -92,7 +92,7 @@ ssize_t __cheri_libcall queue_allocation_size(size_t elementSize,
  * multiplied by the element size would overflow).
  */
 int __cheri_libcall queue_create(Timeout              *timeout,
-                                 struct SObjStruct    *heapCapability,
+                                 AllocatorCapability   heapCapability,
                                  struct MessageQueue **outQueue,
                                  size_t                elementSize,
                                  size_t                elementCount);
@@ -108,7 +108,7 @@ int __cheri_libcall queue_create(Timeout              *timeout,
  * This function will check the heap capability first and so will avoid
  * upgrading the locks if freeing the queue would fail.
  */
-int __cheri_libcall queue_destroy(struct SObjStruct   *heapCapability,
+int __cheri_libcall queue_destroy(AllocatorCapability  heapCapability,
                                   struct MessageQueue *handle);
 
 /**
@@ -161,10 +161,10 @@ int __cheri_libcall queue_items_remaining(struct MessageQueue *handle,
  */
 int __cheri_compartment("message_queue")
   queue_create_sealed(Timeout            *timeout,
-                      struct SObjStruct  *heapCapability,
-                      struct SObjStruct **outQueue,
-                      size_t              elementSize,
-                      size_t              elementCount);
+                      AllocatorCapability heapCapability,
+                      CHERI_SEALED(struct MessageQueue *) * outQueue,
+                      size_t elementSize,
+                      size_t elementCount);
 
 /**
  * Destroy a queue handle.  If this is called on a restricted endpoint
@@ -174,9 +174,9 @@ int __cheri_compartment("message_queue")
  * the queue.
  */
 int __cheri_compartment("message_queue")
-  queue_destroy_sealed(Timeout           *timeout,
-                       struct SObjStruct *heapCapability,
-                       struct SObjStruct *queueHandle);
+  queue_destroy_sealed(Timeout            *timeout,
+                       AllocatorCapability heapCapability,
+                       CHERI_SEALED(struct MessageQueue *) queueHandle);
 
 /**
  * Send a message via a sealed queue endpoint.  This behaves in the same way as
@@ -185,9 +185,9 @@ int __cheri_compartment("message_queue")
  * destroyed during the call.
  */
 int __cheri_compartment("message_queue")
-  queue_send_sealed(Timeout           *timeout,
-                    struct SObjStruct *handle,
-                    const void        *src);
+  queue_send_sealed(Timeout *timeout,
+                    CHERI_SEALED(struct MessageQueue *) handle,
+                    const void *src);
 
 /**
  * Receive a message via a sealed queue endpoint.  This behaves in the same way
@@ -196,7 +196,9 @@ int __cheri_compartment("message_queue")
  * queue is destroyed during the call.
  */
 int __cheri_compartment("message_queue")
-  queue_receive_sealed(Timeout *timeout, struct SObjStruct *handle, void *dst);
+  queue_receive_sealed(Timeout *timeout,
+                       CHERI_SEALED(struct MessageQueue *) handle,
+                       void *dst);
 
 /**
  * Returns, via `items`, the number of items in the queue specified by `handle`.
@@ -207,7 +209,8 @@ int __cheri_compartment("message_queue")
  * `-ECOMPARTMENTFAIL` for any failure case.
  */
 int __cheri_compartment("message_queue")
-  queue_items_remaining_sealed(struct SObjStruct *handle, size_t *items);
+  queue_items_remaining_sealed(CHERI_SEALED(struct MessageQueue *) handle,
+                               size_t *items);
 
 /**
  * Initialise an event waiter source so that it will wait for the queue to be
@@ -237,7 +240,8 @@ multiwaiter_queue_send_init(struct EventWaiterSource *source,
  */
 int __cheri_compartment("message_queue")
   multiwaiter_queue_receive_init_sealed(struct EventWaiterSource *source,
-                                        struct SObjStruct        *handle);
+                                        CHERI_SEALED(struct MessageQueue *)
+                                          handle);
 
 /**
  * Initialise an event waiter source as in `multiwaiter_queue_send_init`,
@@ -249,7 +253,8 @@ int __cheri_compartment("message_queue")
  */
 int __cheri_compartment("message_queue")
   multiwaiter_queue_send_init_sealed(struct EventWaiterSource *source,
-                                     struct SObjStruct        *handle);
+                                     CHERI_SEALED(struct MessageQueue *)
+                                       handle);
 
 /**
  * Convert a queue handle returned from `queue_create_sealed` into one that can
@@ -261,9 +266,10 @@ int __cheri_compartment("message_queue")
  */
 int __cheri_compartment("message_queue")
   queue_receive_handle_create_sealed(struct Timeout     *timeout,
-                                     struct SObjStruct  *heapCapability,
-                                     struct SObjStruct  *handle,
-                                     struct SObjStruct **outHandle);
+                                     AllocatorCapability heapCapability,
+                                     CHERI_SEALED(struct MessageQueue *) handle,
+                                     CHERI_SEALED(struct MessageQueue *) *
+                                       outHandle);
 
 /**
  * Convert a queue handle returned from `queue_create_sealed` into one that can
@@ -275,8 +281,9 @@ int __cheri_compartment("message_queue")
  */
 int __cheri_compartment("message_queue")
   queue_send_handle_create_sealed(struct Timeout     *timeout,
-                                  struct SObjStruct  *heapCapability,
-                                  struct SObjStruct  *handle,
-                                  struct SObjStruct **outHandle);
+                                  AllocatorCapability heapCapability,
+                                  CHERI_SEALED(struct MessageQueue *) handle,
+                                  CHERI_SEALED(struct MessageQueue *) *
+                                    outHandle);
 
 __END_DECLS

--- a/sdk/lib/event_group/event_group.cc
+++ b/sdk/lib/event_group/event_group.cc
@@ -33,9 +33,9 @@ struct EventGroup
 	EventWaiter waiters[];
 };
 
-int eventgroup_create(Timeout     *timeout,
-                      SObjStruct  *heapCapability,
-                      EventGroup **outGroup)
+int eventgroup_create(Timeout            *timeout,
+                      AllocatorCapability heapCapability,
+                      EventGroup        **outGroup)
 {
 	auto threads = thread_count();
 	if (threads == static_cast<uint16_t>(-1))
@@ -177,7 +177,8 @@ int eventgroup_get(EventGroup *group, uint32_t *outBits)
 	return 0;
 }
 
-int eventgroup_destroy_force(SObjStruct *heapCapability, EventGroup *group)
+int eventgroup_destroy_force(AllocatorCapability heapCapability,
+                             EventGroup         *group)
 {
 	group->lock.upgrade_for_destruction();
 	// Force all waiters to wake.
@@ -194,7 +195,7 @@ int eventgroup_destroy_force(SObjStruct *heapCapability, EventGroup *group)
 	return heap_free(heapCapability, group);
 }
 
-int eventgroup_destroy(SObjStruct *heapCapability, EventGroup *group)
+int eventgroup_destroy(AllocatorCapability heapCapability, EventGroup *group)
 {
 	group->lock.lock();
 	return eventgroup_destroy_force(heapCapability, group);

--- a/sdk/lib/queue/queue.cc
+++ b/sdk/lib/queue/queue.cc
@@ -335,7 +335,7 @@ namespace
 
 } // namespace
 
-int queue_destroy(struct SObjStruct   *heapCapability,
+int queue_destroy(AllocatorCapability  heapCapability,
                   struct MessageQueue *handle)
 {
 	int ret = 0;
@@ -393,7 +393,7 @@ ssize_t queue_allocation_size(size_t elementSize, size_t elementCount)
 }
 
 int queue_create(Timeout              *timeout,
-                 struct SObjStruct    *heapCapability,
+                 AllocatorCapability   heapCapability,
                  struct MessageQueue **outQueue,
                  size_t                elementSize,
                  size_t                elementCount)

--- a/sdk/lib/thread_pool/thread_pool.cc
+++ b/sdk/lib/thread_pool/thread_pool.cc
@@ -22,10 +22,10 @@ namespace
 
 } // namespace
 
-int thread_pool_async(ThreadPoolCallback fn, void *data)
+int thread_pool_async(ThreadPoolCallback fn, CHERI_SEALED(void *) data)
 {
-	Capability<void> fnCap{reinterpret_cast<void *>(fn)};
-	Capability<void> dataCap{data};
+	Capability<void>       fnCap{reinterpret_cast<void *>(fn)};
+	Capability<void, true> dataCap{data};
 	// The function must be sealed with the type used for export table entries
 	// for us to be able to invoke it.  The data capability doesn't *have* to
 	// be sealed, but it's a bad idea if it is unsealed because it adds the

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -1,7 +1,6 @@
 // Copyright Microsoft and CHERIoT Contributors.
 // SPDX-License-Identifier: MIT
 // Use a large quota for this compartment.
-#include "token.h"
 #define MALLOC_QUOTA 0x100000
 #define TEST_NAME "Allocator"
 
@@ -17,6 +16,7 @@
 #include <switcher.h>
 #include <thread.h>
 #include <thread_pool.h>
+#include <token.h>
 #include <vector>
 
 using thread_pool::async;
@@ -157,6 +157,7 @@ namespace
 
 			state = 1;
 
+#	if __has_builtin(__builtin_cheri_tag_get_temporal)
 			/* Check that globals are swept */
 			TEST(!__builtin_cheri_tag_get_temporal(pGlobal),
 			     "Revoker failed to sweep globals");
@@ -167,6 +168,7 @@ namespace
 
 			TEST(!__builtin_cheri_tag_get_temporal(unsealedToken->pointer),
 			     "Revoker failed to sweep static sealed cap");
+#	endif
 
 			/* Wait for the async thread to have performed its test */
 			sleeps = 0;

--- a/tests/multiwaiter-test.cc
+++ b/tests/multiwaiter-test.cc
@@ -19,7 +19,7 @@ int test_multiwaiter()
 	static uint32_t futex  = 0;
 	static uint32_t futex2 = 0;
 	int             ret;
-	MultiWaiter    *mw;
+	MultiWaiter     mw;
 	Timeout         t{0};
 	ret = multiwaiter_create(&t, MALLOC_CAPABILITY, &mw, 4);
 	TEST((ret == 0) && (mw != nullptr),

--- a/tests/queue-test.cc
+++ b/tests/queue-test.cc
@@ -105,11 +105,11 @@ void test_queue_sealed()
 {
 	auto    heapSpace = heap_quota_remaining(MALLOC_CAPABILITY);
 	Timeout t{1};
-	SObj    receiveHandle;
-	SObj    sendHandle;
-	SObj    queue;
-	char    bytes[ItemSize];
-	int     ret =
+	CHERI_SEALED(struct MessageQueue *) receiveHandle;
+	CHERI_SEALED(struct MessageQueue *) sendHandle;
+	CHERI_SEALED(struct MessageQueue *) queue;
+	char bytes[ItemSize];
+	int  ret =
 	  queue_create_sealed(&t, MALLOC_CAPABILITY, &queue, ItemSize, MaxItems);
 	TEST(ret == 0, "MessageQueue creation failed with {}", ret);
 	ret = queue_receive_handle_create_sealed(


### PR DESCRIPTION
This still supports the old mode and, because some existing code may require use of SObj, provides a compatibility mode for migration.

With the sealed branch of the compiler, there is a __sealed_capability qualifier.  This qualifier is part of the type system and sealed capabilities cannot be dereferenced (the hardware enforces this, now the compiler does as well).  The seal and unseal builtins are perform the conversion between a `T*` and a `T*__sealed_capability`.