### PR TITLE
debug.hh: add convenience log_if helpers & tests

### DIFF
--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -752,6 +752,39 @@ namespace
 			}
 		}
 
+		template<DebugLevel Level = DebugLevel::Information>
+		static __always_inline void
+		log_if(bool condition, const char *fmt, auto... args)
+		{
+			static_assert(
+			  Level != DebugLevel::None,
+			  "None is valid only as a threshold, not as a reporting level");
+			if constexpr (Level >= Threshold)
+			{
+				if (condition)
+				{
+					log<Level>(fmt, args...);
+				}
+			}
+		}
+
+		template<DebugLevel                   Level = DebugLevel::Information,
+		         DebugConcepts::LazyAssertion Condition>
+		static __always_inline void
+		log_if(Condition condition, const char *fmt, auto... args)
+		{
+			static_assert(
+			  Level != DebugLevel::None,
+			  "None is valid only as a threshold, not as a reporting level");
+			if constexpr (Level >= Threshold)
+			{
+				if (condition())
+				{
+					log<Level>(fmt, args...);
+				}
+			}
+		}
+
 		/**
 		 * Helper to report failure.
 		 *

--- a/tests/debug-test.cc
+++ b/tests/debug-test.cc
@@ -25,5 +25,30 @@ int test_debug_cxx()
 	  "This should not be printed (information)");
 	Warn::log<DebugLevel::Warning>("This should be printed (warning)");
 	Warn::log<DebugLevel::Error>("This should be printed (error)");
+
+	{
+		bool correctEval = false;
+		Warn::log_if<DebugLevel::Error>(
+		  [&]() {
+			  correctEval = true;
+			  return true;
+		  },
+		  "This conditional log line should be printed");
+		Warn::Invariant(correctEval,
+		                "Failed to evaluate conditional log's lambda");
+	}
+
+	{
+		bool excessiveEval = false;
+		Warn::log_if<DebugLevel::Information>(
+		  [&]() {
+			  excessiveEval = true;
+			  return true;
+		  },
+		  "This conditional log line should not be printed");
+		Warn::Invariant(!excessiveEval,
+		                "Suppressed conditional log still evaluated");
+	}
+
 	return 0;
 }


### PR DESCRIPTION
In particular, add a lambda-taking form like ::Assert() to help the compiler eliminate useless logging code that's below the current threshold.