### PR TITLE
Shared objects might want LoadGlobal permission

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -1034,7 +1034,8 @@ class MState
 	 */
 	[[nodiscard]] __always_inline auto hazard_list_begin()
 	{
-		auto    *lockWord{SHARED_OBJECT(uint32_t, allocator_epoch)};
+		auto    *lockWord{SHARED_OBJECT_WITH_DATA_PERMISSIONS(
+          uint32_t, allocator_epoch, true, true)};
 		uint32_t epoch = *lockWord >> 16;
 		Debug::Invariant(
 		  (epoch & 1) == 0,
@@ -1284,9 +1285,14 @@ class MState
 	bool hazard_pointer_check(Capability<void> allocation)
 	{
 		// It is now safe to walk the hazard list.
-		Capability<void *> hazards =
-		  const_cast<void **>(SHARED_OBJECT_WITH_PERMISSIONS(
-		    void *, allocator_hazard_pointers, true, false, true, false));
+		Capability<void *> hazards = const_cast<void **>(
+		  SHARED_OBJECT_WITH_PERMISSIONS(void *,
+		                                 allocator_hazard_pointers,
+		                                 true,
+		                                 false,
+		                                 true,
+		                                 false,
+		                                 false));
 		size_t pointers = hazards.length() / sizeof(void *);
 		for (size_t i = 0; i < pointers; i++)
 		{

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -100,9 +100,13 @@ namespace
 		Capability m{tbase.cast<MState>()};
 
 		size_t hazardQuarantineSize =
-		  Capability{
-		    SHARED_OBJECT_WITH_PERMISSIONS(
-		      void *, allocator_hazard_pointers, true, false, true, false)}
+		  Capability{SHARED_OBJECT_WITH_PERMISSIONS(void *,
+		                                            allocator_hazard_pointers,
+		                                            true,
+		                                            false,
+		                                            true,
+		                                            false,
+		                                            false)}
 		    .length();
 
 		m.bounds()            = sizeof(*m);
@@ -129,13 +133,15 @@ namespace
 	{
 		if (gm == nullptr)
 		{
+			// Access without LoadGlobal to help ensure we don't break isolation
 			Capability heap = const_cast<void *>(
 			  MMIO_CAPABILITY_WITH_PERMISSIONS(void,
 			                                   heap,
 			                                   /*load*/ true,
 			                                   /*store*/ true,
 			                                   /*capabilities*/ true,
-			                                   /*loadMutable*/ true));
+			                                   /*loadMutable*/ true,
+			                                   /*loadGlobal*/ false));
 
 			revoker.init();
 			gm = mstate_init(heap, heap.bounds());

--- a/sdk/core/loader/types.h
+++ b/sdk/core/loader/types.h
@@ -858,11 +858,17 @@ namespace loader
 		static constexpr size_t PermitLoadMutable = (1UL << 28);
 
 		/**
+		 * Bit in `sizeAndPermissions` indicating that this import has
+		 * load-global permission.
+		 */
+		static constexpr size_t PermitLoadGlobal = (1UL << 27);
+
+		/**
 		 * Mask for the used permissions.
 		 */
-		static constexpr size_t PermissionsMask = PermitLoad | PermitStore |
-		                                          PermitLoadStoreCapabilities |
-		                                          PermitLoadMutable;
+		static constexpr size_t PermissionsMask =
+		  PermitLoad | PermitStore | PermitLoadStoreCapabilities |
+		  PermitLoadMutable | PermitLoadGlobal;
 
 		/**
 		 * Mask for the space reserved for permissions.
@@ -941,7 +947,8 @@ namespace loader
 			  Permission::Load,
 			  Permission::Store,
 			  Permission::LoadStoreCapability,
-			  Permission::LoadMutable};
+			  Permission::LoadMutable,
+			  Permission::LoadGlobal};
 			CHERI::PermissionSet p{DefaultPermissions};
 			if ((sizeAndPermissions & PermitLoad) == 0)
 			{
@@ -958,6 +965,10 @@ namespace loader
 			if ((sizeAndPermissions & PermitLoadMutable) == 0)
 			{
 				p = p.without(Permission::LoadMutable);
+			}
+			if ((sizeAndPermissions & PermitLoadGlobal) == 0)
+			{
+				p = p.without(Permission::LoadGlobal);
 			}
 			return p;
 		}

--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -16,7 +16,7 @@
 		static const struct Perms                                              \
 		{                                                                      \
 			bool permitLoad, permitStore, permitLoadStoreCapabilities,         \
-			  permitLoadMutable;                                               \
+			  permitLoadMutable, permitLoadGlobal;                             \
 		} perms = {__VA_ARGS__};                                               \
 		type *ret; /* NOLINT(bugprone-macro-parentheses) */                    \
 		__asm(".ifndef " mangledName "\n"                                      \
@@ -38,7 +38,8 @@
 		      : "i"(((perms.permitLoad) ? (1 << 31) : 0) +                     \
 		            ((perms.permitStore) ? (1 << 30) : 0) +                    \
 		            ((perms.permitLoadStoreCapabilities) ? (1 << 29) : 0) +    \
-		            ((perms.permitLoadMutable) ? (1 << 28) : 0)));             \
+		            ((perms.permitLoadMutable) ? (1 << 28) : 0) +              \
+		            ((perms.permitLoadGlobal) ? (1 << 27) : 0)));              \
 		ret;                                                                   \
 	})
 
@@ -48,8 +49,8 @@
  * can be used only in code (it cannot be used to initialise a global).
  *
  * The last arguments specify the set of permissions that this capability
- * holds: Load Data (LD), Store Data (SD), Memory Capabilities (MC), and Load
- * Mutable (LM).
+ * holds: Load Data (LD), Store Data (SD), Memory Capabilities (MC), Load
+ * Mutable (LM), and Load Global (LG).
  *
  * MMIO capabilities are always global (GL) and without store local (SL).
  */
@@ -79,8 +80,8 @@
  * used to initialise a global).
  *
  * The last arguments specify the set of permissions that this capability
- * holds: Load Data (LD), Store Data (SD), Memory Capabilities (MC), and Load
- * Mutable (LM).
+ * holds: Load Data (LD), Store Data (SD), Memory Capabilities (MC), Load
+ * Mutable (LM), and Load Global (LG).
  *
  * Capabilities to pre-shared objects are always global (GL) and without store
  * local (SL).
@@ -103,7 +104,21 @@
  * To define a reduced set of permissions use `SHARED_OBJECT_WITH_PERMISSIONS`.
  */
 #define SHARED_OBJECT(type, name)                                              \
-	SHARED_OBJECT_WITH_PERMISSIONS(type, name, true, true, true, true)
+	SHARED_OBJECT_WITH_PERMISSIONS(type, name, true, true, true, true, true)
+
+/**
+ * Provide a capability of the type `type *` referring to the pre-shared object
+ * with `name` as its name.  This macro can be used only in code (it cannot be
+ * used to initialise a global).
+ *
+ * Pre-shared object capabilities produced by this macro have the indicated load
+ * and store permission, but no load/store-capability permissions (and,
+ * therefore, no load-mutable or load-global permissions).
+ */
+#define SHARED_OBJECT_WITH_DATA_PERMISSIONS(                                   \
+  type, name, permitLoad, permitStore)                                         \
+	SHARED_OBJECT_WITH_PERMISSIONS(                                            \
+	  type, name, permitLoad, permitStore, false, false, false)
 
 /**
  * Macro to test whether a device with a specific name exists in the board

--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -10,15 +10,14 @@
  * Helper macro for MMIO and pre-shared object imports, should not be used
  * directly.
  */
-#define IMPORT_CAPABILITY_WITH_PERMISSIONS_HELPER(type,                        \
-                                                  name,                        \
-                                                  prefix,                      \
-                                                  mangledName,                 \
-                                                  permitLoad,                  \
-                                                  permitStore,                 \
-                                                  permitLoadStoreCapabilities, \
-                                                  permitLoadMutable)           \
+#define IMPORT_CAPABILITY_WITH_PERMISSIONS_HELPER(                             \
+  type, name, prefix, mangledName, ...)                                        \
 	({                                                                         \
+		static const struct Perms                                              \
+		{                                                                      \
+			bool permitLoad, permitStore, permitLoadStoreCapabilities,         \
+			  permitLoadMutable;                                               \
+		} perms = {__VA_ARGS__};                                               \
 		type *ret; /* NOLINT(bugprone-macro-parentheses) */                    \
 		__asm(".ifndef " mangledName "\n"                                      \
 		      "  .type     " mangledName ",@object\n"                          \
@@ -36,31 +35,12 @@
 		      "      %%cheriot_compartment_hi(" mangledName ")\n"              \
 		      "  clc     %0, %%cheriot_compartment_lo_i(1b)(%0)\n"             \
 		      : "=C"(ret)                                                      \
-		      : "i"(((permitLoad) ? (1 << 31) : 0) +                           \
-		            ((permitStore) ? (1 << 30) : 0) +                          \
-		            ((permitLoadStoreCapabilities) ? (1 << 29) : 0) +          \
-		            ((permitLoadMutable) ? (1 << 28) : 0)));                   \
+		      : "i"(((perms.permitLoad) ? (1 << 31) : 0) +                     \
+		            ((perms.permitStore) ? (1 << 30) : 0) +                    \
+		            ((perms.permitLoadStoreCapabilities) ? (1 << 29) : 0) +    \
+		            ((perms.permitLoadMutable) ? (1 << 28) : 0)));             \
 		ret;                                                                   \
 	})
-
-/**
- * Helper macro, should not be used directly.
- */
-#define MMIO_CAPABILITY_WITH_PERMISSIONS_HELPER(type,                          \
-                                                name,                          \
-                                                mangledName,                   \
-                                                permitLoad,                    \
-                                                permitStore,                   \
-                                                permitLoadStoreCapabilities,   \
-                                                permitLoadMutable)             \
-	IMPORT_CAPABILITY_WITH_PERMISSIONS_HELPER(type,                            \
-	                                          name,                            \
-	                                          __export_mem_,                   \
-	                                          mangledName,                     \
-	                                          permitLoad,                      \
-	                                          permitStore,                     \
-	                                          permitLoadStoreCapabilities,     \
-	                                          permitLoadMutable)
 
 /**
  * Provide a capability of the type `volatile type *` referring to the MMIO
@@ -68,24 +48,18 @@
  * can be used only in code (it cannot be used to initialise a global).
  *
  * The last arguments specify the set of permissions that this capability
- * holds.  MMIO capabilities are always global and without store local.  They
- * may optionally omit additional capabilities.
+ * holds: Load Data (LD), Store Data (SD), Memory Capabilities (MC), and Load
+ * Mutable (LM).
+ *
+ * MMIO capabilities are always global (GL) and without store local (SL).
  */
-#define MMIO_CAPABILITY_WITH_PERMISSIONS(type,                                 \
-                                         name,                                 \
-                                         permitLoad,                           \
-                                         permitStore,                          \
-                                         permitLoadStoreCapabilities,          \
-                                         permitLoadMutable)                    \
-	MMIO_CAPABILITY_WITH_PERMISSIONS_HELPER(                                   \
+#define MMIO_CAPABILITY_WITH_PERMISSIONS(type, name, ...)                      \
+	IMPORT_CAPABILITY_WITH_PERMISSIONS_HELPER(                                 \
 	  volatile type, /* NOLINT(bugprone-macro-parentheses) */                  \
 	  name,                                                                    \
-	  "__import_mem_" #name "_" #permitLoad "_" #permitStore                   \
-	  "_" #permitLoadStoreCapabilities "_" #permitLoadMutable,                 \
-	  permitLoad,                                                              \
-	  permitStore,                                                             \
-	  permitLoadStoreCapabilities,                                             \
-	  permitLoadMutable)
+	  __export_mem_,                                                           \
+	  "\"__import_mem_" #name "_" #__VA_ARGS__ "\"",                           \
+	  __VA_ARGS__)
 
 /**
  * Provide a capability of the type `volatile type *` referring to the MMIO
@@ -97,7 +71,7 @@
  * MMIO_CAPABILITY_WITH_PERMISSIONS.
  */
 #define MMIO_CAPABILITY(type, name)                                            \
-	MMIO_CAPABILITY_WITH_PERMISSIONS(type, name, true, true, false, false)
+	MMIO_CAPABILITY_WITH_PERMISSIONS(type, name, true, true)
 
 /**
  * Provide a capability of the type `type *` referring to the pre-shared object
@@ -105,34 +79,28 @@
  * used to initialise a global).
  *
  * The last arguments specify the set of permissions that this capability
- * holds.  Pre-shared objects are always global and without store local.  They
- * may optionally omit additional permissions.
+ * holds: Load Data (LD), Store Data (SD), Memory Capabilities (MC), and Load
+ * Mutable (LM).
+ *
+ * Capabilities to pre-shared objects are always global (GL) and without store
+ * local (SL).
  */
-#define SHARED_OBJECT_WITH_PERMISSIONS(type,                                   \
-                                       name,                                   \
-                                       permitLoad,                             \
-                                       permitStore,                            \
-                                       permitLoadStoreCapabilities,            \
-                                       permitLoadMutable)                      \
+#define SHARED_OBJECT_WITH_PERMISSIONS(type, name, ...)                        \
 	IMPORT_CAPABILITY_WITH_PERMISSIONS_HELPER(                                 \
 	  type, /* NOLINT(bugprone-macro-parentheses) */                           \
 	  name,                                                                    \
 	  __cheriot_shared_object_,                                                \
-	  "__import_cheriot_shared_object_" #name "_" #permitLoad "_" #permitStore \
-	  "_" #permitLoadStoreCapabilities "_" #permitLoadMutable,                 \
-	  permitLoad,                                                              \
-	  permitStore,                                                             \
-	  permitLoadStoreCapabilities,                                             \
-	  permitLoadMutable)
+	  "\"__import_cheriot_shared_object_" #name "_" #__VA_ARGS__ "\"",         \
+	  __VA_ARGS__)
 
 /**
  * Provide a capability of the type `type *` referring to the pre-shared object
  * with `name` as its name.  This macro can be used only in code (it cannot be
  * used to initialise a global).
  *
- * Pre-shared object capabilities produced by this macro have load, store,
- * load-mutable, and load/store-capability permissions.  To define a reduced
- * set of permissions use `SHARED_OBJECT_WITH_PERMISSIONS`.
+ * Pre-shared object capabilities produced by this macro have Load Data (LD),
+ * Store Data (SD), Memory Capability (MC), and Load Mutable (LM) permissions.
+ * To define a reduced set of permissions use `SHARED_OBJECT_WITH_PERMISSIONS`.
  */
 #define SHARED_OBJECT(type, name)                                              \
 	SHARED_OBJECT_WITH_PERMISSIONS(type, name, true, true, true, true)

--- a/sdk/lib/compartment_helpers/claim_fast.cc
+++ b/sdk/lib/compartment_helpers/claim_fast.cc
@@ -10,9 +10,9 @@
 int heap_claim_ephemeral(Timeout *timeout, const void *ptr, const void *ptr2)
 {
 	void   **hazards = switcher_thread_hazard_slots();
-	auto    *epochCounter{const_cast<
-	     cheriot::atomic<uint32_t> *>(SHARED_OBJECT_WITH_PERMISSIONS(
-      cheriot::atomic<uint32_t>, allocator_epoch, true, false, false, false))};
+	auto    *epochCounter{const_cast<cheriot::atomic<uint32_t> *>(
+      SHARED_OBJECT_WITH_DATA_PERMISSIONS(
+        cheriot::atomic<uint32_t>, allocator_epoch, true, false))};
 	uint32_t epoch  = epochCounter->load();
 	int      values = 2;
 	// Skip processing pointers that don't refer to heap memory.

--- a/tests.extra/regress-double_ref_shared/top1.cc
+++ b/tests.extra/regress-double_ref_shared/top1.cc
@@ -2,8 +2,7 @@
 
 void top1()
 {
-	auto ref1 =
-	  SHARED_OBJECT_WITH_PERMISSIONS(struct Foo, foo, true, true, false, false);
+	auto ref1 = SHARED_OBJECT_WITH_DATA_PERMISSIONS(Foo, foo, true, true);
 
 	ref1->bar = 1;
 }

--- a/tests.extra/regress-double_ref_shared/top2.cc
+++ b/tests.extra/regress-double_ref_shared/top2.cc
@@ -6,8 +6,7 @@ using Debug = ConditionalDebug<true, "top2">;
 
 void top2()
 {
-	auto ref2 = SHARED_OBJECT_WITH_PERMISSIONS(
-	  struct Foo, foo, true, false, false, false);
+	auto ref2 = SHARED_OBJECT_WITH_DATA_PERMISSIONS(Foo, foo, true, false);
 
 	Debug::log("ref2: {}", ref2->bar);
 }

--- a/tests/misc-test.cc
+++ b/tests/misc-test.cc
@@ -534,22 +534,30 @@ int test_misc()
 	                     Permission::Load,
 	                     Permission::Store,
 	                     Permission::LoadStoreCapability,
-	                     Permission::LoadMutable});
+	                     Permission::LoadMutable,
+	                     Permission::LoadGlobal});
 	check_shared_object(
 	  "exampleK",
-	  SHARED_OBJECT_WITH_PERMISSIONS(void, exampleK, true, true, false, false),
+	  SHARED_OBJECT_WITH_PERMISSIONS(
+	    void, exampleK, true, true, false, false, false),
 	  1024,
 	  {Permission::Global, Permission::Load, Permission::Store});
 	check_shared_object(
 	  "test_word",
-	  SHARED_OBJECT_WITH_PERMISSIONS(void, test_word, true, false, true, false),
+	  SHARED_OBJECT_WITH_PERMISSIONS(
+	    void, test_word, true, false, true, false, false),
 	  4,
 	  {Permission::Global, Permission::Load, Permission::LoadStoreCapability});
 	check_shared_object("test_word",
 	                    SHARED_OBJECT_WITH_PERMISSIONS(
-	                      void, test_word, true, false, false, false),
+	                      void, test_word, true, false, false, false, false),
 	                    4,
 	                    {Permission::Global, Permission::Load});
+	check_shared_object(
+	  "test_word data",
+	  SHARED_OBJECT_WITH_DATA_PERMISSIONS(void, test_word, true, false),
+	  4,
+	  {Permission::Global, Permission::Load});
 	check_odd_memcmp();
 	TEST_EQUAL(strnlen(*volatileString, 3),
 	           3,

--- a/tests/mmio-test.cc
+++ b/tests/mmio-test.cc
@@ -59,6 +59,9 @@ int test_mmio()
 	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, false, false),
 	  {Permission::Global, Permission::Load, Permission::Store});
 	check_permissions(
+	  MMIO_CAPABILITY(Uart, uart) /* check default permissions */,
+	  {Permission::Global, Permission::Load, Permission::Store});
+	check_permissions(
 	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, true, false),
 	  {Permission::Global,
 	   Permission::Load,

--- a/tests/mmio-test.cc
+++ b/tests/mmio-test.cc
@@ -16,66 +16,86 @@ void check_permissions(Capability<volatile void> mmio, PermissionSet p)
 
 int test_mmio()
 {
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, false, false, false, false, false),
+	                  {Permission::Global});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, false, false, true, false, false),
+	                  {Permission::Global});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, false, false, false, true, false),
+	                  {Permission::Global});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, false, false, true, true, false),
+	                  {Permission::Global});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, false, true, false, false, false),
+	                  {Permission::Global, Permission::Store});
 	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, false, false, false),
-	  {Permission::Global});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, false, true, false),
-	  {Permission::Global});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, false, false, true),
-	  {Permission::Global});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, false, true, true),
-	  {Permission::Global});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, true, false, false),
-	  {Permission::Global, Permission::Store});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, true, true, false),
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(
+	    Uart, uart, false, true, true, false, false),
 	  {Permission::Global, Permission::Store, Permission::LoadStoreCapability});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, false, true, false, true, false),
+	                  {Permission::Global, Permission::Store});
 	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, true, false, true),
-	  {Permission::Global, Permission::Store});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, false, true, true, true),
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(
+	    Uart, uart, false, true, true, true, false),
 	  {Permission::Global, Permission::Store, Permission::LoadStoreCapability});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, true, false, false, false, false),
+	                  {Permission::Global, Permission::Load});
 	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, false, false, false),
-	  {Permission::Global, Permission::Load});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, false, true, false),
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(
+	    Uart, uart, true, false, true, false, false),
 	  {Permission::Global, Permission::Load, Permission::LoadStoreCapability});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, true, false, false, true, false),
+	                  {Permission::Global, Permission::Load});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, true, false, true, true, false),
+	                  {Permission::Global,
+	                   Permission::Load,
+	                   Permission::LoadStoreCapability,
+	                   Permission::LoadMutable});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, true, false, true, true, true),
+	                  {Permission::Global,
+	                   Permission::Load,
+	                   Permission::LoadStoreCapability,
+	                   Permission::LoadMutable,
+	                   Permission::LoadGlobal});
 	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, false, false, true),
-	  {Permission::Global, Permission::Load});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, false, true, true),
-	  {Permission::Global,
-	   Permission::Load,
-	   Permission::LoadStoreCapability,
-	   Permission::LoadMutable});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, false, false),
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(
+	    Uart, uart, true, true, false, false, false),
 	  {Permission::Global, Permission::Load, Permission::Store});
 	check_permissions(
 	  MMIO_CAPABILITY(Uart, uart) /* check default permissions */,
 	  {Permission::Global, Permission::Load, Permission::Store});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, true, true, true, false, false),
+	                  {Permission::Global,
+	                   Permission::Load,
+	                   Permission::Store,
+	                   Permission::LoadStoreCapability});
 	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, true, false),
-	  {Permission::Global,
-	   Permission::Load,
-	   Permission::Store,
-	   Permission::LoadStoreCapability});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, false, true),
+	  MMIO_CAPABILITY_WITH_PERMISSIONS(
+	    Uart, uart, true, true, false, true, false),
 	  {Permission::Global, Permission::Load, Permission::Store});
-	check_permissions(
-	  MMIO_CAPABILITY_WITH_PERMISSIONS(Uart, uart, true, true, true, true),
-	  {Permission::Global,
-	   Permission::Load,
-	   Permission::Store,
-	   Permission::LoadStoreCapability,
-	   Permission::LoadMutable});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, true, true, true, true, false),
+	                  {Permission::Global,
+	                   Permission::Load,
+	                   Permission::Store,
+	                   Permission::LoadStoreCapability,
+	                   Permission::LoadMutable});
+	check_permissions(MMIO_CAPABILITY_WITH_PERMISSIONS(
+	                    Uart, uart, true, true, true, true, true),
+	                  {Permission::Global,
+	                   Permission::Load,
+	                   Permission::Store,
+	                   Permission::LoadStoreCapability,
+	                   Permission::LoadMutable,
+	                   Permission::LoadGlobal});
 	return 0;
 }


### PR DESCRIPTION
Changes `sdk/core/loader/types.h` to introduce a PermitLoadGlobal bit on import entries and teaches `sdk/include/compartment-macros.h` to use it.  The rest of the changes are catching up core components and the test suite (which is expanded a bit to test the new bit).

This will not pass CI because the compiler currently mismatches the (existing) loader, in that it only masked out the top 4, not 8, bits of the length for types.  Local testing with https://github.com/CHERIoT-Platform/llvm-project/pull/180 suggests that at least that is simple to fix.

This surely conflicts with #545 and, unless @davidchisnall thinks I'm about to blow a hole in the security model, will require revisions to https://github.com/CHERIoT-Platform/llvm-project/pull/147 .

Tagging @xdoardo who, for some reason, isn't eligible as a reviewer.  