### PR TITLE
Sunburst: Fix Ethernet ICMP checksum field offset

### DIFF
--- a/sdk/include/platform/sunburst/platform-ethernet.hh
+++ b/sdk/include/platform/sunburst/platform-ethernet.hh
@@ -142,7 +142,7 @@ class Ksz8851Ethernet
 		FlushTransmitQueue             = 1 << 4,
 		TransmitChecksumGenerationIp   = 1 << 5,
 		TransmitChecksumGenerationTcp  = 1 << 6,
-		TransmitChecksumGenerationIcmp = 1 << 9,
+		TransmitChecksumGenerationIcmp = 1 << 8,
 	};
 
 	/**

--- a/sdk/include/platform/sunburst/v0.2/platform-ethernet.hh
+++ b/sdk/include/platform/sunburst/v0.2/platform-ethernet.hh
@@ -149,7 +149,7 @@ class Ksz8851Ethernet
 	  FlushTransmitQueue             = 1 << 4,
 	  TransmitChecksumGenerationIp   = 1 << 5,
 	  TransmitChecksumGenerationTcp  = 1 << 6,
-	  TransmitChecksumGenerationIcmp = 1 << 9,
+	  TransmitChecksumGenerationIcmp = 1 << 8,
 	};
 
 	/**


### PR DESCRIPTION
See Table 4-35 (p. 47) of the datasheet for the KSZ8851SNL/SNLI (KSZ8851 SPI Ethernet MAC) used on Sonata.

The ICMP Checksum Generation field should be the 8th (zero-indexed) bit of the Transmit Control register, not the 9th. This means that with the current Ethernet driver, ICMP checksums are not being generated by Sonata, which is not intended.