### PR TITLE
bechmarks/allocation: rework

### DIFF
--- a/benchmarks/allocation/alloc.cc
+++ b/benchmarks/allocation/alloc.cc
@@ -5,40 +5,92 @@
 
 using Debug = ConditionalDebug<DEBUG_ALLOCBENCH, "Allocator benchmark">;
 
+void run(size_t allocSize, size_t allocations, size_t inHeap)
+{
+	auto start = rdcycle();
+	for (size_t i = 0; i < allocations; i++)
+	{
+		void *ptr = malloc(allocSize);
+		Debug::Assert(ptr != nullptr,
+		              "Allocation {} of {} {}-byte allocations failed.",
+		              i,
+		              allocations,
+		              allocSize);
+		free(ptr);
+	}
+	auto end = rdcycle();
+
+	asm volatile("" : : : "memory");
+
+	printf(__XSTRING(BOARD) "\t%ld\t%ld\t%ld\t%ld\n",
+	       static_cast<int>(allocSize),
+	       allocations,
+	       inHeap,
+	       end - start);
+
+	auto quota = heap_quota_remaining(MALLOC_CAPABILITY);
+	Debug::Invariant(quota == MALLOC_QUOTA,
+	                 "Quota remaining {}, should be {}",
+	                 quota,
+	                 MALLOC_QUOTA);
+
+	Debug::Invariant(heap_quarantine_empty() == 0,
+	                 "Call to heap_quarantine_empty failed");
+}
+
 /**
  * Try allocating 1 MiB of memory in allocation sizes ranging from 32 - 4096
  * bytes, report how long it takes.
  */
 int __cheri_compartment("allocbench") run()
 {
+	const ptraddr_t HeapStart = LA_ABS(__export_mem_heap);
+	const ptraddr_t HeapEnd   = LA_ABS(__export_mem_heap_end);
+
+	const size_t HeapSize = HeapEnd - HeapStart;
+
+	const size_t TotalSize = 8 * HeapSize;
+
+	auto runWrap = [&](size_t allocSize) {
+		return run(allocSize, TotalSize / allocSize, HeapSize / allocSize);
+	};
+
 	// Make sure sail doesn't print annoying log messages in the middle of the
 	// output the first time that allocation happens.
 	free(malloc(16));
+
 	Debug::Invariant(heap_quarantine_empty() == 0,
 	                 "Call to heap_quarantine_empty failed");
-	printf("#board\tsize\ttime\n");
+
+	printf("#board\tsize\tnalloc\tinheap\ttime\n");
+
 	const size_t MinimumSize = 32;
-	const size_t MaximumSize = 131072;
-	const size_t TotalSize   = 1024 * 1024;
-	for (size_t size = MinimumSize; size <= MaximumSize; size <<= 1)
+
+	for (size_t pow2 = MinimumSize; pow2 <= HeapSize; pow2 <<= 1)
 	{
-		size_t allocations = TotalSize / size;
-		auto   start       = rdcycle();
-		for (size_t i = 0; i < allocations; i++)
+		if (pow2 < (HeapSize / 4))
 		{
-			void *ptr = malloc(size);
-			Debug::Assert(ptr != nullptr, "Allocation {} of {} {}-byte allocations failed.", i, allocations, size);
-			free(ptr);
+			runWrap(pow2);
 		}
-		auto end = rdcycle();
-		printf(__XSTRING(BOARD) "\t%ld\t%ld\n", static_cast<int>(size), end - start);
-		auto quota = heap_quota_remaining(MALLOC_CAPABILITY);
-		Debug::Invariant(quota == MALLOC_QUOTA, "Quota remaining {}, should be {}", quota, MALLOC_QUOTA);
-		Debug::log("Flushing quarantine");
-		Debug::Invariant(heap_quarantine_empty() == 0,
-		                 "Call to heap_quarantine_empty failed");
-		Debug::log("Flushed quarantine");
+		else
+		{
+			for (size_t mantissa = 0; mantissa < 7; mantissa++)
+			{
+				size_t size = pow2 + mantissa * (pow2 / 8);
+				if (size < HeapSize)
+				{
+					// These tend to have few allocations; run the test
+					// repeatedly.
+					for (size_t i = 0; i < 4; i++)
+					{
+						runWrap(size);
+					}
+				}
+			}
+		}
 	}
+
+	printf("----- end of results (HeapSize is %zd)\n", HeapSize);
 
 	return 0;
 }

--- a/benchmarks/allocation/xmake.lua
+++ b/benchmarks/allocation/xmake.lua
@@ -28,7 +28,7 @@ firmware("allocator-benchmark")
                 compartment = "allocbench",
                 priority = 1,
                 entry_point = "run",
-                stack_size = 0x300,
+                stack_size = 0x400,
                 trusted_stack_frames = 4
             },
         }, {expand = false})


### PR DESCRIPTION
A slightly more detailed allocator benchmark, reporting more than just powers of two, and automagically sensitive to the maximum heap size.

It may not be worth running the larger size / few allocation benchmarks repeatedly, given the low variance observed in practice, but it seemed like a good idea at the time.

On my Sonata, this yields
```
#board	size	nalloc	inheap	time
sonata-1.0	32	30928	3866	332138707
sonata-1.0	64	15464	1933	174724776
sonata-1.0	128	7732	966	88808861
sonata-1.0	256	3866	483	45719597
sonata-1.0	512	1933	241	23773772
sonata-1.0	1024	966	120	12904387
sonata-1.0	2048	483	60	7308696
sonata-1.0	4096	241	30	4912352
sonata-1.0	8192	120	15	3298963
sonata-1.0	16384	60	7	2357563
sonata-1.0	32768	30	3	2172523
sonata-1.0	32768	30	3	2175256
sonata-1.0	32768	30	3	2169798
sonata-1.0	32768	30	3	2171251
sonata-1.0	36864	26	3	1973980
sonata-1.0	36864	26	3	1988255
sonata-1.0	36864	26	3	1975309
sonata-1.0	36864	26	3	1972605
sonata-1.0	40960	24	3	1908449
sonata-1.0	40960	24	3	1907447
sonata-1.0	40960	24	3	1921509
sonata-1.0	40960	24	3	1907965
sonata-1.0	45056	21	2	2081450
sonata-1.0	45056	21	2	2081134
sonata-1.0	45056	21	2	2081711
sonata-1.0	45056	21	2	2082296
sonata-1.0	49152	20	2	2091632
sonata-1.0	49152	20	2	2087812
sonata-1.0	49152	20	2	2087995
sonata-1.0	49152	20	2	2087525
sonata-1.0	53248	18	2	1866455
sonata-1.0	53248	18	2	1871827
sonata-1.0	53248	18	2	1891189
sonata-1.0	53248	18	2	1870903
sonata-1.0	57344	17	2	1798334
sonata-1.0	57344	17	2	1797258
sonata-1.0	57344	17	2	1798319
sonata-1.0	57344	17	2	1798311
sonata-1.0	65536	15	1	2366241
sonata-1.0	65536	15	1	2368064
sonata-1.0	65536	15	1	2366483
sonata-1.0	65536	15	1	2369249
sonata-1.0	73728	13	1	2166662
sonata-1.0	73728	13	1	2168655
sonata-1.0	73728	13	1	2166761
sonata-1.0	73728	13	1	2165238
sonata-1.0	81920	12	1	2111263
sonata-1.0	81920	12	1	2111176
sonata-1.0	81920	12	1	2111432
sonata-1.0	81920	12	1	2111744
sonata-1.0	90112	10	1	1842416
sonata-1.0	90112	10	1	1845390
sonata-1.0	90112	10	1	1843392
sonata-1.0	90112	10	1	1844316
sonata-1.0	98304	10	1	1941365
sonata-1.0	98304	10	1	1942188
sonata-1.0	98304	10	1	1940180
sonata-1.0	98304	10	1	1941174
sonata-1.0	106496	9	1	1826500
sonata-1.0	106496	9	1	1826561
sonata-1.0	106496	9	1	1826197
sonata-1.0	106496	9	1	1825627
sonata-1.0	114688	8	1	1692663
sonata-1.0	114688	8	1	1692027
sonata-1.0	114688	8	1	1693068
sonata-1.0	114688	8	1	1694799
----- end of results (HeapSize is 123712)
```

It's useful to print out `inheap`, the number of objects of that size in the heap, because one of four cases hold:
- 1: we could allocate exactly one, and cycling that one object is going to block on the revoker.
- 2: we could allocate up to two, and we'll be able to cycle between the two of them, and some times both can be on quarantine rings
- 3: we could allocate up to three, and we can cycle the three between "the one fresh out of quarantine", "the one being revoked", and "the one about to be revoked", essentially.
- many: we can actually do some batching of quarantining and revocation