### PR TITLE
sdk/xmake: conditionally link the allocator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       run: |
         set -e
         cd $PWD/examples/03.hello_safe_compartment/
-        xmake f --board=sonata-simulator --sdk=/cheriot-tools/ --board-mixins=sonata-1.x-sram-mixin
+        xmake f --board=sonata-simulator --sdk=/cheriot-tools/ --board-mixins=sonata-1.x-sram-mixin --allocator=false
         xmake
         env SONATA_SIMULATOR_BOOT_STUB=/cheriot-tools/elf/sonata_simulator_sram_boot_stub xmake run
 

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -1307,6 +1307,7 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 	}
 
 	// Set up export tables
+	Debug::log("Populating export tables' PCC/CGP");
 
 	// Helper to construct a writeable pointer to an export table.
 	auto getExportTableHeader = [](const auto &range) {
@@ -1319,6 +1320,12 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 
 	for (auto &compartment : imgHdr.privilegedCompartments)
 	{
+		if (compartment.exportTable.size() == 0)
+		{
+			Debug::log("Skipping privileged compartment without export table");
+			continue;
+		}
+
 		auto expTablePtr = getExportTableHeader(compartment.exportTable);
 		Debug::log("Error handler for compartment is {}",
 		           expTablePtr->errorHandler);

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -700,7 +700,7 @@ namespace
 					                 "Invalid sealed object {}",
 					                 typeAddress);
 				}
-				// Seal with the allocator's sealing key
+				// Seal with the static token sealing key
 				Capability sealedObject =
 				  build(entry.address, entry.size())
 				    .seal(build<void, Root::Type::Seal>(StaticToken, 1));
@@ -1295,13 +1295,16 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 	              2 * sizeof(void *),
 	              PermissionSet{Permission::Global, Permission::Unseal});
 
-	constexpr size_t DynamicSealingLength =
-	  std::numeric_limits<ptraddr_t>::max() - FirstDynamicSoftware + 1;
-	setSealingKey(imgHdr.allocator(), Allocator);
-	setSealingKey(imgHdr.allocator(),
-	              FirstDynamicSoftware,
-	              DynamicSealingLength,
-	              sizeof(void *));
+	if (imgHdr.allocator().code.size() != 0)
+	{
+		constexpr size_t DynamicSealingLength =
+		  std::numeric_limits<ptraddr_t>::max() - FirstDynamicSoftware + 1;
+		setSealingKey(imgHdr.allocator(), Allocator);
+		setSealingKey(imgHdr.allocator(),
+		              FirstDynamicSoftware,
+		              DynamicSealingLength,
+		              sizeof(void *));
+	}
 
 	// Set up export tables
 


### PR DESCRIPTION
This is a long-standing todo, but it's helpful for shrinking some of our `tests.extra` unit tests, even if the full test suite would absolutely not be happy.