### PR TITLE
tests/stack_integrity: correct asm clobbers

### DIFF
--- a/tests/stack_integrity_thread.cc
+++ b/tests/stack_integrity_thread.cc
@@ -114,9 +114,9 @@ int exhaust_thread_stack_spill(__cheri_callback int (*fn)())
 	  "cmove     cs0, csp\n"
 
 	  // Shrink the available stack space
-	  "cgetbase  s1, csp\n"
-	  "addi      s1, s1, %[stackleft]\n"
-	  "csetaddr  csp, csp, s1\n"
+	  "cgetbase  t2, csp\n"
+	  "addi      t2, t2, %[stackleft]\n"
+	  "csetaddr  csp, csp, t2\n"
 
 	  // Make the call
 	  "1:\n"
@@ -127,7 +127,10 @@ int exhaust_thread_stack_spill(__cheri_callback int (*fn)())
 	  "cmove     csp, cs0\n"
 	  : /* outs */ "+C"(res)
 	  : /* ins */[stackleft] "i"(sizeof(void *))
-	  : /* clobbers */ "ct2", "cs0", "cs1");
+	  : /* clobbers */
+	  "cs0" /* scratch in asm above */,
+	  "ct2" /* scratch in asm above */,
+	  "ca1" /* implicitly by the switcher, by .Lhandle_error_in_switcher */);
 
 	*threadStackTestFailed = false;
 	TEST_EQUAL(res, -ENOTENOUGHSTACK, "Bad return value for stack exhaustion");


### PR DESCRIPTION
- We weren't declaring "ca1" as clobbered, but it is as part of the switcher returning -ECOMPARTMENTFAIL and zeroing the 2nd return register.  The control flow here is a little dizzying:

  1. the `cjalr ct2` in `exhaust_thread_stack_spill`, vectors to

  2. the switcher's `__Z26compartment_switcher_entryz`, which reaches

  3. `.Lswitch_entry_first_spill` and traps (bounds violation on `csp`), causing the core to install mtcc as pcc, taking us to

  4. `exception_entry_asm`, which eventually reaches

  5. `.Lhandle_error_in_switcher`, which sets `a0` to `-ENOTENOUGHSTACK` and zeros `a1`, before continuing on to

  6. `.Lhandle_return_context_install`, which updates the to-be-restored `ca0` and `ca1` with those values, sets the context continuation to `.Lswitch_just_return`, and then jumps to

  7. `.Lcommon_context_install`, which restores the full context from the trusted stack and `mret`s (having put the context continuation just set above into `mepcc`) to

  8. `.Lswitch_just_return`, landing us at a `cret` instruction, which, at long last, gets us back to...

  9. the instruction after the `cjalr ct2` from step 1.

- While here, use one fewer scratch register in the asm, making the compiler's life slightly easier