### PR TITLE
Allow providing an explicit type for static sealed things.

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -207,20 +207,43 @@
  *
  * The object created with this macro can be accessed only by code that has
  * access to the sealing key.
+ *
+ * Unlike `DECLARE_STATIC_SEALED_VALUE`, this allows the type that value should
+ * be read as to be different to the type used to initialise it.  The type of
+ * the value in `STATIC_SEALED_VALUE` will be `CHERI_SEALED(valueType*)`.  This
+ * is useful for variable length arrays at the end of the structure.
  */
-#define DECLARE_STATIC_SEALED_VALUE(type, compartment, keyName, name)          \
-	struct __##name##_type; /* NOLINT(bugprone-macro-parentheses) */           \
+#define DECLARE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                             \
+  type, valueType, compartment, keyName, name)                                 \
 	/* Implementation detail: This declaration in the reserved namespace       \
 	 * exists only so that __typeof__ can be used later to determine the       \
 	 * original type.  This will be removed once the compiler understands      \
 	 * static sealed objects natively. */                                      \
-	extern type __sealed_type_placeholder_##name;                              \
+	extern valueType __sealed_type_placeholder_##name;                         \
 	extern __if_cxx("C") struct __##name##_type                                \
 	{                                                                          \
 		uint32_t key;                                                          \
 		uint32_t padding;                                                      \
 		type     body;                                                         \
-	} name /* NOLINT(bugprone-macro-parentheses) */
+	} name; /* NOLINT(bugprone-macro-parentheses) */                           \
+	/* Make sure the type that we're casting this to is not bigger than the    \
+	 * value that we've emitted. */                                            \
+	_Static_assert(sizeof(__sealed_type_placeholder_##name) <=                 \
+	               sizeof(name.body))
+
+/**
+ * Forward-declare a static sealed object.  This declares an object of type
+ * `type` that can be referenced with the `STATIC_SEALED_VALUE` macro using
+ * `name`.  The pointer returned by the latter macro will be sealed with the
+ * sealing key exported from `compartment` as `keyName` with the
+ * `STATIC_SEALING_TYPE` macro.
+ *
+ * The object created with this macro can be accessed only by code that has
+ * access to the sealing key.
+ */
+#define DECLARE_STATIC_SEALED_VALUE(type, compartment, keyName, name)          \
+	DECLARE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                                 \
+	  type, type, compartment, keyName, name)
 
 /**
  * Define a static sealed object.  This creates an object of type `type`,
@@ -245,11 +268,18 @@
 
 /**
  * Helper macro that declares and defines a sealed value.
+ *
+ * Unlike `DECLARE_AND_DEFINE_STATIC_SEALED_VALUE`, this allows the type that
+ * value should be read as to be different to the type used to initialise it.
+ * The type of the value in `STATIC_SEALED_VALUE` will be
+ * `CHERI_SEALED(valueType*)`.  This is useful for variable length arrays at
+ * the end of the structure.
  */
-#define DECLARE_AND_DEFINE_STATIC_SEALED_VALUE(                                \
-  type, compartment, keyName, name, initialiser, ...)                          \
-	DECLARE_STATIC_SEALED_VALUE(                                               \
+#define DECLARE_AND_DEFINE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                  \
+  type, valueType, compartment, keyName, name, initialiser, ...)               \
+	DECLARE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                                 \
 	  type,                                                                    \
+	  valueType,                                                               \
 	  compartment,                                                             \
 	  keyName,                                                                 \
 	  name); /* NOLINT(bugprone-macro-parentheses) */                          \
@@ -260,6 +290,14 @@
 	  name,                                                                    \
 	  initialiser,                                                             \
 	  ##__VA_ARGS__); /* NOLINT(bugprone-macro-parentheses) */
+
+/**
+ * Helper macro that declares and defines a sealed value.
+ */
+#define DECLARE_AND_DEFINE_STATIC_SEALED_VALUE(                                \
+  type, compartment, keyName, name, initialiser, ...)                          \
+	DECLARE_AND_DEFINE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                      \
+	  type, type, compartment, keyName, name, initialiser, ##__VA_ARGS__)
 
 /**
  * Returns a sealed capability to the named object created with


### PR DESCRIPTION
This makes the use case of variable-sized software capabilities (flexible array member) simpler.