### PR TITLE
irq-ext bench: wait longer for IRQs

### DIFF
--- a/benchmarks/interrupt-latency-ext/interrupt_bench.cc
+++ b/benchmarks/interrupt-latency-ext/interrupt_bench.cc
@@ -192,7 +192,7 @@ int __cheri_compartment("interrupt_bench") entry_high_priority()
 
 	while (true)
 	{
-		Timeout t{MS_TO_TICKS(1000)};
+		Timeout t{MS_TO_TICKS(2000)};
 
 		auto irqCount = *interruptFutex;
 		source.go();
@@ -210,6 +210,11 @@ int __cheri_compartment("interrupt_bench") entry_high_priority()
 
 		source.done();
 
+		/*
+		 * If this reports ETIMEDOUT, check that `t` is actually allowing enough
+		 * time to lapse.  SAFE's Ibex revoker, for example, takes over a
+		 * simulated second to run.
+		 */
 		Debug::Invariant(
 		  waitRes == 0, "Unexpected result from futex_timed_wait: {}", waitRes);
 
@@ -224,6 +229,8 @@ int __cheri_compartment("interrupt_bench") entry_high_priority()
 		                 lastIrqCount);
 		lastIrqCount = irqCount;
 
+		// Rate limit us to make the output easier to observe
+		t = MS_TO_TICKS(250);
 		thread_sleep(&t, ThreadSleepNoEarlyWake);
 	}
 }


### PR DESCRIPTION
Running in Verilated CHERIoT-SAFE, the revoker can take over a simulated second to complete a run, so be prepared to wait longer.  This probably could be tuned, but lowering the amount of work done too much threatens to make Sonata not actually wait for an IRQ.