### PR TITLE
Pass -fno-builtin-printf, too

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -139,6 +139,7 @@ toolchain("cheriot-clang")
 			"-fomit-frame-pointer",
 			"-fno-builtin-setjmp",
 			"-fno-builtin-longjmp",
+			"-fno-builtin-printf",
 			"-fno-exceptions",
 			"-fno-asynchronous-unwind-tables",
 			"-fno-c++-static-destructors",


### PR DESCRIPTION
Otherwise, for example, building our network stack's MQTT compartment with debugging will get some of its printf()s replaced with putchar() and puts(), which we don't have.