### PR TITLE
core/loader: used named values for mie and mstatus

### DIFF
--- a/sdk/core/loader/boot.S
+++ b/sdk/core/loader/boot.S
@@ -148,11 +148,11 @@ start:
 
 	// Done scheduler setup. Now prepare an idle thread.
 	zeroOne			sp
-	li				t1, 0x880
+	li				t1, (MIE_MEIE | MIE_MTIE)
 	// Enable external and timer interrupts.
 	csrs			mie, t1
 	// Globally enable interrupts.
-	csrsi			mstatus, 0x8
+	csrsi			mstatus, MSTATUS_MIE
 	// Yield to the scheduler to start real tasks.
 	ecall
 	// The idle thread sleeps and only waits for interrupts.

--- a/sdk/core/loader/constants.h
+++ b/sdk/core/loader/constants.h
@@ -8,6 +8,8 @@
 #define IMAGE_HEADER_LOADER_DATA_SIZE_OFFSET 10
 
 #ifdef __cplusplus
+#	include <priv/riscv.h>
+
 #	include "types.h"
 #	include "../scheduler/loaderinfo.h"
 namespace
@@ -41,3 +43,6 @@ namespace
 #endif
 
 EXPORT_ASSEMBLY_OFFSET(SchedulerEntryInfo, threads, 16);
+EXPORT_ASSEMBLY_EXPRESSION(MIE_MEIE, priv::MIE_MEIE, 0x800);
+EXPORT_ASSEMBLY_EXPRESSION(MIE_MTIE, priv::MIE_MTIE, 0x080);
+EXPORT_ASSEMBLY_EXPRESSION(MSTATUS_MIE, priv::MSTATUS_MIE, 8);

--- a/sdk/include/priv/riscv.h
+++ b/sdk/include/priv/riscv.h
@@ -127,6 +127,9 @@ namespace priv
 	constexpr size_t MIE_STIE = (1 << 5);
 	constexpr size_t MIE_HTIE = (1 << 6);
 	constexpr size_t MIE_MTIE = (1 << 7);
+	constexpr size_t MIE_SEIE = (1 << 9);
+	constexpr size_t MIE_HEIE = (1 << 10);
+	constexpr size_t MIE_MEIE = (1 << 11);
 
 	constexpr size_t MIP_USIP = (1 << 0);
 	constexpr size_t MIP_SSIP = (1 << 1);
@@ -137,6 +140,7 @@ namespace priv
 	constexpr size_t MIP_HTIP = (1 << 6);
 	constexpr size_t MIP_MTIP = (1 << 7);
 	constexpr size_t MIP_SEIP = (1 << 9);
+	constexpr size_t MIE_HEIP = (1 << 10);
 	constexpr size_t MIP_MEIP = (1 << 11);
 
 	static inline size_t intr_disable(void)


### PR DESCRIPTION
NFCI, just doing away with some magic numbers