### PR TITLE
debug.hh: use 'enum struct DebugLevel'

### DIFF
--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -21,7 +21,7 @@ riscv32-unknown-unknown
 -Isdk/include/platform/generic-riscv
 -Isdk/include
 -DDEBUG_LOADER=true
--DDEBUG_ALLOCATOR=true
+-DDEBUG_ALLOCATOR=DebugLevel::Information
 -DDEBUG_SCHEDULER=true
 -DDEBUG_CXXRT=true
 -DSAIL

--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -1203,7 +1203,7 @@ class MState
 			return AllocationFailureQuotaExceeded{};
 		}
 
-		if constexpr (DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR != DebugLevel::None)
 		{
 			// Periodically sanity check the entire state for this mspace.
 			static size_t           sanityCounter        = 0;
@@ -1526,7 +1526,7 @@ class MState
 	 */
 	bool ok_address(ptraddr_t a)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return true;
 		}
@@ -1534,7 +1534,7 @@ class MState
 	}
 	bool ok_address(void *p)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return true;
 		}
@@ -1542,7 +1542,7 @@ class MState
 	}
 	void ok_any_chunk(MChunkHeader *p)
 	{
-		if constexpr (HasTemporalSafety && DEBUG_ALLOCATOR)
+		if constexpr (HasTemporalSafety && DEBUG_ALLOCATOR != DebugLevel::None)
 		{
 			bool thisShadowBit =
 			  revoker.shadow_bit_get(CHERI::Capability{p}.address());
@@ -1565,7 +1565,7 @@ class MState
 	// Sanity check an in-use chunk.
 	void ok_in_use_chunk(MChunkHeader *p)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return;
 		}
@@ -1583,7 +1583,7 @@ class MState
 	// Sanity check a free chunk.
 	void ok_free_chunk(MChunkHeader *pHeader)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return;
 		}
@@ -1641,7 +1641,7 @@ class MState
 	// Sanity check a chunk that was just malloced.
 	void ok_malloced_chunk(MChunkHeader *p, size_t s)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return;
 		}
@@ -1677,7 +1677,7 @@ class MState
 	 */
 	void ok_tree_next(TChunk *from, TChunk *t)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return;
 		}
@@ -1717,7 +1717,7 @@ class MState
 	 */
 	void ok_tree(TChunk *from, TChunk *t)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return;
 		}
@@ -1817,7 +1817,7 @@ class MState
 	// Sanity check the tree at treebin[i].
 	void ok_treebin(BIndex i)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return;
 		}
@@ -1838,7 +1838,7 @@ class MState
 	// Sanity check smallbin[i].
 	void ok_smallbin(BIndex i)
 	{
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return;
 		}
@@ -1872,7 +1872,7 @@ class MState
 		{
 			mspace_bg_revoker_kick();
 		}
-		if constexpr (!DEBUG_ALLOCATOR)
+		if constexpr (DEBUG_ALLOCATOR == DebugLevel::None)
 		{
 			return;
 		}

--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -577,7 +577,7 @@ namespace
 	/**
 	 * Debug level.
 	 */
-	enum DebugLevel
+	enum class DebugLevel
 	{
 		/**
 		 * This is informative and may be helpful for debugging.


### PR DESCRIPTION
Prevent automagic conversion of DebugLevel to a boolean, because DebugLevel::None is nonzero (in fact, the largest of the DebugLevel values) as it is meant to be used as a threshold for reporting.

The use of an 'enum struct' means that we can't mistakenly write things like "if constexpr (DEBUG...)" and end up with debug code compiled in when DEBUG... is DebugLevel::None (or wonder why debugging might be elided when it's ::Information).

Update the sole user of DebugLevel, the allocator, to compile.