### PR TITLE
Enable printing function pointers using debug::log.

### DIFF
--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -388,7 +388,7 @@ struct DebugFormatArgumentAdaptor<T>
 	__always_inline static DebugFormatArgument construct(T value)
 	{
 		return {reinterpret_cast<uintptr_t>(
-		          static_cast<const volatile void *>(value)),
+		          reinterpret_cast<const volatile void *>(value)),
 		        DebugFormatArgumentKind::DebugFormatArgumentPointer};
 	}
 };

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -121,6 +121,7 @@ int __cheri_compartment("test_runner") run_tests()
 	debug_log("Trying to print unsigned 32-bit integer: {}", 0x12345U);
 	debug_log("Trying to print unsigned 64-bit integer: {}",
 	          0x123456789012345ULL);
+	debug_log("Trying to print function pointer {}", compartment_error_handler);
 	const char *testString = "Hello, world! with some trailing characters";
 	// Make sure that we don't print the trailing characters
 	debug_log("Trying to print std::string_view: {}",


### PR DESCRIPTION
This requires a reinterpret_cast rather than a static cast.