### PR TITLE
New external IRQ latency benchmark

### DIFF
--- a/benchmarks/interrupt-latency-ext/interrupt_bench.cc
+++ b/benchmarks/interrupt-latency-ext/interrupt_bench.cc
@@ -1,0 +1,244 @@
+#include "../timing.h"
+#include <compartment.h>
+#include <debug.hh>
+#include <fail-simulator-on-error.h>
+#include <futex.h>
+#include <interrupt.h>
+#include <simulator.h>
+#include <thread.h>
+#include <timeout.h>
+
+using Debug = ConditionalDebug<true, "irq">;
+
+/////
+// Choose your metric.
+/////
+
+#if !defined(METRIC)
+#	define METRIC rdcycle
+#endif
+
+/////
+// Choose your IRQ source
+/////
+
+#if defined(SAIL)
+
+struct Source
+{
+	static constexpr const char *name = "Stub";
+
+	uint32_t fake_futex;
+
+	Source() : fake_futex(0) {}
+
+	auto futex()
+	{
+		return &fake_futex;
+	}
+
+	void init()
+	{
+		Debug::log("Sail lacks external IRQs; this is a stub for CI!");
+		simulation_exit(0);
+	}
+
+	void go() {}
+
+	void done() {}
+};
+
+#elif defined(IRQ_SOURCE_ibex_revoker)
+
+#	if !__has_include(<platform-hardware_revoker.hh>)
+#		error This benchmark requires a hardware revoker as an IRQ source.
+#	endif
+#	include <platform-hardware_revoker.hh>
+
+#	if !DEVICE_EXISTS(revoker) && !defined(CLANG_TIDY)
+#		error Memory map was not configured with a revoker device
+#	endif
+
+#	include <platform/concepts/hardware_revoker.hh>
+
+template<Revocation::IsHardwareRevokerDevice T>
+    requires requires(T v) {
+	    { v.interrupt_futex() } -> std::same_as<const uint32_t *>;
+	    { v.request_interrupt() } -> std::same_as<void>;
+    }
+struct RevokerSource
+{
+	T revoker;
+
+	RevokerSource() : revoker() {}
+
+	auto futex()
+	{
+		return revoker.interrupt_futex();
+	}
+
+	void init()
+	{
+		revoker.init();
+
+		// Wait for any in-progress scan to complete.  There shouldn't be one,
+		// but it can't hurt to check.
+		while (revoker.system_epoch_get() & 1)
+		{
+			;
+		}
+	}
+
+	void go()
+	{
+		revoker.request_interrupt();
+		revoker.system_bg_revoker_kick();
+	}
+
+	void done()
+	{
+		// snapshot epoch value, because it can change between calls
+		auto epoch = revoker.system_epoch_get();
+		Debug::Invariant(
+		  (epoch & 1) == 0, "Unexpected odd revoker epoch: {}", epoch);
+	}
+};
+
+struct Source : public RevokerSource<Ibex::HardwareRevoker>
+{
+	static constexpr const char *name = "Ibex Revoker";
+};
+
+#elif defined(IRQ_SOURCE_sunburst_uart1)
+
+#	include "platform/sunburst/platform-pinmux.hh"
+
+DECLARE_AND_DEFINE_INTERRUPT_CAPABILITY(uart1InterruptCap,
+                                        Uart1Interrupt,
+                                        true,
+                                        true);
+
+struct Source
+{
+	static constexpr const char *name = "Sunburst UART 1";
+
+	volatile Uart &uart1;
+
+	Source() : uart1(*MMIO_CAPABILITY(Uart, uart1)) {}
+
+	auto futex()
+	{
+		return interrupt_futex_get(STATIC_SEALED_VALUE(uart1InterruptCap));
+	}
+
+	void init()
+	{
+		auto pinSinks =
+		  MMIO_CAPABILITY(SonataPinmux::PinSinks, pinmux_pins_sinks);
+		pinSinks->get(SonataPinmux::PinSink::ser1_tx)
+		  .select(1); // uart1 tx -> ser1_tx
+		auto blockSinks =
+		  MMIO_CAPABILITY(SonataPinmux::BlockSinks, pinmux_block_sinks);
+		blockSinks->get(SonataPinmux::BlockSink::uart_1_rx)
+		  .select(1); // ser1_rx -> uart1 rx
+
+		uart1.init(300);
+
+		uart1.fifoCtrl = OpenTitanUart::FifoControlTransmitReset |
+		                 OpenTitanUart::FifoControlReceiveReset;
+	}
+
+	void go()
+	{
+		while ((uart1.status & OpenTitanUart::StatusTransmitFull) == 0)
+		{
+			uart1.writeData = 'A';
+		}
+		uart1.interruptEnable = OpenTitanUart::InterruptTransmitWatermark;
+		interrupt_complete(STATIC_SEALED_VALUE(uart1InterruptCap));
+	}
+
+	void done()
+	{
+		uart1.interruptEnable = 0;
+	}
+};
+
+#else
+
+#	error Unknown or unspecified IRQ source
+
+#endif
+
+extern "C"
+{
+	int start;
+}
+
+/**
+ * Initialize the system, wait for an IRQ, and determine how long it took
+ */
+int __cheri_compartment("interrupt_bench") entry_high_priority()
+{
+	Source source{};
+
+	Debug::log("Using {} for IRQs", source.name);
+
+	source.init();
+
+	auto            interruptFutex = source.futex();
+	decltype(start) lastStart      = 0;
+	uint32_t        lastIrqCount   = *interruptFutex - 1;
+
+	while (true)
+	{
+		Timeout t{MS_TO_TICKS(1000)};
+
+		auto irqCount = *interruptFutex;
+		source.go();
+
+		auto waitRes = futex_timed_wait(&t, interruptFutex, irqCount);
+		auto end     = METRIC();
+
+		// Force the metric read to happen prior to our invariant checks &c.
+		asm volatile("" : : : "memory");
+
+		Debug::log("{} latency at IRQ count {}; {} ",
+		           __XSTRING(METRIC),
+		           irqCount,
+		           end - start);
+
+		source.done();
+
+		Debug::Invariant(
+		  waitRes == 0, "Unexpected result from futex_timed_wait: {}", waitRes);
+
+		Debug::Invariant(
+		  start != lastStart,
+		  "Low priority thread did not run; make the source do more work");
+		lastStart = start;
+
+		Debug::Invariant(irqCount == lastIrqCount + 1,
+		                 "Missed IRQ at {}; was {}",
+		                 irqCount,
+		                 lastIrqCount);
+		lastIrqCount = irqCount;
+
+		thread_sleep(&t, ThreadSleepNoEarlyWake);
+	}
+}
+
+/**
+ * This lower priority thread will run once the higher priority thread is
+ * waiting on the IRQ futex.  All it does is keep the starting value as up to
+ * date as it can, so that when the high priority thread wakes, we have a
+ * reasonable snapshot of the last value observed on core prior to the IRQ
+ * handler firing.
+ */
+int __cheri_compartment("interrupt_bench") entry_low_priority()
+{
+	while (true)
+	{
+		start = METRIC();
+	}
+}

--- a/benchmarks/interrupt-latency-ext/xmake.lua
+++ b/benchmarks/interrupt-latency-ext/xmake.lua
@@ -1,0 +1,56 @@
+-- Copyright Microsoft and CHERIoT Contributors.
+-- SPDX-License-Identifier: MIT
+
+set_project("CHERIoT interrupt-latency benchmark");
+sdkdir = "../../sdk"
+includes(sdkdir)
+set_toolchains("cheriot-clang")
+
+-- Support libraries
+includes(path.join(sdkdir, "lib/freestanding"),
+         path.join(sdkdir, "lib/atomic"),
+         path.join(sdkdir, "lib/crt"))
+
+option("board")
+    set_default("sail")
+
+option("irq-source")
+    set_default("ibex_revoker")
+    set_values("ibex_revoker", "sunburst_uart1")
+
+option("metric")
+    set_default("rdcycle")
+    set_values("rdcycle", "rdinstret", "rd_lsu_stalls", "rd_ifetch_stalls")
+
+debugOption("interrupt_bench");
+compartment("interrupt_bench")
+    add_deps("crt", "freestanding", "stdio", "debug")
+    -- Allow allocating an effectively unbounded amount of memory (more than exists)
+    add_rules("cheriot.component-debug")
+    add_defines("BOARD=" .. tostring(get_config("board")))
+    add_defines("METRIC=" .. tostring(get_config("metric")))
+    add_defines("IRQ_SOURCE_" .. tostring(get_config("irq-source")))
+    add_files("interrupt_bench.cc")
+
+-- Firmware image for the example.
+firmware("interrupt-benchmark")
+    add_deps("interrupt_bench")
+    on_load(function(target)
+        target:values_set("board", "$(board)")
+        target:values_set("threads", {
+            {
+                compartment = "interrupt_bench",
+                priority = 2,
+                entry_point = "entry_high_priority",
+                stack_size = 0x400,
+                trusted_stack_frames = 4
+            },
+            {
+                compartment = "interrupt_bench",
+                priority = 1,
+                entry_point = "entry_low_priority",
+                stack_size = 0x400,
+                trusted_stack_frames = 4
+            },
+        }, {expand = false})
+    end)

--- a/benchmarks/timing.h
+++ b/benchmarks/timing.h
@@ -32,6 +32,24 @@ namespace
 		return cycles;
 	}
 
+#ifdef IBEX
+
+	static int rd_lsu_stalls()
+	{
+		int res;
+		__asm__ volatile("csrr %0, mhpmcounter3" : "=r"(res));
+		return res;
+	}
+
+	static int rd_ifetch_stalls()
+	{
+		int res;
+		__asm__ volatile("csrr %0, mhpmcounter4" : "=r"(res));
+		return res;
+	}
+
+#endif
+
 	/**
 	 * Utility function to return the size of the current stack based on the
 	 * length of csp capability register. If used in a thread entry point this

--- a/benchmarks/timing.h
+++ b/benchmarks/timing.h
@@ -5,6 +5,16 @@ namespace
 	/**
 	 * Read the cycle counter.
 	 */
+	int rdinstret()
+	{
+		int res;
+		__asm__ volatile("csrr %0, minstret" : "=r"(res));
+		return res;
+	}
+
+	/**
+	 * Read the cycle counter.
+	 */
 	int rdcycle()
 	{
 		int cycles;

--- a/sdk/core/allocator/revoker.h
+++ b/sdk/core/allocator/revoker.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <utils.hh>
 
+#include <platform/concepts/hardware_revoker.hh>
+
 #if __has_include(<platform-hardware_revoker.hh>)
 #	include <platform-hardware_revoker.hh>
 #elif defined(TEMPORAL_SAFETY) && !defined(SOFTWARE_REVOKER)
@@ -17,36 +19,6 @@
 
 namespace Revocation
 {
-	/**
-	 * Concept for a hardware revoker.  Boards can provide their own definition
-	 * of this, which must be found in `<hardware_revoker.hh>` in a path
-	 * provided by the board search.
-	 */
-	template<typename T>
-	concept IsHardwareRevokerDevice = requires(T v, uint32_t epoch) {
-		{ v.init() };
-		{ v.system_epoch_get() } -> std::same_as<uint32_t>;
-		{
-			v.template has_revocation_finished_for_epoch<true>(epoch)
-		} -> std::same_as<uint32_t>;
-		{
-			v.template has_revocation_finished_for_epoch<false>(epoch)
-		} -> std::same_as<uint32_t>;
-		{ v.system_bg_revoker_kick() } -> std::same_as<void>;
-	};
-
-	/**
-	 * If this revoker supports an interrupt to notify of completion then it
-	 * must have a method that blocks waiting for the interrupt to fire.  This
-	 * method should return true if the epoch has been reached or false if the
-	 * timeout expired.
-	 */
-	template<typename T>
-	concept SupportsInterruptNotification =
-	  requires(T v, Timeout *timeout, uint32_t epoch) {
-		  { v.wait_for_completion(timeout, epoch) } -> std::same_as<bool>;
-	  };
-
 	/**
 	 * Class for interacting with the shadow bitmap.  This bitmap controls the
 	 * behaviour of a hardware load barrier, which will invalidate capabilities

--- a/sdk/include/platform/concepts/hardware_revoker.hh
+++ b/sdk/include/platform/concepts/hardware_revoker.hh
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <concepts>
+
+struct Timeout;
+
+namespace Revocation
+{
+	/**
+	 * Concept for a hardware revoker.  Boards can provide their own definition
+	 * of this, which must be found in `<hardware_revoker.hh>` in a path
+	 * provided by the board search.
+	 */
+	template<typename T>
+	concept IsHardwareRevokerDevice = requires(T v, uint32_t epoch) {
+		{ v.init() };
+		{ v.system_epoch_get() } -> std::same_as<uint32_t>;
+		{
+			v.template has_revocation_finished_for_epoch<true>(epoch)
+		} -> std::same_as<uint32_t>;
+		{
+			v.template has_revocation_finished_for_epoch<false>(epoch)
+		} -> std::same_as<uint32_t>;
+		{ v.system_bg_revoker_kick() } -> std::same_as<void>;
+	};
+
+	/**
+	 * If this revoker supports an interrupt to notify of completion then it
+	 * must have a method that blocks waiting for the interrupt to fire.  This
+	 * method should return true if the epoch has been reached or false if the
+	 * timeout expired.
+	 */
+	template<typename T>
+	concept SupportsInterruptNotification =
+	  requires(T v, Timeout *timeout, uint32_t epoch) {
+		  { v.wait_for_completion(timeout, epoch) } -> std::same_as<bool>;
+	  };
+} // namespace Revocation

--- a/sdk/include/platform/ibex/platform-hardware_revoker.hh
+++ b/sdk/include/platform/ibex/platform-hardware_revoker.hh
@@ -204,6 +204,31 @@ namespace Ibex
 			// timeout parameter, we fail either way.
 			return false;
 		}
+
+		/**
+		 * Reveal the interrupt futex word.
+		 *
+		 * This is deliberately not part of the core/allocator/revoker.h
+		 * IsHardwareRevokerDevice concept and should be used only in testing
+		 * and other extenuating circumstances.
+		 */
+		const uint32_t *interrupt_futex()
+		{
+			return interruptFutex;
+		}
+
+		/**
+		 * Request the delivery of an IRQ when the revoker finishes its current
+		 * scan.
+		 *
+		 * This is deliberately not part of the core/allocator/revoker.h
+		 * IsHardwareRevokerDevice concept and should be used only in testing
+		 * and other extenuating circumstances.
+		 */
+		void request_interrupt()
+		{
+			revoker_device().interruptRequested = 1;
+		}
 	};
 } // namespace Ibex
 


### PR DESCRIPTION
This uses existing peripherals that can be used as IRQ "loopbacks",
which fire some appreciable delay after a software event, to measure
cycle, instruction, or HPMC counters of interest.  Presently, the Ibex
revoker engine or the Sunburst UART1 can be used as triggers; it should
be easy to add other sources.