### PR TITLE
Add sprintf to stdio.

### DIFF
--- a/sdk/include/stdio.h
+++ b/sdk/include/stdio.h
@@ -8,6 +8,7 @@
 #include <compartment-macros.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <cheri-builtins.h>
 
 #define PRT_MAX_SIZE (0x80)
 #define EOF (-1)
@@ -65,10 +66,19 @@ static inline int printf(const char *format, ...)
 #endif
 
 int __cheri_libcall snprintf(char *str, size_t size, const char *format, ...);
-int __cheri_libcall vsnprintf(const char *str,
+int __cheri_libcall vsnprintf(char *str,
                               size_t      size,
                               const char *format,
                               va_list     ap);
+
+static inline int sprintf(char *str, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	int ret = vsnprintf(str, cheri_top_get(str) - cheri_address_get(str), format, args);
+	va_end(args);
+	return ret;
+}
 __END_DECLS
 
 #endif /* !__STDIO_H__ */

--- a/tests/stdio-test.cc
+++ b/tests/stdio-test.cc
@@ -12,12 +12,11 @@ int test_stdio()
 	const size_t BufferSize = 64;
 	char         buffer[BufferSize];
 	snprintf(buffer, BufferSize, "%d", 42);
-	TEST(strcmp(buffer, "42") == 0,
-	     "snprintf(\"%d\", 42) gave {}",
-	     std::string_view{buffer, BufferSize});
+	// Using std::string_view makes equality do string comparison
+	TEST_EQUAL(std::string_view(buffer), "42", "snprintf(\"%d\", 42) failed");
 	snprintf(buffer, BufferSize, "%d", -42);
-	TEST(strcmp(buffer, "-42") == 0,
-	     "snprintf(\"%d\", -42) gave {}",
-	     std::string_view{buffer, BufferSize});
+	TEST_EQUAL(std::string_view(buffer), "-42", "snprintf(\"%d\", -42) failed");
+	sprintf(buffer, "%x", 6 * 9);
+	TEST_EQUAL(std::string_view(buffer), "36", "sprintf(\"%x\", 6 * 9) failed");
 	return 0;
 }


### PR DESCRIPTION
We can use the length of the output capability to calculate the length to pass to vnsprintf, making sprintf safe! Also fixes an error in the prototype for vnsprintf.
