### PR TITLE
Fix clang-tidy warnings in compartment-macros.h

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -225,11 +225,11 @@
 		uint32_t key;                                                          \
 		uint32_t padding;                                                      \
 		type     body;                                                         \
-	} name; /* NOLINT(bugprone-macro-parentheses) */                           \
+	}(name);                                                                   \
 	/* Make sure the type that we're casting this to is not bigger than the    \
 	 * value that we've emitted. */                                            \
 	_Static_assert(sizeof(__sealed_type_placeholder_##name) <=                 \
-	               sizeof(name.body))
+	               sizeof((name).body))
 
 /**
  * Forward-declare a static sealed object.  This declares an object of type


### PR DESCRIPTION
CI is currently failing in main due to this somehow slipping through. The brackets are never actually needed because the macro will probably fail horribly if name is not a single token, but this mollifies clang-tidy.