### PR TITLE
tests.extra/regress-double_ref_shared

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -23,7 +23,7 @@
 		__asm(".ifndef " mangledName "\n"                                      \
 		      "  .type     " mangledName ",@object\n"                          \
 		      "  .section  .compartment_imports." #name                        \
-		      ",\"awG\",@progbits," #name ",comdat\n"                          \
+		      ",\"awG\",@progbits," mangledName ",comdat\n"                    \
 		      "  .globl    " mangledName "\n"                                  \
 		      "  .p2align  3\n" mangledName ":\n"                              \
 		      "  .word " #prefix #name "\n"                                    \

--- a/tests.extra/regress-double_ref_shared/README.md
+++ b/tests.extra/regress-double_ref_shared/README.md
@@ -1,0 +1,3 @@
+This exhibits one compartment with two compilatioon units that each reference a
+shared object with different permissions.  Because of the differing permissions,
+two import entries should be created.

--- a/tests.extra/regress-double_ref_shared/common.h
+++ b/tests.extra/regress-double_ref_shared/common.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <compartment-macros.h>
+
+struct Foo
+{
+	int bar;
+};
+
+void top1();
+void top2();
+
+int __cheri_compartment("top") entry();

--- a/tests.extra/regress-double_ref_shared/top1.cc
+++ b/tests.extra/regress-double_ref_shared/top1.cc
@@ -1,0 +1,17 @@
+#include "common.h"
+
+void top1()
+{
+	auto ref1 =
+	  SHARED_OBJECT_WITH_PERMISSIONS(struct Foo, foo, true, true, false, false);
+
+	ref1->bar = 1;
+}
+
+int entry()
+{
+	top1();
+	top2();
+
+	return 0;
+}

--- a/tests.extra/regress-double_ref_shared/top2.cc
+++ b/tests.extra/regress-double_ref_shared/top2.cc
@@ -1,0 +1,13 @@
+#include "common.h"
+
+#include <debug.hh>
+
+using Debug = ConditionalDebug<true, "top2">;
+
+void top2()
+{
+	auto ref2 = SHARED_OBJECT_WITH_PERMISSIONS(
+	  struct Foo, foo, true, false, false, false);
+
+	Debug::log("ref2: {}", ref2->bar);
+}

--- a/tests.extra/regress-double_ref_shared/xmake.lua
+++ b/tests.extra/regress-double_ref_shared/xmake.lua
@@ -1,0 +1,31 @@
+set_project("CHERIoT Scheduler IRQ Exception PoC")
+sdkdir = "../../sdk"
+includes(sdkdir)
+set_toolchains("cheriot-clang")
+
+option("board")
+    set_default("sail")
+
+compartment("top")
+    add_files("top1.cc")
+    add_files("top2.cc")
+
+    on_load(function(target)
+      target:values_set("shared_objects", { foo = 4 }, {expand = false})
+    end)
+
+firmware("top_compartment")
+    add_deps("freestanding", "debug")
+    add_deps("top")
+    on_load(function(target)
+        target:values_set("board", "$(board)")
+        target:values_set("threads", {
+            {
+                compartment = "top",
+                priority = 1,
+                entry_point = "entry",
+                stack_size = 0x200,
+                trusted_stack_frames = 1
+            }
+        }, {expand = false})
+    end)


### PR DESCRIPTION
This currently fails to link with...

```
/cheri/out/cheriot/sdk/bin/ld.lld -n --script=../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/top_compartment-firmware.ldscript --relax -o ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/top_compartment --compartment-report=../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/top_compartment.json ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/.objs/cheriot.loader/cheriot/cheriot/release/__/__/sdk/core/loader/boot.S.o ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/.objs/cheriot.loader/cheriot/cheriot/release/__/__/sdk/core/loader/boot.cc.o ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/.objs/cheriot.switcher/cheriot/cheriot/release/__/__/sdk/core/switcher/entry.S.o ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/atomic1.library ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/atomic4.library ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/cheriot.allocator.compartment ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/compartment_helpers.library ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/locks.library ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/cheriot.token_library.library ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/crt.library ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/debug.library ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/freestanding.library ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/top.compartment ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/top_compartment.scheduler.compartment
ld.lld: error: ../../../../../build/cheriot/cheriot-rtos/regress-double/build.sonata/cheriot/cheriot/release/top.compartment:(function top2(): .text+0x26): relocation against symbol __import_cheriot_shared_object_foo_true_false_false_false which is not defined
```

FWIW, `top1.cc.o` contains
```
00000000 g     O .compartment_imports.foo       00000008 __import_cheriot_shared_object_foo_true_true_false_false
```
and `top2.cc.o` contains
```
00000000 g     O .compartment_imports.foo       00000008 __import_cheriot_shared_object_foo_true_false_false_false
```