### PR TITLE
sdk/xmake: support board mixins

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,25 @@ jobs:
           xmake
         done
 
+  sonata-sram-hello:
+    name: Check Sonata SRAM-only Hello World
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cheriot-platform/devcontainer:latest
+      options: --user 1001
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Build and run hello world
+      run: |
+        set -e
+        cd $PWD/examples/03.hello_safe_compartment/
+        xmake f --board=sonata-simulator --sdk=/cheriot-tools/ --board-mixins=sonata-1.x-sram-mixin
+        xmake
+        env SONATA_SIMULATOR_BOOT_STUB=/cheriot-tools/elf/sonata_simulator_sram_boot_stub xmake run
+
   check-format:
     name: Check coding conventions
     runs-on: ubuntu-latest

--- a/sdk/boards/sonata-1.x-sram-mixin.json
+++ b/sdk/boards/sonata-1.x-sram-mixin.json
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "remove",
+    "path": "/data_memory"
+  },
+  {
+    "op": "replace",
+    "path": "/instruction_memory/start",
+    "value": 0x00101000
+  },
+  {
+    "op": "replace",
+    "path": "/instruction_memory/end",
+    "value": 0x00120000
+  }
+]

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -528,7 +528,7 @@ rule("firmware")
 		visit_all_dependencies(function (target)
 			local targetBoardFile = target:get("cheriot.board_file")
 			local targetBoardDir = target:get("cheriot.board_dir")
-			if not targetBoard then
+			if not targetBoardFile and not targetBoardDir then
 				target:set("cheriot.board_file", boardfile)
 				target:set("cheriot.board_dir", boarddir)
 			else


### PR DESCRIPTION
Mixins are "baseless" patches, or just a list of JSON patch directives.

Add an example to remove the use of HyperRAM on Sonata 1.x builds, removing the `"data_memory"` key and moving the `"instruction_memory"` map's values to those of SRAM.