### PR TITLE
Use the new support for aliases in the toolchain to make memmove an alias to memcpy.

### DIFF
--- a/sdk/lib/freestanding/memcpy.c
+++ b/sdk/lib/freestanding/memcpy.c
@@ -121,6 +121,10 @@ done:
 }
 
 void *memmove(void *dst0, const void *src0, size_t length)
+#if defined(__CHERIOT__) && (__CHERIOT__ >= 20250610)
+  __attribute__((alias("memcpy")));
+#else
 {
 	return memcpy(dst0, src0, length);
 }
+#endif


### PR DESCRIPTION
NOTE: This needs a devcontainer release to happen containing the alias support before it can be landed.
