### PR TITLE
event_group: thread IDs are 1-indexed

### DIFF
--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -68,6 +68,12 @@ enum ThreadSleepFlags : uint32_t
  * This is mostly useful where one compartment can run under different threads
  * and it matters which thread entered this compartment.
  *
+ * User threads (that is, those defined in the xmake firmware configuration)
+ * are 1-indexed, with 0 indicating primordial idle and scheduling contexts.
+ * Those contexts are very restricted in what it can do, so almost surely
+ * subtract one from the returned ID if it's being used as an index into an
+ * array.
+ *
  * This is implemented in the switcher.
  */
 uint16_t __cheri_libcall thread_id_get(void);
@@ -89,7 +95,8 @@ __cheri_compartment("scheduler") uint64_t thread_elapsed_cycles_idle(void);
 __cheri_compartment("scheduler") uint64_t thread_elapsed_cycles_current(void);
 
 /**
- * Returns the number of threads, including threads that have exited.
+ * Returns the number of user threads (that is, those defined in the xmake
+ * firmware configuration), including threads that have exited.
  *
  * This API never fails, but if the trusted stack is exhausted  and it cannot
  * be called then it will return -1.  Callers that have not probed the trusted

--- a/sdk/lib/event_group/event_group.cc
+++ b/sdk/lib/event_group/event_group.cc
@@ -71,7 +71,7 @@ int eventgroup_wait(Timeout    *timeout,
 		return (waitForAll ? ((bitsWanted & bits) == bitsWanted)
 		                   : ((bitsWanted & bits) != 0));
 	};
-	auto    &waiter = group->waiters[thread_id_get()];
+	auto    &waiter = group->waiters[thread_id_get() - 1];
 	uint32_t bitsSeen;
 	// Set up our state for the waiter with the lock held.
 	if (LockGuard g{group->lock, timeout})


### PR DESCRIPTION
While here, add a note for future users of `thread_id_get`.  At a glance, nobody else in-tree is yet indexing quite like this, and [the scheduler](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/7da05da6e1f7bb517b4d0517b0f0dd4cb69a7142/sdk/core/scheduler/main.cc#L203-L210) is already doing the right thing (or we'd probably have noticed a lot sooner).

This has been lurking for a long while, at least since b5692081e26fb7ad9c0a1bde3eb059d6037d1336.