### PR TITLE
scheduler: bound interrupt_futex_get

### DIFF
--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -747,6 +747,7 @@ namespace
 		  .futex_word_for_source(interruptCapability->state.interruptNumber)
 		  .and_then([&](uint32_t &word) {
 			  Capability capability{&word};
+			  capability.bounds() = sizeof(uint32_t);
 			  capability.permissions() &=
 			    {Permission::Load, Permission::Global};
 			  result = capability.get();

--- a/sdk/core/scheduler/plic.h
+++ b/sdk/core/scheduler/plic.h
@@ -149,6 +149,12 @@ namespace
 							master().interrupt_complete(source);
 						}
 					}
+
+					// The returned pointer (reference) will have bounds of the
+					// entire futexWords array.  That's likely fine within the
+					// scheduler and saves us a setbounds on the IRQ handling
+					// path, but it does mean that interrupt_futex_get needs to
+					// do the bounding.
 					return {futexWords[i]};
 				}
 			}

--- a/sdk/include/platform/ibex/platform-hardware_revoker.hh
+++ b/sdk/include/platform/ibex/platform-hardware_revoker.hh
@@ -109,6 +109,23 @@ namespace Ibex
 			// Get a pointer to the futex that we use to wait for interrupts.
 			interruptFutex = interrupt_futex_get(
 			  STATIC_SEALED_VALUE(revokerInterruptCapability));
+
+#ifndef CLANG_TIDY
+			{
+				using namespace CHERI;
+
+				auto cap = Capability{interruptFutex};
+
+				Debug::Assert(cap.bounds() == sizeof(uint32_t),
+				              "Interrupt futexes are not properly bounded: {}",
+				              cap);
+				Debug::Assert(
+				  cap.permissions() ==
+				    PermissionSet{Permission::Global, Permission::Load},
+				  "Interrupt futexes are not properly permissioned: {}",
+				  cap);
+			}
+#endif
 		}
 
 		/**


### PR DESCRIPTION
It's probably fine to pass around unbounded results internally, but we should certainly not do so across the compartment boundary.