### PR TITLE
Add Sonata 1.0 and 1.1 board descriptions.

### DIFF
--- a/sdk/boards/sonata-1.0.patch
+++ b/sdk/boards/sonata-1.0.patch
@@ -1,0 +1,15 @@
+{
+  "base": "sonata-1.1",
+  "patch": [
+    {
+      "op": "add",
+      "path": "/defines/0",
+      "value": "CHERIOT_NO_SAIL_83"
+    },
+    {
+      "op": "add",
+      "path": "/cxflags",
+      "value": "-mllvm -enable-machine-outliner=never"
+    }
+  ]
+}

--- a/sdk/boards/sonata-1.1.json
+++ b/sdk/boards/sonata-1.1.json
@@ -96,10 +96,8 @@
         "SUNBURST_SHADOW_SIZE=0x800",
         "ipconfigDRIVER_INCLUDED_RX_IP_CHECKSUM=1",
         "ipconfigDRIVER_INCLUDED_TX_IP_CHECKSUM=1",
-        "CHERIOT_NO_SAIL_83",
         "STDERR_TO_STDOUT=1"
     ],
-    "cxflags": "-mllvm -enable-machine-outliner=never",
     "driver_includes" : [
         "../include/platform/sunburst",
         "../include/platform/ibex",

--- a/sdk/boards/sonata-prerelease.patch
+++ b/sdk/boards/sonata-prerelease.patch
@@ -1,0 +1,4 @@
+{
+  "base": "sonata-1.1",
+  "patch": [ ]
+}

--- a/sdk/boards/sonata-simulator.patch
+++ b/sdk/boards/sonata-simulator.patch
@@ -1,5 +1,5 @@
 {
-  "base": "sonata-prerelease",
+  "base": "sonata-1.1",
   "patch": [
     {
       "op": "replace",

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -259,7 +259,7 @@ local function board_file_for_name(boardName)
 	-- The directory containing the board file.
 	local boarddir = path.directory(boardfile);
 	-- If this isn't a path, look in the boards directory
-	if path.basename(boardfile) == boardfile then
+	if not os.isfile(boardfile) then
 		boarddir = path.join(scriptdir, "boards")
 		local fullBoardPath = path.join(boarddir, boardfile .. '.json')
 		if not os.isfile(fullBoardPath) then


### PR DESCRIPTION
The -prerelease name is now gone, since everything we support is currently in a release.  We can resurrect it if needed.

1.0 is defined as a small diff on 1.1 (it adds some small tweaks to handle missing features.).