### PR TITLE
sunburst: enforce NoCopyNoMove on MMIO drivers

### DIFF
--- a/sdk/include/platform/sunburst/platform-i2c.hh
+++ b/sdk/include/platform/sunburst/platform-i2c.hh
@@ -2,6 +2,7 @@
 #include <cdefs.h>
 #include <debug.hh>
 #include <stdint.h>
+#include <utils.hh>
 
 /**
  * Driver for the OpenTitan's I2C block.
@@ -9,7 +10,7 @@
  * Documentation source can be found at:
  * https://github.com/lowRISC/opentitan/tree/4fe1b8dd1a09af9dbc242434481ae031955dfd85/hw/ip/i2c
  */
-struct OpenTitanI2c
+struct OpenTitanI2c : private utils::NoCopyNoMove
 {
 	/// Interrupt State Register
 	uint32_t interruptState;

--- a/sdk/include/platform/sunburst/platform-rgbctrl.hh
+++ b/sdk/include/platform/sunburst/platform-rgbctrl.hh
@@ -1,6 +1,7 @@
 #pragma once
 #include <cdefs.h>
 #include <stdint.h>
+#include <utils.hh>
 
 /**
  * An enum representing each of the Sonata's RGB LEDs.
@@ -14,7 +15,7 @@ enum class SonataRgbLed
 /**
  * A driver for the Sonata's RGB LED Controller
  */
-struct SonataRgbLedController
+struct SonataRgbLedController : private utils::NoCopyNoMove
 {
 	/**
 	 * Registers for setting the 8-bit red, green, and blue values

--- a/sdk/include/platform/sunburst/platform-uart.hh
+++ b/sdk/include/platform/sunburst/platform-uart.hh
@@ -8,6 +8,8 @@
 #	define DEFAULT_UART_BAUD_RATE 921'600
 #endif
 
+#include <utils.hh>
+
 /**
  * OpenTitan UART
  *
@@ -17,7 +19,7 @@
  * Rendered register documentation is served at:
  * https://opentitan.org/book/hw/ip/uart/doc/registers.html
  */
-struct OpenTitanUart
+struct OpenTitanUart : private utils::NoCopyNoMove
 {
 	/**
 	 * Interrupt State Register.


### PR DESCRIPTION
Some memory mapped drivers were missing necessary set up to prevent an accidental copy or move.