### PR TITLE
Remove global permission from switcher PCC.

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -186,7 +186,7 @@ namespace
 	constexpr auto StoreLPerm = Root::Permissions<Root::Type::RWStoreL>;
 	/// PCC permissions for the switcher.
 	constexpr auto SwitcherPccPermissions =
-	  Root::Permissions<Root::Type::Execute>;
+	  Root::Permissions<Root::Type::Execute>.without(Permission::Global);
 	/// PCC permissions for unprivileged compartments
 	constexpr auto UserPccPermissions =
 	  Root::Permissions<Root::Type::Execute>.without(

--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -93,10 +93,16 @@
 /*
  * Multiple points in the switcher are exposed to callers via sentries (either
  * forward-arc sentries manufactured elsewhere or backwards-arc sentries
- * manufactured by CJALRs herein.  Sentries can have their GL(obal) permission
- * cleared by the bearer, but nothing here relies on PCC being GL(obal): we
+ * manufactured by CJALRs herein.  All of these will be local (that is, they
+ * will have their GL(obal) permission cleared by the loader -- see
+ * loader/boot.cc's construction of SwitcherPccPermissions -- or will inherit
+ * the clear GL(obal) from PCC.  Nothing here relies on PCC being GL(obal): we
  * never store anything derived from our PCC to memory, much less through an
- * authority not bearing SL permission.
+ * authority not bearing SL permission.  Our callers and callees should not
+ * attempt to store their sentries to us in non-stack memory: the sentries to
+ * __Z26compartment_switcher_entryz are fetched from import tables into
+ * registers as part of the compiler's lowering, and return sentries should be
+ * generally confined to the stack.
  *
  * Similarly, the switcher communicates with the outside world by means of
  * sealed data capabilities (to TrustedStacks and compartment export tables).

--- a/tests/misc-test.cc
+++ b/tests/misc-test.cc
@@ -334,6 +334,14 @@ void check_sealed_scoping()
 
 int test_misc()
 {
+	// Inspect the return sentry the switcher gave us.  Unlike the one given to
+	// run_tests() (over in the "test_runner" compartment), this one is not a
+	// thread entry vector, and so is computed by cjalr in
+	// compartment_switcher_entry.
+	Capability switcher_return_sentry{__builtin_return_address(0)};
+	TEST(!switcher_return_sentry.permissions().contains(Permission::Global),
+	     "Switcher return sentry should be local");
+
 	check_timeouts();
 	check_memchr();
 	check_memrchr();

--- a/tests/misc-test.cc
+++ b/tests/misc-test.cc
@@ -334,13 +334,15 @@ void check_sealed_scoping()
 
 int test_misc()
 {
-	// Inspect the return sentry the switcher gave us.  Unlike the one given to
-	// run_tests() (over in the "test_runner" compartment), this one is not a
-	// thread entry vector, and so is computed by cjalr in
-	// compartment_switcher_entry.
-	Capability switcher_return_sentry{__builtin_return_address(0)};
-	TEST(!switcher_return_sentry.permissions().contains(Permission::Global),
-	     "Switcher return sentry should be local");
+	{
+		// Inspect the return sentry the switcher gave us.  Unlike the one given
+		// to run_tests() (over in the "test_runner" compartment), this one is
+		// not a thread entry vector, and so is computed by cjalr in
+		// compartment_switcher_entry.
+		Capability switcherReturnSentry{__builtin_return_address(0)};
+		TEST(!switcherReturnSentry.permissions().contains(Permission::Global),
+		     "Switcher return sentry should be local");
+	}
 
 	check_timeouts();
 	check_memchr();

--- a/tests/test-runner.cc
+++ b/tests/test-runner.cc
@@ -88,6 +88,14 @@ __attribute__((noinline, weak)) void *pcc_as_sentry()
 [[cheriot::interrupt_state(disabled)]]
 int __cheri_compartment("test_runner") run_tests()
 {
+	// Inspect the return sentry the switcher gave us.
+	// Since the switcher does not need Global on PCC it runs with a local one,
+	// meaning the return sentry we receive should also be local, which is fine
+	// as we have no reason to store it anywhere except the stack.
+	Capability switcher_return_sentry{__builtin_return_address(0)};
+	TEST(!switcher_return_sentry.permissions().contains(Permission::Global),
+	     "Switcher return sentry should be local");
+
 	// This is started as an interrupts-disabled thread, make sure that it
 	// really is!  This should always be CheriSealTypeReturnSentryDisabling,
 	// but older ISA versions didn't have separate forward and backwards


### PR DESCRIPTION
Since the switcher does not load any globals via PCC it does not need
the Global permission on its PCC.  Removing it slightly reduces its
privilege and also means the return sentry that compartments get is
local, slightly reducing the scope for mischief.
