### PR TITLE
Add a stream implementation and most of the FreeRTOS compat API.

### DIFF
--- a/sdk/include/FreeRTOS-Compat/FreeRTOS.h
+++ b/sdk/include/FreeRTOS-Compat/FreeRTOS.h
@@ -154,13 +154,14 @@ typedef uint64_t TimeOut_t;
 // Some things include this file expecting to get other FreeRTOS headers,
 // others include those files directly.
 #include "event_groups.h"
-#include "task.h"
 #include "queue.h"
+#include "stream_buffer.h"
+#include "task.h"
 
 // Some things expect this to include list.h.  This is an incredibly complex
 // data structure that it is not worth reimplementing, so include it if it
 // exists and allow components to copy it from FreeRTOS if they want it (it's
 // MIT licensed).
 #if __has_include(<list.h>)
-#include <list.h>
+#	include <list.h>
 #endif

--- a/sdk/include/FreeRTOS-Compat/stream_buffer.h
+++ b/sdk/include/FreeRTOS-Compat/stream_buffer.h
@@ -1,0 +1,219 @@
+#pragma once
+#include "FreeRTOS.h"
+#include <queue.h>
+
+/**
+ * Stream handle.  This is used to reference streams in the API functions.
+ */
+typedef struct MessageQueue *StreamBufferHandle_t;
+
+#ifndef CHERIOT_NO_AMBIENT_MALLOC
+/**
+ * Create a stream buffer that can store `xBufferSizeBytes` bytes.
+ *
+ * Returns NULL if queue creation failed, false otherwise.
+ */
+static inline StreamBufferHandle_t
+xStreamBufferCreate(size_t xBufferSizeBytes, size_t xTriggerLevelBytes)
+{
+	(void)xTriggerLevelBytes;
+	StreamBufferHandle_t ret     = NULL;
+	struct Timeout       timeout = {0, UnlimitedTimeout};
+	int                  rc =
+	  queue_create(&timeout, MALLOC_CAPABILITY, &ret, 1, xBufferSizeBytes);
+	return ret;
+}
+
+/**
+ * Destroy a queue.
+ *
+ * Note that, unlike the underlying CHERIoT RTOS API, this has no mechanism to
+ * signal failure.  If memory deallocation fails (for example, as a result of
+ * insufficient stack or trusted-stack space, this API may leak the queue.
+ */
+static inline void vStreamBufferDelete(StreamBufferHandle_t xStreamBuffer)
+{
+	struct Timeout timeout = {0, UnlimitedTimeout};
+	(void)queue_destroy(MALLOC_CAPABILITY, xStreamBuffer);
+}
+#endif
+
+/**
+ * Sends `xDataLengthBytes` of data from `pvTxData` to the stream
+ * `xStreamBuffer`.
+ *
+ * Returns the number of bytes read or zero in case of an error.
+ * Unlike the underlying CHERIoT RTOS API, this API has no way of signalling
+ * specific errors so all errors are reported as zero return values.
+ */
+static inline size_t xStreamBufferSend(StreamBufferHandle_t xStreamBuffer,
+                                       const void          *pvTxData,
+                                       size_t               xDataLengthBytes,
+                                       TickType_t           waitTicks)
+{
+	struct Timeout timeout = {0, waitTicks};
+	int            rv =
+	  queue_send_multiple(&timeout, xStreamBuffer, pvTxData, xDataLengthBytes);
+	if (rv < 0)
+	{
+		return 0;
+	}
+	return rv;
+}
+
+/*
+ * Send to the stream from an ISR.  We do not allow running code from ISRs and
+ * so this behaves like a non-blocking `xStreamBufferSend`.
+ *
+ * The `pxHigherPriorityTaskWoken` parameter is used to return whether a yield
+ * is necessary.  A yield is never necessary in this implementation and so this
+ * is unconditionally given a value of `pdFALSE`.
+ */
+static inline size_t
+xStreamBufferSendFromISR(StreamBufferHandle_t xStreamBuffer,
+                         const void          *pvTxData,
+                         size_t               xDataLengthBytes,
+                         BaseType_t          *pxHigherPriorityTaskWoken)
+{
+	*pxHigherPriorityTaskWoken = pdFALSE;
+	return xStreamBufferSend(xStreamBuffer, pvTxData, xDataLengthBytes, 0);
+}
+
+/**
+ * Receive up to `xBufferLengthBytes` bytes into `pvRxData` from the stream
+ * given by `xStreamBuffer`.
+ *
+ * Returns the number of bytes read, this may be zero in case of an error.
+ * Unlike the underlying CHERIoT RTOS API, this API has no way of signalling
+ * specific errors so all errors are reported as zero return values.
+ */
+static inline size_t xStreamBufferReceive(StreamBufferHandle_t xStreamBuffer,
+                                          void                *pvRxData,
+                                          size_t     xBufferLengthBytes,
+                                          TickType_t xTicksToWait)
+{
+	struct Timeout timeout = {0, xTicksToWait};
+	int            rv      = queue_receive_multiple(
+      &timeout, xStreamBuffer, pvRxData, xBufferLengthBytes);
+	if (rv < 0)
+	{
+		return 0;
+	}
+	return rv;
+}
+
+/*
+ * Receive from the stream from an ISR.  We do not allow running code from ISRs
+ * and so this behaves like a non-blocking `xStreamBufferReceive`.
+ *
+ * The `pxHigherPriorityTaskWoken` parameter is used to return whether a yield
+ * is necessary.  A yield is never necessary in this implementation and so this
+ * is unconditionally given a value of `pdFALSE`.
+ */
+static inline size_t
+xStreamBufferReceiveFromISR(StreamBufferHandle_t xStreamBuffer,
+                            void                *pvRxData,
+                            size_t               xBufferLengthBytes,
+                            BaseType_t          *pxHigherPriorityTaskWoken)
+{
+	*pxHigherPriorityTaskWoken = pdFALSE;
+	return xStreamBufferSend(xStreamBuffer, pvRxData, xBufferLengthBytes, 0);
+}
+
+/**
+ * Returns the amount of data in a stream, in bytes.
+ *
+ * This API is intrinsically racy because more data can be sent to the queue in
+ * between calling this function and acting on the result.
+ *
+ * Note that, unlike FreeRTOS streams, CHERIoT RTOS message queues are thread
+ * safe and so this amount can also *decrease* if another thread receives from
+ * this stream.
+ */
+static inline size_t
+xStreamBufferBytesAvailable(StreamBufferHandle_t xStreamBuffer)
+{
+	size_t outItems;
+	// Stream buffers use an item size of one and so the number of items and the
+	// number of bytes is the same.
+	(void)queue_items_remaining(xStreamBuffer, &outItems);
+	return outItems;
+}
+
+/**
+ * Returns the amount of space available in a stream, in bytes.
+ *
+ * This API is intrinsically racy because more data can be read from the queue
+ * in between calling this function and acting on the result.
+ *
+ * Note that, unlike FreeRTOS streams, CHERIoT RTOS message queues are thread
+ * safe and so this amount can also *decrease* if another thread sends over
+ * this stream.
+ */
+static inline size_t
+xStreamBufferSpacesAvailable(StreamBufferHandle_t xStreamBuffer)
+{
+	size_t outItems;
+	// Stream buffers use an item size of one and so the number of items and the
+	// number of bytes is the same.
+	(void)queue_items_remaining(xStreamBuffer, &outItems);
+	return xStreamBuffer->queueSize - outItems;
+}
+
+/**
+ * Updates the trigger level of the stream.
+ *
+ * Trigger levels are not currently supported by CHERIoT RTOS.
+ */
+__attribute__((
+  deprecated("Trigger levels are not currently supported in the FreeRTOS "
+             "streams compatibility layer"))) static inline BaseType_t
+xStreamBufferSetTriggerLevel(StreamBufferHandle_t xStreamBuffer,
+                             size_t               xTriggerLevel)
+{
+	return pdFALSE;
+}
+
+/**
+ * Returns `pdTRUE` if the stream is empty, `pdFALSE` otherwise.
+ *
+ * Note, this API is inherently racy.
+ */
+static inline BaseType_t
+xStreamBufferIsEmpty(StreamBufferHandle_t xStreamBuffer)
+{
+	return xStreamBufferBytesAvailable(xStreamBuffer) == 0;
+}
+
+/**
+ * Returns `pdTRUE` if the stream is full, `pdFALSE` otherwise.
+ *
+ * Note, this API is inherently racy.
+ */
+static inline BaseType_t xStreamBufferIsFull(StreamBufferHandle_t xStreamBuffer)
+{
+	return xStreamBufferSpacesAvailable(xStreamBuffer) == 0;
+}
+
+/**
+ * Reset the stream, unless another thread is currently active using it.
+ *
+ * This differs slightly from the FreeRTOS implementation, threads blocked
+ * waiting to acquire the endpoint locks do not prevent this operation and any
+ * threads waiting to send will become unblocked.
+ */
+static inline BaseType_t xStreamBufferReset(StreamBufferHandle_t xStreamBuffer)
+{
+	struct Timeout timeout = {0, 0};
+	return queue_reset(&timeout, xStreamBuffer) == 0;
+}
+
+/**
+ * Reset a stream from an ISR.  We do not allow running code from
+ * ISRs and so this behaves like a non-blocking `xStreamBufferReset`.
+ */
+static inline BaseType_t
+xStreamBufferResetFromISR(StreamBufferHandle_t xStreamBuffer)
+{
+	return xStreamBufferReset(xStreamBuffer);
+}

--- a/sdk/lib/queue/queue.cc
+++ b/sdk/lib/queue/queue.cc
@@ -47,6 +47,21 @@ namespace
 	}
 
 	/**
+	 * Helper for wrapping add.  Adds `addend` to `counter`, wrapping to zero
+	 * if it reaches double `size`.
+	 */
+	constexpr uint32_t
+	add_and_wrap(uint32_t size, uint32_t counter, uint32_t addend)
+	{
+		counter += addend;
+		if (counter >= 2 * size)
+		{
+			counter -= (2 * size);
+		}
+		return counter;
+	}
+
+	/**
 	 * Returns the number of items in the queue for the given size with the
 	 * specified producer and consumer counters.
 	 */
@@ -138,6 +153,21 @@ namespace
 			              "items-remaining calculation is incorrect");
 		}
 
+		template<auto A, auto B>
+		static void constexpr check_equal()
+		{
+			static_assert(A == B);
+		}
+
+		template<uint32_t Expected, uint32_t Counter, uint32_t Addend>
+		static constexpr void check_add_and_wrap()
+		{
+			if constexpr (Counter < 2 * Size)
+			{
+				check_equal<add_and_wrap(Size, Counter, Addend), Expected>();
+			}
+		}
+
 		/**
 		 * For every producer counter value from 0 up to `Size` after a consumer
 		 * counter value, check that it returns the correct value for the
@@ -148,6 +178,7 @@ namespace
 		{
 			constexpr auto Producer = add(Consumer, Displacement);
 			check_items_remaining<Producer, Consumer, Displacement>();
+			check_add_and_wrap<Producer, Consumer, Displacement>();
 			if constexpr (Displacement == 0)
 			{
 				static_assert(is_empty(Producer, Consumer),
@@ -207,17 +238,23 @@ namespace
 	static_assert(CheckIsFullValue<33>, "CheckIsFull failed");
 
 	/**
-	 * Returns a pointer to the element in the queue indicated by `counter`.
+	 * Returns the index of the element in the queue indicated by `counter`.
 	 */
-	Capability<void> buffer_at_counter(struct MessageQueue &handle,
-	                                   uint32_t             counter)
+	size_t index_at_counter(struct MessageQueue &handle, uint32_t counter)
 	{
 		// Handle wrap for the second run around the counter.
-		size_t index =
-		  counter >= handle.queueSize ? counter - handle.queueSize : counter;
-		auto             offset = index * handle.elementSize;
+		return counter >= handle.queueSize ? counter - handle.queueSize
+		                                   : counter;
+	}
+
+	/**
+	 * Returns a pointer into the queue buffer starting at index.
+	 */
+	void *queue_pointer_at_index(struct MessageQueue &handle, size_t index)
+	{
 		Capability<void> pointer{&handle};
-		pointer.address() += sizeof(MessageQueue) + offset;
+		pointer.address() +=
+		  sizeof(MessageQueue) + (index * handle.elementSize);
 		return pointer;
 	}
 
@@ -415,18 +452,21 @@ int queue_create(Timeout              *timeout,
 	return 0;
 }
 
-int queue_send(Timeout *timeout, struct MessageQueue *handle, const void *src)
+int queue_send_multiple(Timeout             *timeout,
+                        struct MessageQueue *handle,
+                        const void          *src,
+                        size_t               count)
 {
 	Debug::log("Send called on: {}", handle);
-	auto *producer   = &handle->producer;
-	auto *consumer   = &handle->consumer;
-	bool  shouldWake = false;
+	auto        *producer   = &handle->producer;
+	auto        *consumer   = &handle->consumer;
+	bool         shouldWake = false;
+	volatile int ret        = 0;
 	{
 		Debug::log("Lock word: {}", producer->load());
 		HighBitFlagLock l{*producer};
 		if (LockGuard g{l, timeout})
 		{
-			volatile int ret = 0;
 			// In an error-handling context, try to add the element to the
 			// queue.  If the permissions on src are invalid, or either `handle`
 			// or `src` is freed concurrently, we will hit the path that returns
@@ -434,56 +474,84 @@ int queue_send(Timeout *timeout, struct MessageQueue *handle, const void *src)
 			// simply leave the queue in the old state.
 			on_error(
 			  [&] {
-				  uint32_t producerCounter = counter_load(producer);
-				  uint32_t consumerValue   = consumer->load();
-				  uint32_t consumerCounter =
-				    consumerValue & ~(HighBitFlagLock::reserved_bits());
-				  Debug::log(
-				    "Producer counter: {}, consumer counter: {}, Size: {}",
-				    producerCounter,
-				    consumerCounter,
-				    handle->queueSize);
-				  while (is_full(
-				    handle->queueSize, producerCounter, consumerCounter))
+				  while (count > 0)
 				  {
-					  // Wait on the value to change.  If we hit this path while
-					  // the consumer lock is held, then the high bits will be
-					  // set.  Make sure that we yield.
-					  if (consumer->wait(timeout, consumerValue) == -ETIMEDOUT)
-					  {
-						  Debug::log("Timed out on futex");
-						  ret = -ETIMEDOUT;
-						  return;
-					  }
-					  consumerValue = consumer->load();
-					  consumerCounter =
+					  uint32_t producerCounter = counter_load(producer);
+					  uint32_t consumerValue   = consumer->load();
+					  uint32_t consumerCounter =
 					    consumerValue & ~(HighBitFlagLock::reserved_bits());
+					  Debug::log(
+					    "Producer counter: {}, consumer counter: {}, Size: {}",
+					    producerCounter,
+					    consumerCounter,
+					    handle->queueSize);
+					  while (is_full(
+					    handle->queueSize, producerCounter, consumerCounter))
+					  {
+						  // Wait on the value to change.  If we hit this path
+						  // while the consumer lock is held, then the high bits
+						  // will be set.  Make sure that we yield.
+						  if (consumer->wait(timeout, consumerValue) ==
+						      -ETIMEDOUT)
+						  {
+							  Debug::log("Timed out on futex (ret: {})", ret);
+							  // If we haven't yet sent anything, report timeout
+							  // failure, otherwise report the number that were
+							  // sent.
+							  if (ret == 0)
+							  {
+								  ret = -ETIMEDOUT;
+							  }
+							  return;
+						  }
+						  consumerValue = consumer->load();
+						  consumerCounter =
+						    consumerValue & ~(HighBitFlagLock::reserved_bits());
+					  }
+					  size_t startIndex =
+					    index_at_counter(*handle, producerCounter);
+					  size_t consumerIndex =
+					    index_at_counter(*handle, consumerCounter);
+
+					  // If the consumer is before the producer, the producer
+					  // can use all of the space from the current space to the
+					  // end.
+					  if (consumerIndex <= startIndex)
+					  {
+						  consumerIndex = handle->queueSize;
+					  }
+					  size_t elementsToCopy =
+					    std::min(count, consumerIndex - startIndex);
+					  Debug::log(
+					    "Send Copying {} elements (count: {}, consumer index: "
+					    "{}, start index: {}",
+					    elementsToCopy,
+					    count,
+					    consumerIndex,
+					    startIndex);
+					  memcpy(queue_pointer_at_index(*handle, startIndex),
+					         static_cast<const char *>(src) +
+					           (ret * handle->elementSize),
+					         elementsToCopy * handle->elementSize);
+					  ret += elementsToCopy;
+					  count -= elementsToCopy;
+					  counter_store(&handle->producer,
+					                add_and_wrap(handle->queueSize,
+					                             producerCounter,
+					                             elementsToCopy));
+					  // Check if the queue was empty before we updated the
+					  // producer counter.  By the time that we reach this
+					  // point, anything on the consumer side will be on the
+					  // path to a futex_wait with the old version of the
+					  // producer counter and so will bounce out again.
+					  shouldWake |=
+					    is_empty(producerCounter, counter_load(consumer));
 				  }
-				  auto entry = buffer_at_counter(*handle, producerCounter);
-				  Debug::log("Send copying {} bytes from {} to {}",
-				             handle->elementSize,
-				             src,
-				             entry);
-				  memcpy(entry, src, handle->elementSize);
-				  counter_store(
-				    &handle->producer,
-				    increment_and_wrap(handle->queueSize, producerCounter));
-				  // Check if the queue was empty before we updated the producer
-				  // counter.  By the time that we reach this point, anything on
-				  // the consumer side will be on the path to a futex_wait with
-				  // the old version of the producer counter and so will bounce
-				  // out again.
-				  shouldWake =
-				    is_empty(producerCounter, counter_load(consumer));
 			  },
 			  [&]() {
 				  ret = -EPERM;
 				  Debug::log("Error in send");
 			  });
-			if (ret != 0)
-			{
-				return ret;
-			}
 		}
 		else
 		{
@@ -495,20 +563,44 @@ int queue_send(Timeout *timeout, struct MessageQueue *handle, const void *src)
 	{
 		handle->producer.notify_all();
 	}
-	return 0;
+	return ret;
 }
 
-int queue_receive(Timeout *timeout, struct MessageQueue *handle, void *dst)
+int queue_send(Timeout *timeout, struct MessageQueue *handle, const void *src)
+{
+	return std::min(0, queue_send_multiple(timeout, handle, src, 1));
+}
+
+int queue_reset(Timeout *timeout, struct MessageQueue *queue)
+{
+	HighBitFlagLock producerLock{queue->producer};
+	HighBitFlagLock consumerLock{queue->consumer};
+	if (LockGuard producerGuard{producerLock, timeout})
+	{
+		if (LockGuard consumerGuard{consumerLock, timeout})
+		{
+			counter_store(&queue->producer, 0);
+			counter_store(&queue->consumer, 0);
+		}
+	}
+	queue->producer.notify_all();
+	return -ETIMEDOUT;
+}
+
+int queue_receive_multiple(Timeout             *timeout,
+                           struct MessageQueue *handle,
+                           void                *dst,
+                           size_t               count)
 {
 	Debug::log("Receive called on: {}", handle);
-	auto *producer   = &handle->producer;
-	auto *consumer   = &handle->consumer;
-	bool  shouldWake = false;
+	auto        *producer   = &handle->producer;
+	auto        *consumer   = &handle->consumer;
+	bool         shouldWake = false;
+	volatile int ret        = 0;
 	{
 		HighBitFlagLock l{*consumer};
 		if (LockGuard g{l, timeout})
 		{
-			volatile int ret = 0;
 			// In an error-handling context, try to add the element to the
 			// queue.  If the permissions on `dst` are invalid, or either
 			// `handle` or `dst` is freed concurrently, we will hit the path
@@ -516,54 +608,88 @@ int queue_receive(Timeout *timeout, struct MessageQueue *handle, void *dst)
 			// failure will simply leave the queue in the old state.
 			on_error(
 			  [&] {
-				  uint32_t producerValue = producer->load();
-				  uint32_t producerCounter =
-				    producerValue & ~(HighBitFlagLock::reserved_bits());
-				  uint32_t consumerCounter = counter_load(consumer);
-				  Debug::log(
-				    "Producer counter: {}, consumer counter: {}, Size: {}",
-				    producerCounter,
-				    consumerCounter,
-				    handle->queueSize);
-				  while (is_empty(producerCounter, consumerCounter))
+				  while (count > 0)
 				  {
-					  // Wait on the value to change.  If we hit this path while
-					  // the producer lock is held, then the high bits will be
-					  // set.  Make sure that we yield.
-					  if (producer->wait(timeout, producerValue) == -ETIMEDOUT)
-					  {
-						  ret = -ETIMEDOUT;
-						  return;
-					  }
-					  producerValue = producer->load();
-					  producerCounter =
+					  uint32_t producerValue = producer->load();
+					  uint32_t producerCounter =
 					    producerValue & ~(HighBitFlagLock::reserved_bits());
+					  uint32_t consumerCounter = counter_load(consumer);
+					  Debug::log(
+					    "Producer counter: {}, consumer counter: {}, Size: {}",
+					    producerCounter,
+					    consumerCounter,
+					    handle->queueSize);
+					  while (is_empty(producerCounter, consumerCounter))
+					  {
+						  // Wait on the value to change.  If we hit this path
+						  // while the producer lock is held, then the high bits
+						  // will be set.  Make sure that we yield.
+						  if (producer->wait(timeout, producerValue) ==
+						      -ETIMEDOUT)
+						  {
+							  Debug::log("Timed out on futex (ret: {})", ret);
+							  // If we haven't yet  anything, report timeout
+							  // failure, otherwise report the number that were
+							  // sent.
+							  if (ret == 0)
+							  {
+								  ret = -ETIMEDOUT;
+							  }
+							  return;
+						  }
+						  producerValue = producer->load();
+						  producerCounter =
+						    producerValue & ~(HighBitFlagLock::reserved_bits());
+					  }
+					  size_t startIndex =
+					    index_at_counter(*handle, consumerCounter);
+					  size_t producerIndex =
+					    index_at_counter(*handle, producerCounter);
+
+					  // If the producer is before the consumer, the producer
+					  // has wrapped and we can read to the end of the buffer.
+					  //
+					  if (producerIndex <= startIndex)
+					  {
+						  producerIndex = handle->queueSize;
+					  }
+					  size_t elementsToCopy =
+					    std::min(count, producerIndex - startIndex);
+					  Debug::log(
+					    "Copying {} elements (count: {}, producer index: "
+					    "{}, start index: {}",
+					    elementsToCopy,
+					    count,
+					    producerIndex,
+					    startIndex);
+					  Debug::log("Send copying {} bytes from {} to {}",
+					             handle->elementSize,
+					             dst,
+					             queue_pointer_at_index(*handle, startIndex));
+					  memcpy(static_cast<char *>(dst) +
+					           (ret * handle->elementSize),
+					         queue_pointer_at_index(*handle, startIndex),
+					         elementsToCopy * handle->elementSize);
+					  ret += elementsToCopy;
+					  count -= elementsToCopy;
+					  counter_store(&handle->consumer,
+					                add_and_wrap(handle->queueSize,
+					                             consumerCounter,
+					                             elementsToCopy));
+					  // Check if the queue was full before we updated the
+					  // consumer counter.  By the time that we reach this
+					  // point, anything on the producer side will be on the
+					  // path to a futex_wait with the old version of the
+					  // consumer counter and so will bounce out again.
+					  shouldWake |= is_full(handle->queueSize,
+					                        counter_load(producer),
+					                        consumerCounter);
 				  }
-				  auto entry = buffer_at_counter(*handle, consumerCounter);
-				  Debug::log("Receive copying {} bytes from {} to {}",
-				             handle->elementSize,
-				             entry,
-				             dst);
-				  memcpy(dst, entry, handle->elementSize);
-				  counter_store(
-				    consumer,
-				    increment_and_wrap(handle->queueSize, consumerCounter));
-				  // Check if the queue was full before we updated the consumer
-				  // counter.  By the time that we reach this point, anything on
-				  // the producer side will be on the path to a futex_wait with
-				  // the old version of the consumer counter and so will bounce
-				  // out again.
-				  shouldWake = is_full(
-				    handle->queueSize, counter_load(producer), consumerCounter);
 			  },
 			  [&]() {
 				  ret = -EPERM;
 				  Debug::log("Error in receive");
 			  });
-			if (ret != 0)
-			{
-				return ret;
-			}
 		}
 		else
 		{
@@ -577,7 +703,12 @@ int queue_receive(Timeout *timeout, struct MessageQueue *handle, void *dst)
 	{
 		handle->consumer.notify_all();
 	}
-	return 0;
+	return ret;
+}
+
+int queue_receive(Timeout *timeout, struct MessageQueue *handle, void *dst)
+{
+	return std::min(0, queue_receive_multiple(timeout, handle, dst, 1));
 }
 
 int queue_items_remaining(struct MessageQueue *handle, size_t *items)

--- a/sdk/lib/queue/queue_compartment.cc
+++ b/sdk/lib/queue/queue_compartment.cc
@@ -120,6 +120,19 @@ int queue_send_sealed(Timeout *timeout,
 	return queue_send(timeout, queue, src);
 }
 
+int queue_send_multiple_sealed(Timeout *timeout,
+                               CHERI_SEALED(MessageQueue *) handle,
+                               const void *src,
+                               size_t      count)
+{
+	MessageQueue *queue = unseal(send_key(), handle);
+	if (!queue || !check_timeout_pointer(timeout))
+	{
+		return -EINVAL;
+	}
+	return queue_send_multiple(timeout, queue, src, count);
+}
+
 int queue_receive_sealed(Timeout *timeout,
                          CHERI_SEALED(MessageQueue *) handle,
                          void *dst)
@@ -130,6 +143,19 @@ int queue_receive_sealed(Timeout *timeout,
 		return -EINVAL;
 	}
 	return queue_receive(timeout, queue, dst);
+}
+
+int queue_receive_multiple_sealed(Timeout *timeout,
+                                  CHERI_SEALED(MessageQueue *) handle,
+                                  void  *dst,
+                                  size_t count)
+{
+	MessageQueue *queue = unseal(receive_key(), handle);
+	if (!queue || !check_timeout_pointer(timeout))
+	{
+		return -EINVAL;
+	}
+	return queue_receive_multiple(timeout, queue, dst, count);
 }
 
 int multiwaiter_queue_receive_init_sealed(struct EventWaiterSource *source,


### PR DESCRIPTION
The core of this is a pair of APIs for sending and receiving more than one element to a queue in a single call.  These are also exposed for the queue compartment, which lets you amortise the cost of cross-compartment calls.

A stream is a message queue where queue items are one byte long. Sending multiple queue items at a time gives a byte-stream abstraction.

FreeRTOS streams are a bit more complicated than CHERIoT RTOS version and have explicit thresholds and callbacks.  These are approximated here.