### PR TITLE
sunburst/uart: add reset()

### DIFF
--- a/sdk/include/platform/sunburst/platform-uart.hh
+++ b/sdk/include/platform/sunburst/platform-uart.hh
@@ -259,6 +259,15 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 		control &= ~(ControlTransmitEnable | ControlReceiveEnable);
 	}
 
+	/**
+	 * Reset the control register to all zeros.  That disables the transceivers,
+	 * clears any loopbacks, disables parity, and so on.
+	 */
+	void reset() volatile
+	{
+		control = 0;
+	}
+
 	[[gnu::always_inline]] uint16_t transmit_fifo_level() volatile
 	{
 		return fifoStatus & 0xff;


### PR DESCRIPTION
Turns out, we might want to forcibly zero the control register, too, now that init() doesn't.

Sorry for the spam; I should have included this with #541 but didn't think things through enough.