### PR TITLE
Reduce scheduler permissions slightly.

### DIFF
--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -539,7 +539,12 @@ __cheriot_minimum_stack(0xb0) int futex_timed_wait(Timeout        *timeout,
 __cheriot_minimum_stack(0xa0) int futex_wake(uint32_t *address, uint32_t count)
 {
 	STACK_CHECK(0xa0);
-	if (!check_pointer<PermissionSet{Permission::Store}>(address))
+	// Futex wake requires you to have a valid pointer, but doesn't require any
+	// permissions.  This allows some things to trigger spurious wakes, but
+	// ensures that the scheduler never needs a writeable capability to a
+	// futex.  This means that the worst a malicious scheduler can do is
+	// trigger spurious wakes, which the API permits and callers must handle.
+	if (!check_pointer<PermissionSet{}>(address))
 	{
 		return -EINVAL;
 	}

--- a/sdk/include/c++-config/atomic
+++ b/sdk/include/c++-config/atomic
@@ -250,7 +250,7 @@ __clang_ignored_warning_push("-Watomic-alignment") namespace std
 			__always_inline void
 			wait(T            old,
 			     memory_order order = memory_order::seq_cst) const noexcept
-			  requires(sizeof(T) == sizeof(uint32_t))
+			    requires(sizeof(T) == sizeof(uint32_t))
 			{
 				futex_wait(reinterpret_cast<const uint32_t *>(&value),
 				           reinterpret_cast<uint32_t>(as_underlying(old)));
@@ -261,48 +261,56 @@ __clang_ignored_warning_push("-Watomic-alignment") namespace std
 			     T              old,
 			     memory_order   order = memory_order::seq_cst,
 			     FutexWaitFlags flags = FutexNone) const noexcept
-			  requires(sizeof(T) == sizeof(uint32_t))
+			    requires(sizeof(T) == sizeof(uint32_t))
 			{
+				// FIXME: The (1<<5) here should be
+				// __CHERI_CAP_PERMISSION_PERMIT_LOAD__, but currently our
+				// compiler provides the wrong value for this pre-defined macro.
 				return futex_timed_wait(
 				  timeout,
-				  reinterpret_cast<const uint32_t *>(&value),
+				  reinterpret_cast<const uint32_t *>(
+				    __builtin_cheri_perms_and(&value, (1 << 5))),
 				  static_cast<uint32_t>(as_underlying(old)),
 				  flags);
 			}
 
 			__always_inline int
 			wait(Timeout *timeout, T old, FutexWaitFlags flags) const noexcept
-			  requires(sizeof(T) == sizeof(uint32_t))
+			    requires(sizeof(T) == sizeof(uint32_t))
 			{
 				return wait(timeout, old, memory_order::seq_cst, flags);
 			}
 
 			__always_inline void
 			wait(T old, memory_order order = memory_order::seq_cst) const
-			  volatile noexcept requires(sizeof(T) == sizeof(uint32_t))
+			  volatile noexcept
+			    requires(sizeof(T) == sizeof(uint32_t))
 			{
 				const_cast<primitive_atomic<T> *>(this)->wait(old, order);
 			}
 
 			__always_inline void notify_one() noexcept
-			  requires(sizeof(T) == sizeof(uint32_t))
+			    requires(sizeof(T) == sizeof(uint32_t))
 			{
-				(void)futex_wake(reinterpret_cast<uint32_t *>(&value), 1);
+				(void)futex_wake(reinterpret_cast<uint32_t *>(
+				                   __builtin_cheri_perms_and(&value, 0)),
+				                 1);
 			}
 			__always_inline void notify_one() volatile noexcept
-			  requires(sizeof(T) == sizeof(uint32_t))
+			    requires(sizeof(T) == sizeof(uint32_t))
 			{
 				const_cast<primitive_atomic<T> *>(this)->notify_one();
 			}
 
 			__always_inline void notify_all() noexcept
-			  requires(sizeof(T) == sizeof(uint32_t))
+			    requires(sizeof(T) == sizeof(uint32_t))
 			{
-				(void)futex_wake(reinterpret_cast<uint32_t *>(&value),
+				(void)futex_wake(reinterpret_cast<uint32_t *>(
+				                   __builtin_cheri_perms_and(&value, 0)),
 				                 std::numeric_limits<uint32_t>::max());
 			}
 			__always_inline void notify_all() volatile noexcept
-			  requires(sizeof(T) == sizeof(uint32_t))
+			    requires(sizeof(T) == sizeof(uint32_t))
 			{
 				const_cast<primitive_atomic<T> *>(this)->notify_all();
 			}
@@ -669,7 +677,7 @@ __clang_ignored_warning_push("-Watomic-alignment") namespace std
 			{
 				return *const_cast<locked_atomic<T> *>(this) = desired;
 			}
-			locked_atomic &operator=(const locked_atomic &) = delete;
+			locked_atomic &operator=(const locked_atomic &)          = delete;
 			locked_atomic &operator=(const locked_atomic &) volatile = delete;
 
 			__always_inline void

--- a/sdk/include/futex.h
+++ b/sdk/include/futex.h
@@ -67,10 +67,14 @@ __always_inline static int futex_wait(const uint32_t *address,
  * Wakes up to `count` threads that are sleeping with `futex[_timed]_wait` on
  * `address`.
  *
- * The `address` argument must permit storing four bytes of data after the
- * address. This call does not store to the address but requiring store
- * permission prevents a thread from waking up a futex that it cannot possibly
- * have moved to a different state.
+ * The `address` argument must be a valid, unsealed, pointer with a length of at
+ * least four after the address but the scheduler does not require any explicit
+ * permissions.  The scheduler never needs store access to the futex word.
+ * Removing store permission means that a compromised scheduler can cause
+ * spurious wakes but cannot tamper with the futex word.  If, for example, the
+ * futex word is a lock then the scheduler can wake threads that are blocked on
+ * the lock but cannot release the lock and so cannot make two threads believe
+ * that they have simultaneously acquired the same lock.
  *
  * The return value for a successful call is the number of threads that were
  * woken.  `-EINVAL` is returned for invalid arguments.

--- a/tests/futex-test.cc
+++ b/tests/futex-test.cc
@@ -82,11 +82,8 @@ int test_futex()
 	fcap.permissions() &=
 	  PermissionSet::omnipotent().without(Permission::Store);
 	ret = futex_wake(fcap, 1);
-	TEST(ret == -EINVAL,
-	     "futex_wake returned {} when called without store permission, "
-	     "expected {}",
-	     ret,
-	     -EINVAL);
+	TEST_EQUAL(
+	  ret, 0, "futex_wake returned when called without store permission");
 
 #ifdef SAIL
 	// If we're targeting Sail, also do some basic tests of the interrupt


### PR DESCRIPTION
The scheduler doesn't require store permission for futexes when it does futex_wake, so don't require any permissions here.  This means that you can spuriously wake any thread waiting on a futex that you have any pointer to, even a read-only one, but the API permits spurious wakes.

The benefit from this is that the scheduler cannot tamper with a futex word.  For example, if a futex is a trivial lock where 1 indicates locked and 0 indicates unlocked, the scheduler currently can both wake waiters and set the lock value to 0 making two threads believe that they acquired the same lock.  With this change, an attacker who gets arbitrary code execution in the scheduler cannot do this, they can only cause threads to wake, see that the lock is already acquired, and then go back to sleep.

The C++ atomics (used for the locks library) now enforce this least privilege when calling the scheduler.

These changes increase the size of the test suite by 32 bytes.