### PR TITLE
Fix compilation error in Sonata 0.2 GPIO driver.

### DIFF
--- a/sdk/include/platform/sunburst/v0.2/platform-gpio.hh
+++ b/sdk/include/platform/sunburst/v0.2/platform-gpio.hh
@@ -91,11 +91,11 @@ struct SonataGPIO
 	/**
 	 * The bit index of the first GPIO pin connected to a user switch.
 	 */
-	static constexpr uint32_t FirstSwitch = Sonata1OrLater ? 0 : 5;
+	static constexpr uint32_t FirstSwitch = 5;
 	/**
 	 * The bit index of the last GPIO pin connected to a user switch.
 	 */
-	static constexpr uint32_t LastSwitch = Sonata1OrLater ? 7 : 13;
+	static constexpr uint32_t LastSwitch = 13;
 	/**
 	 * The number of user switches.
 	 */


### PR DESCRIPTION
This was introduced when merging https://github.com/CHERIoT-Platform/cheriot-rtos/pull/437 but noone noticed because we have no CI for sonata 0.2 and everyone migrated to 1.0.