### PR TITLE
Switch to using riscv32cheriot as the default arch name when building.

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -136,7 +136,7 @@ toolchain("cheriot-clang")
 		-- Flags used for C/C++ and assembly
 		local default_flags = {
 			"-target",
-			"riscv32-unknown-unknown",
+			"riscv32cheriot-unknown-unknown",
 			"-mcpu=cheriot",
 			"-mabi=cheriot",
 			"-mxcheri-rvc",


### PR DESCRIPTION
This will be needed to ensure that everything links properly once we
start setting EF_CHERIOT in ELF headers.
