### PR TITLE
helper_find_llvm_install: $PATH suffices

### DIFF
--- a/scripts/includes/helper_find_llvm_install.sh
+++ b/scripts/includes/helper_find_llvm_install.sh
@@ -31,7 +31,7 @@ find_llvm_tool() {
 find_llvm_tool_required() {
 	LLVM_TOOL=$(find_llvm_tool $1)
 
-	if [ ! -x ${LLVM_TOOL} ] ; then
+	if ! command -v ${LLVM_TOOL} >/dev/null 2>&1 ; then
 		echo Unable to locate $1, please set TOOLS_PATH to the directory containing the LLVM toolchain. >&2
 		exit 1
 	fi


### PR DESCRIPTION
For required tools, it's fine not to have the actual file name, so long as the thing we have is something the shell understands as a command when run.