### PR TITLE
Various fixes to the allocator and the allocator tests.

### DIFF
--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -511,8 +511,7 @@ namespace
 		auto claim      = [&]() {
             ssize_t claimSize = heap_claim(SECOND_HEAP, alloc);
             claimCount++;
-            TEST((allocSize <= claimSize) &&
-                   (claimSize <= allocSize + CHERIOTHeapMinChunkSize),
+            TEST((allocSize <= claimSize),
                  "{}-byte allocation claimed as {} bytes (claim number {})",
                  allocSize,
                  claimSize,

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -78,7 +78,7 @@ namespace
 		int res = heap_free(MALLOC_CAPABILITY, p);
 		TEST_EQUAL(res, 0, "heap_free returned nonzero");
 		TEST(
-		  !Capability{p}.is_valid(),
+		  !Capability{p}.is_valid_temporal(),
 		  "Freed pointer still live; load barrier or revoker out of service?");
 	}
 
@@ -631,10 +631,10 @@ namespace
 		TEST_EQUAL(heap_free(SECOND_HEAP, ptr2), 0, "Second free failed");
 		debug_log("After free 2, quota left: {}",
 		          heap_quota_remaining(SECOND_HEAP));
-		TEST(Capability{ptr}.is_valid(),
+		TEST(Capability{ptr}.is_valid_temporal(),
 		     "Pointer in hazard slot was freed: {}",
 		     ptr);
-		TEST(Capability{ptr2}.is_valid(),
+		TEST(Capability{ptr2}.is_valid_temporal(),
 		     "Pointer in hazard slot was freed: {}",
 		     ptr2);
 		state = 2;
@@ -847,7 +847,7 @@ int test_allocator()
 		q.without_permissions(CHERI::Permission::Global);
 
 		TEST_SUCCESS(heap_free(MALLOC_CAPABILITY, q));
-		TEST(!Capability{p}.is_valid(),
+		TEST(!Capability{p}.is_valid_temporal(),
 		     "Free of non-global pointer failed to revoke");
 	}
 


### PR DESCRIPTION
- Demonstrate a race in the allocator between claims and ephemeral claims, and how this race may lead the allocator to ignore a claim and make quota disappear into the void. Fix this by checking the number of claims on an object when removing it from the hazard quarantine (surprisingly small patch, hopefully I got it right!). This corner-case was reported by Reto Achermann (UBC) as we are working on formally verifying the allocator.
- Improve allocator tests to make them more readable and expressive.
- The tests have multiple instances of using `is_valid` to check tags when they should be using something not subject to CSE (here be dragons). I made the mistake myself when updating the tests. Address this by adding a C++ wrapper `is_valid_temporal` for `__builtin_cheri_tag_get_temporal` and using it where appropriate in the tests. Make sure the behavior w.r.t. CSE is well-documented.

Entirely artisanal, no AI involved. All hallucinations are mine.