### PR TITLE
Fix incorrect path for kunyan_ethernet device in arty-a7 board patch.

### DIFF
--- a/sdk/boards/ibex-arty-a7-100.patch
+++ b/sdk/boards/ibex-arty-a7-100.patch
@@ -11,7 +11,7 @@
     },
     {
       "op": "add",
-      "path": "/kunyan_ethernet",
+      "path": "/devices/kunyan_ethernet",
       "value": {
         "start": 0x14004000,
         "end": 0x14008000


### PR DESCRIPTION
Fixes #480 .