### PR TITLE
Add support for levels in the ConditionalDebug class.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,12 @@ jobs:
         include:
           - sonata: false
           - build-type: debug
-            build-flags: --debug-loader=y --debug-scheduler=y --debug-allocator=y --allocator-rendering=y -m debug
+            build-flags: --debug-loader=y --debug-scheduler=y --debug-allocator=information --allocator-rendering=y -m debug
           - build-type: release
-            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=n -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y
+            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=none -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y
           - board: sonata-simulator
             build-type: release
-            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=n -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y
+            build-flags: --debug-loader=n --debug-scheduler=n --debug-allocator=none -m release --stack-usage-check-allocator=y --stack-usage-check-scheduler=y
             sonata: true
       fail-fast: false
     runs-on: ubuntu-latest

--- a/scripts/run-sonata-sim.sh
+++ b/scripts/run-sonata-sim.sh
@@ -34,5 +34,6 @@ fi
 # Check to see if the output indicates failure
 if grep -i failure "${SONATA_SIMULATOR_UART_LOG}"; then
 	echo "Log output contained 'failure'"
+	cat "${SONATA_SIMULATOR_UART_LOG}"
 	exit 5
 fi

--- a/tests/debug-test.cc
+++ b/tests/debug-test.cc
@@ -2,6 +2,8 @@
 #include <compartment.h>
 #include <debug.h>
 
+using Warn = ConditionalDebug<DebugLevel::Warning, "Debug test">;
+
 int test_debug_cxx()
 {
 	unsigned char x = 'c';
@@ -19,5 +21,9 @@ int test_debug_cxx()
 	CHERIOT_INVARIANT(true, "Testing C++ invariant failure");
 	CHERIOT_INVARIANT(
 	  true, "Testing C++ invariant failure: 42:{}", 42, 1, 3, 4, "oops");
+	Warn::log<DebugLevel::Information>(
+	  "This should not be printed (information)");
+	Warn::log<DebugLevel::Warning>("This should be printed (warning)");
+	Warn::log<DebugLevel::Error>("This should be printed (error)");
 	return 0;
 }

--- a/tests/stack_integrity_thread.cc
+++ b/tests/stack_integrity_thread.cc
@@ -129,7 +129,7 @@ int exhaust_thread_stack_spill(__cheri_callback int (*fn)())
 	  : /* clobbers */ "ct2", "cs0", "cs1");
 
 	*threadStackTestFailed = false;
-	TEST(res == -ENOTENOUGHSTACK, "Bad return {}", res);
+	TEST_EQUAL(res, -ENOTENOUGHSTACK, "Bad return value for stack exhaustion");
 
 	return 0;
 }

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -63,16 +63,17 @@ namespace
 extern "C" enum ErrorRecoveryBehaviour
 compartment_error_handler(struct ErrorState *frame, size_t mcause, size_t mtval)
 {
+	debug_log("mcause: {}, pcc: {}, cra: {}",
+	          mcause,
+	          frame->pcc,
+	          frame->get_register_value<RegisterNumber::CRA>());
+	auto [reg, cause] = CHERI::extract_cheri_mtval(mtval);
+	debug_log("Error {} in register {}", reg, cause);
 	if (mcause == 0x2)
 	{
 		debug_log("Test failure in test runner");
 		simulation_exit(1);
 	}
-	debug_log("mcause: {}, pcc: {}", mcause, frame->pcc);
-	auto [reg, cause] = CHERI::extract_cheri_mtval(mtval);
-	debug_log("Error {} in register {}", reg, cause);
-	debug_log("Current test crashed");
-	crashDetected = true;
 	return ErrorRecoveryBehaviour::InstallContext;
 }
 

--- a/tests/tests.hh
+++ b/tests/tests.hh
@@ -39,7 +39,7 @@ using Test = ConditionalDebug<true,
 template<typename... Args>
 void debug_log(const char *fmt, Args... args)
 {
-	Test::log(fmt, args...);
+	Test::log(fmt, std::forward<Args>(args)...);
 }
 
 #define TEST(cond, msg, ...) Test::Invariant((cond), msg, ##__VA_ARGS__)


### PR DESCRIPTION
The class is now instantiated with a threshold level, from None to Error (for backwards compatibility, true means Information and false means None).

Log messages also provide a log level (Information if none is provided) and will fire if the log level is greater than or equal to the threshold.