### PR TITLE
sunburst: default to debug being switched off

### DIFF
--- a/sdk/include/platform/sunburst/platform-adc.hh
+++ b/sdk/include/platform/sunburst/platform-adc.hh
@@ -17,7 +17,7 @@ class SonataAnalogueDigitalConverter : private utils::NoCopyNoMove
 	/**
 	 * Flag to set when debugging the driver for UART log messages.
 	 */
-	static constexpr bool DebugDriver = true;
+	static constexpr bool DebugDriver = false;
 
 	/**
 	 * Helper for conditional debug logs and assertions.

--- a/sdk/include/platform/sunburst/platform-i2c.hh
+++ b/sdk/include/platform/sunburst/platform-i2c.hh
@@ -295,7 +295,7 @@ struct OpenTitanI2c
 	static constexpr uint32_t ReceiveFifoDepth = 8;
 
 	/// Flag set when we're debugging this driver.
-	static constexpr bool DebugOpenTitanI2c = true;
+	static constexpr bool DebugOpenTitanI2c = false;
 
 	/// Helper for conditional debug logs and assertions.
 	using Debug = ConditionalDebug<DebugOpenTitanI2c, "OpenTitan I2C">;


### PR DESCRIPTION
Debug flag should probably be consistent among drivers and should probably default to being off