### PR TITLE
Add bitpacks.hh, a proxy-based wrapper for packed bit-fields

### DIFF
--- a/sdk/include/__macro_map.h
+++ b/sdk/include/__macro_map.h
@@ -8,10 +8,15 @@
  *
  * You can copy, modify, distribute and perform the work,
  * even for commercial purposes, all without asking permission.
- *
- * CHERIoT modifications:
+ */
+/*
+ * The CHERIoT import is taken from https://github.com/swansontec/map-macro,
+ * specifically, the commit with SHA-1 033a3e7f151c9f3e1baabfe3868a3a8ef2bb0304
+ * and lightly modified as follows:
  * - Added CHERIOT_ prefix to all macros to avoid namespace pollution
  * - Used pragma once instead of include guards
+ * - Formatted to fit local conventions
+ * - Removed the MAP_UD_I and MAP_LIST_UD_I variants (and the MAP_INC* helpers)
  */
 
 #pragma once
@@ -45,6 +50,11 @@
 #define CHERIOT_MAP1(f, x, peek, ...)                                          \
 	f(x) CHERIOT_MAP_NEXT(peek, CHERIOT_MAP0)(f, peek, __VA_ARGS__)
 
+#define CHERIOT_MAP0_UD(f, ud, x, peek, ...)                                   \
+	f(x, ud) CHERIOT_MAP_NEXT(peek, CHERIOT_MAP1_UD)(f, ud, peek, __VA_ARGS__)
+#define CHERIOT_MAP1_UD(f, ud, x, peek, ...)                                   \
+	f(x, ud) CHERIOT_MAP_NEXT(peek, CHERIOT_MAP0_UD)(f, ud, peek, __VA_ARGS__)
+
 #define CHERIOT_MAP_LIST_NEXT1(test, next)                                     \
 	CHERIOT_MAP_NEXT0(test, CHERIOT_MAP_COMMA next, 0)
 #define CHERIOT_MAP_LIST_NEXT(test, next)                                      \
@@ -55,6 +65,13 @@
 #define CHERIOT_MAP_LIST1(f, x, peek, ...)                                     \
 	f(x) CHERIOT_MAP_LIST_NEXT(peek, CHERIOT_MAP_LIST0)(f, peek, __VA_ARGS__)
 
+#define CHERIOT_MAP_LIST0_UD(f, ud, x, peek, ...)                              \
+	f(x, ud) CHERIOT_MAP_LIST_NEXT(peek, CHERIOT_MAP_LIST1_UD)(                \
+	  f, ud, peek, __VA_ARGS__)
+#define CHERIOT_MAP_LIST1_UD(f, ud, x, peek, ...)                              \
+	f(x, ud) CHERIOT_MAP_LIST_NEXT(peek, CHERIOT_MAP_LIST0_UD)(                \
+	  f, ud, peek, __VA_ARGS__)
+
 /**
  * Applies the function macro `f` to each of the remaining parameters.
  */
@@ -62,8 +79,26 @@
 	CHERIOT_EVAL(CHERIOT_MAP1(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
 
 /**
+ * Applies the function macro `f` to each of the remaining parameters and passes
+ * userdata as the second parameter to each invocation, e.g. MAP_UD(f, x, a, b,
+ * c) evaluates to f(a, x) f(b, x) f(c, x)
+ */
+#define CHERIOT_MAP_UD(f, ud, ...)                                             \
+	CHERIOT_EVAL(CHERIOT_MAP1_UD(f, ud, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
+
+/**
  * Applies the function macro `f` to each of the remaining parameters and
  * inserts commas between the results.
  */
 #define CHERIOT_MAP_LIST(f, ...)                                               \
 	CHERIOT_EVAL(CHERIOT_MAP_LIST1(f, __VA_ARGS__, ()()(), ()()(), ()()(), 0))
+
+/**
+ * Applies the function macro `f` to each of the remaining parameters, inserts
+ * commas between the results, and passes userdata as the second parameter to
+ * each invocation, e.g. MAP_LIST_UD(f, x, a, b, c) evaluates to f(a, x), f(b,
+ * x), f(c, x)
+ */
+#define CHERIOT_MAP_LIST_UD(f, ud, ...)                                        \
+	CHERIOT_EVAL(                                                              \
+	  CHERIOT_MAP_LIST1_UD(f, ud, __VA_ARGS__, ()()(), ()()(), ()()(), 0))

--- a/sdk/include/bitpack.hh
+++ b/sdk/include/bitpack.hh
@@ -1,0 +1,1471 @@
+#pragma once
+
+/**
+ * \defgroup bitpacks Bitpacks
+ *
+ * \section bitpacks_intro Introduction
+ *
+ * `Bitpack`-s are a way to handle situations where many flags and/or fields of
+ * arbitrary widths are packed into an underlying integer (such as a `uint32_t`
+ * and referred to as a `Bitpack`'s `Storage` type) at arbitrary bit alignments.
+ * This is similar to C and C++'s bitfields, but more portable, more versatile,
+ * and with a type-centric interface.  They encapsulate the bitwise AND, OR, and
+ * shift operations required to get at spans of bits within a word.  They are
+ * meant to be particularly useful for handling memory mapped I/O (MMIO)
+ * registers for hardware drivers.
+ *
+ * Those readers interested in formal details are invited to see \ref
+ * bitpacks_formal.
+ *
+ * `Bitpack`-s support the following features:
+ *
+ * * Arbitrary width numeric fields at arbitrary bit position within an
+ *   underlying integer type.
+ *
+ * * Arbitrary width enumeration fields, again at arbitrary position.
+ *
+ * * `const` fields to represent, for example, fields mutable only by hardware.
+ *
+ * * `volatile` `Bitpacks` require overt reads and writes, making it easier to
+ *   map program source to memory or register updates.  Individual methods'
+ *   documentation will call out special handling of `volatile` forms.
+ *
+ * * a type-centric perspective on fields, with type-based accessors (getters,
+ *   setters, read-modify-write helpers, &c).
+ *
+ * * usable in `constexpr` contexts.
+ *
+ * \subsection bitpacks_intro_defining Defining Bitpacks and Fields
+ *
+ * To define a bitpack, begin by defining a `class` (or `struct`) that inherits
+ * from the `Bitpack` template given below, specifying the underlying `Storage`
+ * type as the template parameter.  It usually suffices to pick one of the
+ * `uintNN_t` `cstdint` types.  For reasons of C++, one often wants a bit of
+ * syntax at the top of these definitions, which is encapsulated in the
+ * `BITPACK_USUAL_PREFIX` macro; add that at the top of your derived class.  We
+ * then need to specify fields of the bitpack in question.
+ *
+ * For each field, this means, ultimately, defining a call to the
+ * `Bitpack::member` method that users of the bitpack can call to access that
+ * field.  While it is perfectly sensible to do so directly, this file also
+ * offers a large number of utilities and affordances which capture common
+ * occurrences.  We will need to specify the type of the field as seen from C++,
+ * though in many cases one will simultaneously define the field and its type.
+ * Further, one will need to specify the `FieldInfo` for the field: this is a
+ * structure holding, in order, the minimum and maximum (both inclusive) bit
+ * positions occupied by the field in the underlying word, and a (default false)
+ * flag to indicate that the field is constant; many of our macros will simply
+ * let us write the values of these properties in order as arguments.
+ *
+ * At the lowest level of assistance, the `BITPACK_MEMBER_ADD` macro
+ * encapsulates the C++ syntax for a method wrapping a call to `member`.  It
+ * takes the name of the method to define, the type of the field, and the values
+ * to use for the `FieldInfo`.
+ *
+ * \remark
+ * \parblock
+ *
+ * For example, `BITPACK_MEMBER_ADD(ticks, uint8_t, 3, 9);` defines a method
+ * `ticks()` that gives `uint8_t`-flavored access to a field spanning bits 3 to
+ * 9 of the bitpack's underlying word.  Callers of this method get a `Proxy` of
+ * the bitpack that can be used to get, set, or alter (read-modify-write) that
+ * field and will see the field's value as a `uint8_t`.
+ *
+ * \endparblock
+ *
+ * Most of the time, though, just as defining a bitpack creates a new C++ type,
+ * one can think of a field within a bitpack as having a unique type within its
+ * containing bitpack.  As such, most of our definition utility macros serve to
+ * define a field while simultaneously defining a type which is both used as the
+ * type of values of the field and as a name for the field.  Behind the scenes,
+ * there is some C++ machinery to provide a `Bitpack::member<FieldType>`
+ * template method that can look up a field's `FieldInfo` from its type; our
+ * macros encapsulate that machinery.
+ *
+ * Often, fields take on enumerated values, for which C++ `enum class` types are
+ * usually reasonably convenient representations.  The
+ * `BITPACK_MEMBER_ADD_ENUM` macro encapsulates the syntax for defining an
+ * `enum class` (with given underlying type) and an associated `FieldInfo`.
+ *
+ * \remark
+ * \parblock
+ *
+ * For example, this block of code...
+ *
+ *     BITPACK_MEMBER_ADD_ENUM(Drivers, uint8_t, 12, 13)
+ *     {
+ *       None     = 0,
+ *       UpOnly   = 1,
+ *       DownOnly = 2,
+ *       Both     = 3,
+ *     };
+ *
+ * defines an `enum class Drivers` within the bitpack containing it (multiple
+ * bitpack definitions may each have their own `Drivers` type within, but each
+ * such may have only one).  This enumeration has an underlying type of
+ * `uint8_t` and four defined values: `Drivers::None`, `Drivers::UpOnly`, &c.
+ * The numeric values of the enumerators are used as values of the field within
+ * the bitpack.  At the same time, the macro will have defined a `FieldInfo`
+ * calling for a non-constant, two-bit field at positions 12 and 13. and
+ * associated this with the `Drivers` type, so that a call to
+ * `member<Drivers>()` within the bitpack will return a `Proxy` for that field
+ * which works with `Drivers`-typed values.
+ *
+ * \endparblock
+ *
+ * It is often useful to have single-bit fields with custom names for the
+ * 0/`false` and 1/`true` values.  This is provided by the
+ * `BITPACK_MEMBER_ADD_ENUM_BOOL` macro; some popular options for names are
+ * provided as wrappers thereof.
+ *
+ * Sometimes fields are numeric rather than enumerative, such as clock dividers
+ * or event counters.  `Bitpack`-s have a `Numeric<Base>` template class to
+ * facilitate creating bespoke C++ types for such fields, and the
+ * `BITPACK_MEMBER_ADD_NUMERIC` macro encapsulates the syntactic clutter of its
+ * use.
+ *
+ * \remark
+ * \parblock
+ *
+ * For example, `BITPACK_MEMBER_ADD_NUMERIC(Ticks, uint16_t, 14, 25, true);`
+ * defines a type `Ticks`, which wraps a `uint16_t`, within the bitpack
+ * containing it.  Like with `BITPACK_MEMBER_ADD_ENUM`, this also defines a
+ * `FieldInfo` and associates it with the `Ticks` type, so that
+ * `member<Ticks>()` within the bitpack will return a proxy of this field.  The
+ * `true` at the end sets the `FieldInfo` `isConst` flag and so will inhibit
+ * attempts to use the `member()` field proxy to change its value.
+ *
+ * \endparblock
+ *
+ * \subsection bitpacks_intro_proxies Using Bitpacks
+ *
+ * Having defined a bitpack and its fields and internal machinery, one can now
+ * make use of it!  Most often, bitpacks are used directly by external code;
+ * that is, the proxies of its fields are public rather than being used by
+ * methods of the bitpack class itself (though, of course, that also works).
+ * As such, C++'s somewhat inflexible syntax rears its head on occasion, and
+ * bitpacks offer macros in an attempt to compensate.
+ *
+ * As a consequence of defining types (of fields) within other types (their
+ * contianing bitpack class), the former are in scope outside the latter only
+ * when qualified with the name of the latter.  Having to always write out the
+ * full `MyBitpackClass::TheFieldType` would be exhausting and distracting.
+ * Conveniently, with a bitpack value in hand, `decltype` gives us a generic way
+ * to refer to its type and can be used to qualify the names of contained types.
+ * The `BITPACK_MEMBER_DECLTYPE(b, T)` macro gets the `Proxy` of the `T`-typed
+ * field within the bitpack value `b` without needing to spell out the latter's
+ * type.  If the type of `b` is dependent (for example, is `auto` or is or
+ * involves a template argument), use `BITPACK_MEMBER_DEPENDENT(b, T)` instead.
+ * See \ref bitpacks_macros_member .
+ *
+ * `Bitpack::Field::Proxy`-s offer six core methods:
+
+ * 1. Projection ("getter") of the field's current value within the containing
+ *    bitpack.  Proxies have implicit conversions to their field's type, so in
+ *    many cases, projection is syntactiaclly free,  When it must be made
+ *    explicit, projection is available as the `raw()` method on the proxy.
+ *    Proxies of field types with underlying types (specifically, `enum` and
+ *    `enum class` types and types derived from the `Bitpack::Numeric` template
+ *    class) also have a `rawer()` method that will return the field's value as
+ *    this underlying type.
+
+ * 2. Assignment ("setter"), in the form of an overloaded `=` operator.  This
+ *    mutates the underlying `Storage` value such that the field being proxied
+ *    now has the given value.  All other bits in the bitpack are unaltered.
+ *
+ * 3. Modification ("read modify write", "RMW"), in the form of the `alter()`
+ *    method.  `alter()` takes a callback, which should take one argument, whose
+ *    type is the field's, and return another value of the same type.  The
+ *    callback will be given the field's current value in the containing bitpack
+ *    and the containing bitpack will be updated so that the field's value is as
+ *    returned from the callback.
+ *
+ * 4. Cloning with override, in the form of the `with()` methods.  These return
+ *    a copy of the bitpack with the proxied field changed as directed.
+ *    `with()` can be given the new field value directly, or it may be given a
+ *    callback that takes the field's current value and returns the desired new
+ *    value.
+ *
+ * 5. Comparison.  For convenience, `Proxy`-s overload the spaceship operator,
+ *    `<=>`, and so implicitly also provide `<`, `<=`, `==`, `!=`, `>=`, and `>`
+ *    between pairs of `Proxy`-s of the same field or between a `Proxy` and a
+ *    value of its field's type.
+ *
+ * 6. Assignment from zero, in the form of the `assign_from()` method.
+ *    `assign_from` takes a callback which should return a value of the field's
+ *    type when given the zero value of that type.  This is sort of like
+ *    `alter()`, except that it does not extract the field's current value
+ *    first.  Mostly, this is useful for polymorpic type shenanigans.
+ *
+ * Atop this core, there are many convenience macros for working with bitpacks
+ * and field proxies.
+ *
+ * Because `Bitpack`-s encourage the use of types and named values defined
+ * within derived classes, code using `Bitpack`-s often needs to use qualified
+ * names or wrap values in type constructors (in addition to qualifying the
+ * field type with the bitpack's type when constructing the field proxy as in
+ the
+ * `BITPACK_MEMBER_` macros above).  The first two families of macros atop
+ * proxies help with these cases.
+ *
+ * * The family of \ref bitpacks_macros_proxyop_qualify is built around the
+ *   `BITPACK_OPERATE_QUALIFY(proxy, operator, value)` macro, which qualifies
+ *   `value` with the field type of the proxy `proxy` and relates the proxy and
+ *   qualified value with `operator`, which is often `=` for assignment or `==`
+ *   for equality testing.  For example,
+ *   `BITPACK_OPERATE_QUALIFY(p, =, UpOnly)`, with `p` a `Proxy` of a
+ *   `Drivers`-typed field (recall above), would assign the field to `UpOnly`
+ *   without needing to use a fully qualified form like
+ *   `MyBitpack::Drivers::UpOnly`.
+ *
+ * * The family of \ref bitpacks_macros_proxyop_construct is built around the
+ *   `BITPACK_OPERATE_WRAP(proxy, operator, value)` macro.  Here, the `value` is
+ *   passed to a single-argument constructor of the proxy's field type.  This
+ *   works well for `Numeric` types: `BITPACK_OPERATE_WRAP(p, ==, 7)` will
+ *   compare the value of the field being proxied by `p` with the value `7`
+ *   converted to that field's type (by said type's constructor).
+ *
+ * Each of these families have further wrappers around their center macros:
+ *
+ * * `BITPACK_OPERATE_{QUALIFY,WRAP}_{DECLTYPE,DEPENDENT}(b, T, operator, v)`
+ *   fuse `BITPACK_OPERATE_{QUALIFY,WRAP}` and
+ *   `BITPACK_MEMBER_{DECLTYPE,DEPENDENT}`, building the `Proxy`
+ *   of the `T`-typed field in the bitpack value `b`, rather than requiring it
+ *   to be explicitly built first.
+ *
+ * * For the case where the type `T` does not need qualification when finding
+ *   its associated field in `b`, use the
+ *   `BITPACK_OPERATE_{QUALIFY,WRAP}_TYPE(b, T, operator, v)` macro (which can
+ *   use `b.member<T>()`, rather than a `BITPACK_MEMBER_` macro, internally).
+ *
+ * * `BITPACK_WITH_{QUALIFY_WRAP}(proxy, value)` and
+ *   `BITPACK_WITH_{QUALIFY,WRAP}_{DECLTYPE,DEPENDENT,TYPE}(b, T, v)` are
+ *   specializations of their `BITPACK_OPERATE_...` siblings with `.with` as the
+ *   operator, as this is a common enough occurrence.
+ *
+ * The family of \ref bitpacks_macros_proxyop_directed is somewhat dual: rather
+ * than using the field type to in some way influence the meaning of a `value`,
+ * this family uses the type of the value to find the appropriate field and a
+ * proxy thereof within a bitpack value.  This can be convenient when a field
+ * value is already available.  The centerpiece of this family is the
+ * `BITPACK_OPERATE_VALUE(b, operator, value)` macro, which relates with
+ * `operator` a proxy of the field in the bitpack value `b` whose type is that
+ * of `value` and `value` itself.  The
+ * `BITPACK_OPERATE_{DECLTYPE,DEPENDENT}(b, operator, value)` wrappers qualify
+ * `value` with the type of the bitpack value `b`.  As above, there are also
+ * `_WITH` specializations of the `_OPERATE` forms.
+ *
+ * There are other macros likely of more niche interest; see...
+ *
+ * * \ref bitpacks_macros_proxyop_enum and
+ * * \ref bitpacks_macros_vararg .
+ *
+ * \section bitpacks_formal A More Formal Perspective
+ *
+ * More formally, `Bitpack`-s are a kind of aggregate structure within a numeric
+ * word and offer lens-like, typed access to contiguous spans of bits therein,
+ * offering a view of bits as a product of typed fields, occuping a disjoint,
+ * contiguous span of bits within that word.
+ *
+ * The static information about a field is represented by a specialization of
+ * the `Bitpack::Field<Type, Info>` template.  `Type` is the exposed C++ type of
+ * the field in question, and `Info` is a (necessarily constexpr) value of the
+ * `FieldInfo` type, which holds the bit indicies of the field's span within the
+ * `Storage` type.  `FieldInfo` also has an `isConst` flag, used to specify that
+ * the field is not mutable from software even if the larger bitpack is
+ * non-constant.
+ *
+ * Our lenses, the centerpiece of the whole thing, are expressed as "proxy"
+ * objects, instances of specializations of the [Bitpack::Field<Type,
+ * Info>::Proxy<DerivedBitpack, RefType>](#Bitpack::Field::Proxy) class, which
+ * wrap references to the underlying `Storage`-typed word in a `Bitpack` class
+ * (or a derived class).  The type of such references, `RefType`, inherits any
+ * `const` and/or `volatile` qualification of the user's handle to the bitpack,
+ * and are additionally `const` qualified if the associated `FieldInfo` has
+ * `isConst` asserted.
+ *
+ * @{
+ */
+
+#include <cdefs.h>
+#include <concepts>
+#include <limits.h>
+#include <stddef.h>
+#include <type_traits>
+
+/*
+ * Mark the Bitpack class declaration with cdef.h's `CHERIOT_EXPERIMENTAL()` --
+ * that is, as eliciting a warning if CHERIOT_EXPERIMENTAL_APIS_WARN is defined
+ * -- unless CHERIOT_EXPERIMENTAL_NOWARN_BITPACKS is defined.
+ */
+#if defined(CHERIOT_EXPERIMENTAL) &&                                           \
+  !defined(CHERIOT_EXPERIMENTAL_NOWARN_BITPACKS)
+#	define BITPACK_DECL_ANNOTATION                                            \
+		CHERIOT_EXPERIMENTAL(                                                  \
+		  "Bitpacks are an experimental CHERIoT RTOS feature")
+#else
+#	define BITPACK_DECL_ANNOTATION
+#endif
+
+/**
+ * The `Bitpack` structure itself, templated on the underlying Storage type.
+ *
+ * This should be the sole (non-empty) superclass of a type representing a
+ * bitfield-esque composite structure.
+ */
+template<typename StorageParam>
+    requires std::is_unsigned_v<StorageParam>
+class BITPACK_DECL_ANNOTATION Bitpack
+{
+	public:
+	/// Expose the underlying storage type
+	using Storage = StorageParam;
+
+	private:
+	Storage value;
+
+	public:
+	/// Construct a `Bitpack` value with an underlying Storage of all zero bits
+	constexpr Bitpack() : value(0) {}
+
+	/**
+	 * Construct a `Bitpack` value from a value of its underlying Storage type.
+	 *
+	 * This is marked `explicit` to make things like "device->register = 0x7;"
+	 * slightly harder to spell, with the intent of encouraging use of named
+	 * constants.
+	 */
+	constexpr explicit Bitpack(Storage v) : value(v) {}
+
+	/**
+	 * Assign a whole `Bitpack` at once given a non-volatile `Bitpack` of the
+	 * same (or convertible, including derived) type.
+	 *
+	 * To assign from a `volatile` `Bitpack`, perform an explicit `.read()`
+	 * first.
+	 *
+	 * "Deducing this" gives us CRTP-esque behavior without, well, the CRTP, so
+	 * this will not accept an unrelated derived `Bitpack` class.  (But will
+	 * accept types that can be converted, so assigning to a `Bitpack`, as
+	 * opposed to a derived class, will accept any derived class, for example.
+	 * Probably best avoid that.)
+	 */
+	template<typename Self>
+	// NOLINTNEXTLINE(misc-unconventional-assign-operator)
+	constexpr Self &&operator=(this Self                      &&self,
+	                           const std::remove_cvref_t<Self> &b)
+	{
+		self.value = b.value;
+		return self;
+	}
+
+	/**
+	 * Compare `Bitpack`-s for equality (reflecting that of `Storage`).
+	 *
+	 * Neither side may be volatile; use explicit `.read()`-s first.
+	 */
+	template<typename Self>
+	    requires(!std::is_volatile_v<Self>)
+	constexpr bool operator==(this Self                      &&self,
+	                          const std::remove_cvref_t<Self> &b)
+	{
+		return self.value == b.value;
+	}
+
+	/**
+	 * Spaceship operator on `Bitpack`-s (reflecing that of `Storage`).
+	 *
+	 * Neither side may be volatile; use explicit `.read()`-s first.
+	 */
+	template<typename Self>
+	    requires(!std::is_volatile_v<Self>)
+	constexpr auto operator<=>(this Self                      &&self,
+	                           const std::remove_cvref_t<Self> &b)
+	{
+		return self.value <=> b.value;
+	}
+
+	/**
+	 * Extract the underlying `Storage` value.
+	 *
+	 * The `Bitpack` must not be `volatile`.  Use `.read()` first.
+	 */
+	constexpr explicit operator Storage() const
+	{
+		return this->value;
+	}
+
+	/**
+	 * A shorter way of spelling `static_cast<Storage>(...)`.
+	 *
+	 * The `Bitpack` must not be `volatile`.  Use `.read()` first.
+	 */
+	[[nodiscard]] constexpr Storage raw() const
+	{
+		return static_cast<Storage>(*this);
+	}
+
+	/**
+	 * Return a snapshot of the underlying `Storage`.
+	 *
+	 * Notably, this can be used to get a `const` `Bitpack` from a `volatile`
+	 * `Bitpack` (`const` or not).
+	 */
+	template<typename Self>
+	const auto read(this Self &&self)
+	{
+		return std::remove_cvref_t<Self>{self.value};
+	}
+
+	/// Convenience wrapper for the types of numeric fields.
+	template<typename T>
+	    requires std::is_unsigned_v<T>
+	struct Numeric
+	{
+		/// Export the underlying numeric type
+		using NumericType = T;
+
+		/*
+		 * The field type must be smaller than the `Bitpack`'s underlying
+		 * `Storage`.
+		 */
+		static_assert(sizeof(T) <= sizeof(Storage));
+
+		T value;
+
+		constexpr Numeric(T v) : value(v) {}
+
+		constexpr operator T() const
+		{
+			return this->value;
+		}
+
+		[[nodiscard]] constexpr T raw() const
+		{
+			return static_cast<T>(this->value);
+		}
+	};
+
+	/**
+	 * Information about a field within a `Bitpack`.
+	 *
+	 * Fields are contiguous spans of bits and so have a lowest and highest bit
+	 * position within the underlying Storage word.
+	 *
+	 * Fields may be marked as constant to dissuade software from attempting to
+	 * change their value.  Do note, though, that any store of an underlying
+	 * Storage word will also, necessarily, include the bits for constant
+	 * Fields.  It is likely generally more advisable to not mix constant and
+	 * non-constant fields within the same Storage word or `Bitpack`.
+	 */
+	struct FieldInfo
+	{
+		/// Minimum 0-indexed bit position occupied by this field
+		size_t minIndex;
+		/// Maximum 0-indexed bit position occupied by this field
+		size_t maxIndex;
+		/**
+		 * Should this field be proxied as constant (and so mutation be slightly
+		 * less ergonomic)?
+		 */
+		bool isConst = false;
+
+		bool operator==(const FieldInfo &) const = default;
+	};
+
+	/**
+	 * A particular Field within a `Bitpack`.
+	 *
+	 * Fields are templated on the type as seen by external code and the
+	 * FieldInfo data giving the field's location and other properties.
+	 */
+	template<typename TypeParam, FieldInfo InfoParam>
+	struct Field
+	{
+		/// Expose the type parameter
+		using Type = TypeParam;
+		/// Expose the FieldInfo parameter
+		static constexpr FieldInfo Info = InfoParam;
+
+		// The field's span of bits must start before it ends
+		static_assert(Info.maxIndex >= Info.minIndex,
+		              "Field span ends before it begins");
+
+		static_assert(!std::is_base_of_v<Numeric<bool>, Type> ||
+		                (Info.maxIndex == Info.minIndex),
+		              "Numeric<bool> fields should be exactly one bit wide");
+
+		static_assert(
+		  !std::is_enum_v<Type> ||
+		    !requires {
+			    { std::underlying_type_t<Type>() } -> std::same_as<bool>;
+		    } || (Info.maxIndex == Info.minIndex),
+		  "Enum fields with underlying type bool should be exactly "
+		  "one bit wide");
+
+		static_assert((Info.maxIndex - Info.minIndex + 1) <=
+		                CHAR_BIT * sizeof(Type),
+		              "Field type is narrower than specified field bit width");
+
+		static_assert((Info.maxIndex - Info.minIndex + 1) <
+		                CHAR_BIT * sizeof(Storage),
+		              "Field width is not smaller than Bitpack's Storage type");
+
+		/// A span of set bits, starting at index 0, and of the field's width.
+		static constexpr Storage ValueMask =
+		  (1U << (Info.maxIndex - Info.minIndex + 1)) - 1;
+
+		/// The mask of bits occupied by this value (occupied bits are set).
+		static constexpr Storage FieldMask = ValueMask << Info.minIndex;
+
+		/// Extract a Field from a raw Storage value
+		constexpr static Type raw_view(Storage storage)
+		{
+			return static_cast<Type>((storage >> Info.minIndex) & ValueMask);
+		}
+
+		/// Compute the underlying Storage transform for a Field update
+		constexpr static Storage raw_with(Storage lhs, Storage rhs)
+		{
+			return (lhs & ~FieldMask) | ((rhs & ValueMask) << Info.minIndex);
+		}
+
+		/// Update for fields whose type can be static_cast to Storage
+		constexpr static Storage raw_with(Storage lhs, Type rhs)
+		    requires requires { static_cast<Storage>(std::declval<Type>()); }
+		{
+			return raw_with(lhs, static_cast<Storage>(rhs));
+		}
+
+		/// Update for fields that are themselves `Bitpacks` at smaller types
+		template<typename OtherStorage>
+		    requires requires { sizeof(OtherStorage) < sizeof(Storage); }
+		constexpr static Storage raw_with(Storage               lhs,
+		                                  Bitpack<OtherStorage> rhs)
+		{
+			return raw_with(lhs, static_cast<OtherStorage>(rhs));
+		}
+
+		/**
+		 * A proxy for this Field within the `Bitpack`'s `Storage`.
+		 *
+		 * This provides getters, setters, and mutators phrased in terms of the
+		 * `Field`'s exposed `Type` rather than the raw bits within the
+		 * `Bitpack`'s underlying `Storage` word.
+		 *
+		 * Proxies are templated on their containing derived type (so that they
+		 * can act "in situ" in the class hierarchy, consuming and returning the
+		 * same type, which must have `Bitpack` as its base type) and the type
+		 * of the reference they hold to their containing `Bitpack`'s underlying
+		 * `Storage` word (so that they can properly propagate `volatile` and
+		 * `const` qualifications from the `Bitpack` value and the `Field`'s
+		 * properties to perceived type).
+		 */
+		template<typename DerivedBitpack, typename RefTypeParam>
+		    requires std::is_base_of_v<Bitpack, DerivedBitpack> &&
+		             std::is_lvalue_reference_v<RefTypeParam> &&
+		             std::is_same_v<Storage, std::remove_cvref_t<RefTypeParam>>
+		class Proxy
+		{
+			/// A qualified reference to the containing `Bitpack`'s `Storage`.
+			RefTypeParam ref;
+
+			public:
+			/// Name the Field of which we are a proxy
+			using Field = Field;
+
+			/// Expose the qualified reference type we hold to the Storage
+			using RefType = RefTypeParam;
+
+			/**
+			 * Construct a proxy given a reference to the storage word.
+			 *
+			 * May take any reference type implicitly convertible to RefType,
+			 * not just RefType itself.
+			 */
+			template<typename R>
+			constexpr Proxy(R &r) : ref(r.value)
+			{
+			}
+
+			/**
+			 * Compute and store an updated `Bitpack` value with a new value for
+			 * this field (of the field type itself).
+			 *
+			 * For `volatile` `Bitpack`s, this will perform a load and store.
+			 */
+			template<typename Self>
+			    requires(
+			      !std::is_const_v<std::remove_reference_t<RefTypeParam>>)
+			// NOLINTNEXTLINE(misc-unconventional-assign-operator)
+			constexpr Self &&operator=(this Self &&self, Field::Type rhs)
+			{
+				self.ref = raw_with(self.ref, rhs);
+				return self;
+			}
+
+			/**
+			 * Compute and store an updated `Bitpack` value with a new value for
+			 * this field, when this field's type is a Numeric wrapper, and the
+			 * RHS is the underlying type inside the Numeric wrapper.
+			 *
+			 * For `volatile` `Bitpack`s, this will perform a load and store.
+			 */
+			template<typename Self, typename RHS>
+			    requires(
+			      !std::is_const_v<std::remove_reference_t<RefTypeParam>> &&
+			      std::is_same_v<Field::Type, Numeric<RHS>>)
+			// NOLINTNEXTLINE(misc-unconventional-assign-operator)
+			constexpr Self &&operator=(this Self &&self, RHS rhs)
+			{
+				self.ref = raw_with(self.ref, Field::Type{rhs});
+				return self;
+			}
+
+			/**
+			 * Compute and store an updated `Bitpack` value with a new value for
+			 * this field, when this field's type is an enum class and the
+			 * RHS is the underlying type of that enum.
+			 *
+			 * For `volatile` `Bitpack`s, this will perform a load and store.
+			 */
+			template<typename Self, typename RHS>
+			    requires(
+			      !std::is_const_v<std::remove_reference_t<RefTypeParam>> &&
+			      std::is_scoped_enum_v<Field::Type> &&
+			      std::is_same_v<std::underlying_type_t<Field::Type>, RHS>)
+			// NOLINTNEXTLINE(misc-unconventional-assign-operator)
+			constexpr Self &&operator=(this Self &&self, RHS rhs)
+			{
+				self.ref = raw_with(self.ref, Field::Type{rhs});
+				return self;
+			}
+
+			/**
+			 * Explicit conversion of a Field::Proxy to the field value.
+			 *
+			 * The Proxy must not have a `volatile` reference to Storage.
+			 * Use `.read()` on the containing `Bitpack`, first.
+			 */
+			template<typename Self>
+			    requires(
+			      !std::is_volatile_v<std::remove_reference_t<RefTypeParam>>)
+			constexpr operator Field::Type(this Self &&self)
+			{
+				return raw_view(self.ref);
+			}
+
+			/// A shorter way of spelling static_cast<Field::Type>()...
+			[[nodiscard]] constexpr Field::Type raw() const
+			{
+				return static_cast<Field::Type>(*this);
+			}
+
+			/// Get the value of this enum-typed field as its underlying type.
+			[[nodiscard]] constexpr auto rawer() const
+			    requires(std::is_enum_v<typename Field::Type>)
+			{
+				return std::to_underlying(this->raw());
+			}
+
+			/**
+			 * Get the value of this Numeric-typed field as its underlying type.
+			 */
+			[[nodiscard]] constexpr auto rawer() const
+			    requires(std::is_base_of_v<
+			             Numeric<typename std::remove_cvref_t<
+			               typename Field::Type>::NumericType>,
+			             typename std::remove_cvref_t<typename Field::Type>>)
+			{
+				return this->raw().raw();
+			}
+
+			/**
+			 * Construct a new `Bitpack` value with an updated value of this
+			 * field.
+			 *
+			 * This is emphatically not `volatile`-qualified, and has no
+			 * `volatile`-qualified overload.  `.read()` the containing
+			 * `Bitpack`, first.
+			 */
+			[[nodiscard]] constexpr DerivedBitpack with(Field::Type rhs) const
+			{
+				return DerivedBitpack{raw_with(this->ref, rhs)};
+			}
+
+			/**
+			 * Construct a new `Bitpack` value with an updated value of this
+			 * field as a function of its current value.
+			 *
+			 * This is emphatically not `volatile`-qualified, and has no
+			 * `volatile`-qualified overload.  `.read()` the containing
+			 * `Bitpack`, first.
+			 */
+			constexpr DerivedBitpack with(auto &&f) const
+			    requires std::
+			      is_invocable_r_v<Field::Type, decltype(f), Field::Type>
+			{
+				/*
+				 * Perform one read and use it twice to avoid double-tapping
+				 * volatile storage!
+				 */
+				Storage storage = this->ref;
+				return DerivedBitpack{raw_with(storage, f(raw_view(storage)))};
+			}
+
+			/**
+			 * Compute and store an updated `Bitpack` value with a new value for
+			 * this field as a function of its current value.
+			 *
+			 * For `volatile` `Bitpack`s, this will perform a load and store.
+			 */
+			template<typename Self>
+			constexpr void alter(this Self &&self, auto &&f)
+			    requires(
+			      std::
+			        is_invocable_r_v<Field::Type, decltype(f), Field::Type> &&
+			      !std::is_const_v<std::remove_reference_t<RefTypeParam>>)
+			{
+				Storage storage = self.ref;
+				self.ref        = raw_with(storage, f(raw_view(storage)));
+			}
+
+			/**
+			 * Convenience function for unconditionally assigning a field when
+			 * it helps to have a zero value of that field's type.
+			 *
+			 * Use `.alter()` if the current value of the field is required.
+			 *
+			 * Because this requires a read of the whole `Bitpack` to update,
+			 * we refuse to operate on `volatile` values, and because it's an
+			 * assignment, we don't operate on `const` values either.
+			 */
+			constexpr void assign_from(auto &&f)
+			    requires(
+			      std::is_invocable_r_v<Field::Type, decltype(f), Field::Type>)
+			{
+				this->ref = raw_with(this->ref, f(raw_view(0)));
+			}
+
+			constexpr auto operator<=>(Proxy rhs) const
+			    requires(requires(Field::Type v) {
+				    { v <=> v };
+			    })
+			{
+				return raw() <=> rhs.raw();
+			}
+
+			constexpr auto operator<=>(Field::Type rhs) const
+			    requires(requires(Field::Type v) {
+				    { v <=> v };
+			    })
+			{
+				return raw() <=> rhs;
+			}
+
+			constexpr bool operator==(Proxy rhs) const
+			    requires(requires(Field::Type v) {
+				    { v == v } -> std::same_as<bool>;
+			    })
+			{
+				return raw() == rhs.raw();
+			}
+
+			constexpr bool operator==(Field::Type rhs) const
+			    requires(requires(Field::Type v) {
+				    { v == v } -> std::same_as<bool>;
+			    })
+			{
+				return raw() == rhs;
+			}
+		};
+
+		template<bool C, typename T>
+		    requires std::is_lvalue_reference_v<T>
+		using ConditionalConstRef = std::
+		  conditional_t<C, std::add_const_t<std::remove_reference_t<T>> &, T>;
+
+		/*
+		 * Guide template deduction to conclude that a Field has a RefType
+		 * that is as CV-qualified as the `Bitpack` of which it is a part, with
+		 * the further possibility of const-qualification for fields annotated
+		 * as constant.
+		 *
+		 * Yes, the `decltype(())` is deliberate: we want the lvalue expression
+		 * rather than the prvalue expression.
+		 */
+		template<typename BitpackType>
+		Proxy(BitpackType &r)
+		  -> Proxy<std::remove_cvref_t<BitpackType>,
+		           ConditionalConstRef<Info.isConst, decltype((r.value))>>;
+	};
+
+	protected:
+	/**
+	 * Build a Field::Proxy of an explicitly given type and info.
+	 *
+	 * This is protected so that it is available to subclasses but not more
+	 * generally.
+	 */
+	template<typename FieldType, FieldInfo Info, typename Self>
+	constexpr auto member(this Self &&self)
+	{
+		return typename Field<FieldType, Info>::Proxy(self);
+	}
+
+	public:
+	/**
+	 * Build a Field::Proxy proxy by asking the derived Self class for a
+	 * FieldInfo structure computed from template expansion of
+	 * Self::field_info_for_type<FieldType>().
+	 */
+	template<typename FieldType, typename Self>
+	    requires std::is_convertible_v<
+	      decltype(std::remove_cvref_t<Self>::template field_info_for_type<
+	               FieldType>()),
+	      const FieldInfo>
+	constexpr auto member(this Self &&self)
+	{
+		/*
+		 * Find the information for the field type; "deducing this" gives us
+		 * access to the derived class's type without need for the CRTP.
+		 */
+		static constexpr FieldInfo Info =
+		  std::remove_cvref_t<Self>::template field_info_for_type<FieldType>();
+
+		return self.template member<FieldType, Info>();
+	}
+
+	/**
+	 * Fetch the value of a field in this `Bitpack` based on the field type.
+	 *
+	 * For `volatile` `Bitpack`s, this will perform a load.
+	 */
+	template<typename FieldType, typename Self>
+	constexpr FieldType get(this Self &&self)
+	{
+		return self.template member<FieldType>();
+	}
+
+	/**
+	 * Compute a new `Bitpack` value with an updated field of a given type.
+	 *
+	 * For `volatile` `Bitpack`s, this will perform a load.
+	 */
+	template<typename FieldType, typename Self>
+	constexpr std::remove_cvref_t<Self> with(this Self &&self, FieldType v)
+	{
+		return self.template member<FieldType>().with(v);
+	}
+
+	/**
+	 * Compute a new `Bitpack` value with an updated field of a given type.
+	 *
+	 * For `volatile` `Bitpack`s, this will perform a load and store.
+	 */
+	template<typename FieldType, typename Self>
+	constexpr void set(this Self &&self, FieldType v)
+	{
+		self.template member<FieldType>() = v;
+	}
+
+	/**
+	 * Convenience function for unconditionally changing several sub-fields at
+	 * once.  Intended particularly for use with `volatile` `Bitpack`-s, to help
+	 * ensure only one read and one write takes place, as the callback operates
+	 * on a non-`volatile` `Bitpack`.
+	 */
+	template<typename Self>
+	constexpr void alter(this Self &&self, auto &&f)
+	    requires std::is_invocable_r_v<std::remove_cvref_t<Self>,
+	                                   decltype(f),
+	                                   std::remove_cvref_t<Self>>
+	{
+		std::remove_cvref_t<Self> value{self.value};
+		self = f(value);
+	}
+
+	/**
+	 * Convenience function for unconditionally assigning an entire `Bitpack`
+	 * from a computed value.  The function receives a zero-valued instance of
+	 * the `Bitpack` type.
+	 */
+	template<typename Self>
+	constexpr void assign_from(this Self &&self, auto &&f)
+	    requires std::is_invocable_r_v<std::remove_cvref_t<Self>,
+	                                   decltype(f),
+	                                   std::remove_cvref_t<Self>>
+	{
+		self = f(std::remove_cvref_t<Self>(0));
+	}
+};
+
+/**
+ * It is occasionally useful to derive one bitpack from another.  Using
+ * BitpackDerived<B> as the sole (non-empty) base class of an aggregate type
+ * reduces the syntactic clutter of deriving from the bitpack B.
+ *
+ * See `BITPACK_DERIVED_PREFIX` and `BITPACK_DERIVED_FIELD_INFO_FOR_TYPE`.
+ */
+template<typename B>
+    requires std::derived_from<B, Bitpack<typename B::Storage>>
+struct BitpackDerived : B
+{
+	using B::B;
+	using B::operator=;
+
+	protected:
+	using ParentBitpack = B;
+};
+
+/**
+ * \defgroup bitpacks_macros Convenience macros
+ * @{
+ */
+
+/**
+ * \defgroup bitpacks_macros_defn Field definition macros
+ * @{
+ */
+
+/**
+ * Capture the incantations often at the top of a `Bitpack` structure,
+ * especially one with type-directed field proxies.
+ */
+#define BITPACK_USUAL_PREFIX                                                   \
+	using Bitpack::Bitpack;                                                    \
+	using Bitpack::operator=;                                                  \
+	template<typename FieldType>                                               \
+	static constexpr FieldInfo field_info_for_type() = delete;
+
+/**
+ * Define a named accessor for a field.
+ *
+ * Takes the name of the accessor, the type to use for the proxy, and the fields
+ * of the FieldInfo (as varargs).  If the latter is omitted, this defines an
+ * alias for a field whose type is sufficient to resolve the FieldInfo through
+ * field_info_for_type.
+ */
+#define BITPACK_MEMBER_ADD(name, Type, ...)                                    \
+	template<typename Self>                                                    \
+	constexpr auto name(this Self &&self)                                      \
+	{                                                                          \
+		return self.template member<Type __VA_OPT__(, {__VA_ARGS__})>();       \
+	}
+
+/**
+ * Encapsulate the gyrations required to define an `enum class`-typed field and
+ * its associated `field_info_for_type` within a `Bitpack`.  Takes the name of
+ * the `enum` class to define, its underlying type, and then the fields of a
+ * `FieldInfo` as varargs; the enumerators should follow the macro invocation,
+ * surrounded in curly braces and terminated with a semicolon.
+ */
+#define BITPACK_MEMBER_ADD_ENUM(Type, Base, ...)                               \
+	enum class Type : Base;                                                    \
+	template<>                                                                 \
+	constexpr FieldInfo field_info_for_type<Type>()                            \
+	{                                                                          \
+		constexpr auto info = FieldInfo{__VA_ARGS__};                          \
+		static_assert(requires { Field<Type, info>(); });                      \
+		return info;                                                           \
+	}                                                                          \
+	enum class Type : Base
+
+/**
+ * Define a new scoped enumeration type whose underlying type is bool, with the
+ * given false and true value names, at the given bit position.
+ *
+ * FieldInfo fields other than minIndex and maxIndex may be provided as
+ * additional arguments.
+ *
+ * Contrast `BITPACK_MEMBER_ADD_BOOL`, which does not introduce the custom
+ * enumerator values like our `FalseVal` and `TrueVal`.
+ *
+ * See `BITPACK_MEMBER_ADD_ENUM`, which this uses, for more details.
+ */
+#define BITPACK_MEMBER_ADD_ENUM_BOOL(Type, FalseVal, TrueVal, BitIndex, ...)   \
+	BITPACK_MEMBER_ADD_ENUM(Type, bool, BitIndex, BitIndex, __VA_ARGS__)       \
+	{                                                                          \
+		FalseVal = false, TrueVal = true,                                      \
+	}
+
+/**
+ * Define a new boolean scoped enumeration with values named "Cleared" (0)
+ * and "Asserted" (1) at the given bit index.
+ */
+#define BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(Type, BitIndex, ...)     \
+	BITPACK_MEMBER_ADD_ENUM_BOOL(Type, Cleared, Asserted, BitIndex, __VA_ARGS__)
+
+/**
+ * Define a new boolean scoped enumeration with values named "Disabled" (0)
+ * and "Enabled" (1) at the given bit index.
+ */
+#define BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(Type, BitIndex, ...)     \
+	BITPACK_MEMBER_ADD_ENUM_BOOL(Type, Disabled, Enabled, BitIndex, __VA_ARGS__)
+
+/**
+ * Encapsulate the gyrations required to define a `Numeric`-typed field and its
+ * associated `field_info_for_type` within a `Bitpack`.  Takes the name of the
+ * struct to define, the `Numeric`'s underlying type, and then the fields of a
+ * `FieldInfo` as varargs.
+ */
+#define BITPACK_MEMBER_ADD_NUMERIC(Type, Base, ...)                            \
+	struct Type : Numeric<Base>                                                \
+	{                                                                          \
+		using Numeric::Numeric;                                                \
+	};                                                                         \
+	template<>                                                                 \
+	constexpr FieldInfo field_info_for_type<Type>()                            \
+	{                                                                          \
+		constexpr auto info = FieldInfo{__VA_ARGS__};                          \
+		static_assert(requires { Field<Type, info>(); });                      \
+		return info;                                                           \
+	}
+
+/**
+ * Define a new type wrapper around bool for a 1-bit field at a given BitIndex.
+ *
+ * FieldInfo fields other than minIndex and maxIndex may be provided as
+ * additional arguments.
+ *
+ * By contrast to `BITPACK_MEMBER_ADD_ENUM_BOOL`, the values introduced here are
+ * `Type{false}` and `Type{true}` rather than custom enumerators.
+ *
+ * See `BITPACK_MEMBER_ADD_NUMERIC`, which this uses, for more details.
+ */
+#define BITPACK_MEMBER_ADD_BOOL(Type, BitIndex, ...)                           \
+	BITPACK_MEMBER_ADD_NUMERIC(Type, bool, BitIndex, BitIndex, __VA_ARGS__)
+
+/// @}
+
+/**
+ * \defgroup bitpacks_macros_member Type-qualifying member accessor macros
+ * @{
+ */
+
+/**
+ * A convenience macro that presumes the type `T` is defined within the
+ * `Bitpack` `b` and finds such a field's proxy.
+ *
+ * There is no `BITPACK_MEMBER_TYPE(b, T)` analogue, because that's just
+ * `b.member<T>()`.
+ */
+#define BITPACK_MEMBER_DECLTYPE(b, T) (b).template member<decltype(b)::T>()
+
+/**
+ * Like BITPACK_MEMBER_DECLTYPE, but with additional an "typename" keyword so we
+ * can use a dependently-typed bitpack `b` (say, the type of `b` is `auto` or,
+ * more generally, involves a template argument).
+ */
+#define BITPACK_MEMBER_DEPENDENT(b, T)                                         \
+	(b).template member<typename decltype(b)::T>()
+
+/// @}
+
+/**
+ * \defgroup bitpacks_macros_derived Derived bitpack definition macros
+ * @{
+ */
+
+/**
+ * Capture the incantations often at the top of a `BitpackDerived` structure.
+ * especially one with type-directed field proxys.
+ */
+#define BITPACK_DERIVED_PREFIX                                                 \
+	using BitpackDerived<ParentBitpack>::BitpackDerived;                       \
+	using BitpackDerived<ParentBitpack>::operator=;                            \
+	/* Inherit field info for most types from parent bitpack */                \
+	template<typename FieldType>                                               \
+	static constexpr FieldInfo field_info_for_type()                           \
+	{                                                                          \
+		return ParentBitpack::field_info_for_type<FieldType>();                \
+	}
+
+/// Modify the field information for a type in a derived bitpack.
+#define BITPACK_DERIVED_FIELD_INFO_FOR_TYPE(Type, lambda)                      \
+	template<>                                                                 \
+	constexpr FieldInfo field_info_for_type<Type>()                            \
+	{                                                                          \
+		static_assert(                                                         \
+		  std::is_invocable_r_v<void, decltype(lambda), FieldInfo &>);         \
+		auto fi = ParentBitpack::field_info_for_type<Type>();                  \
+		lambda(fi);                                                            \
+		return fi;                                                             \
+	}
+
+/**
+ * Modify the constness field information for a type in a derived bitpack.
+ * This is a thin wrapper around BITPACK_DERIVED_FIELD_INFO_FOR_TYPE.
+ */
+#define BITPACK_DERIVED_FIELD_CONST_FOR_TYPE(Type, c)                          \
+	BITPACK_DERIVED_FIELD_INFO_FOR_TYPE(Type, [](auto &fi) { fi.isConst = c; })
+
+/// @}
+
+/**
+ * \defgroup bitpacks_macros_proxyop_qualify Type-qualifying proxy operator
+ * macros
+ * @{
+ */
+
+/**
+ * Operate between a `Field::Proxy` `proxy` and a given `value`, which will be
+ * qualifed with `proxy`'s `Field::Type` name.
+ *
+ * This will not work on `volatile` bitpacks; use `.read` first.
+ */
+#define BITPACK_OPERATE_QUALIFY(proxy, operator, value)                        \
+	({                                                                         \
+		using F = decltype(proxy)::Field::Type;                                \
+		(proxy) operator(F::value);                                            \
+	})
+
+/// A fusion of BITPACK_MEMBER_DECLTYPE and BITPACK_OPERATE_QUALIFY
+#define BITPACK_OPERATE_QUALIFY_DECLTYPE(b, T, operator, v)                    \
+	BITPACK_OPERATE_QUALIFY(BITPACK_MEMBER_DECLTYPE(b, T), operator, v)
+
+/// A fusion of BITPACK_MEMBER_DEPENDENT and BITPACK_OPERATE_QUALIFY
+#define BITPACK_OPERATE_QUALIFY_DEPENDENT(b, T, operator, v)                   \
+	BITPACK_OPERATE_QUALIFY(BITPACK_MEMBER_DEPENDENT(b, T), operator, v)
+
+/// A fusion of .member<>() and BITPACK_OPERATE_QUALIFY
+#define BITPACK_OPERATE_QUALIFY_TYPE(b, T, operator, v)                        \
+	BITPACK_OPERATE_QUALIFY((b).template member<T>(), operator, v)
+
+/// A specialization of BITPACK_OPERATE_QUALIFY using `.with` as the operator
+#define BITPACK_WITH_QUALIFY(proxy, value)                                     \
+	BITPACK_OPERATE_QUALIFY(proxy, .with, value)
+
+/**
+ * A specialization of BITPACK_OPERATE_QUALIFY_DECLTYPE using `.with` as the
+ * operator
+ */
+#define BITPACK_WITH_QUALIFY_DECLTYPE(b, T, v)                                 \
+	BITPACK_OPERATE_QUALIFY_DECLTYPE(b, T, .with, v)
+
+/**
+ * A specialization of BITPACK_OPERATE_QUALIFY_DEPENDENT using `.with` as the
+ * operator
+ */
+#define BITPACK_WITH_QUALIFY_DEPENDENT(b, T, v)                                \
+	BITPACK_OPERATE_QUALIFY_DEPENDENT(b, T, .with, v)
+
+/**
+ * A specialization of BITPACK_OPERATE_QUALIFY_TYPE using `.with` as the
+ * operator
+ */
+#define BITPACK_WITH_QUALIFY_TYPE(b, T, v)                                     \
+	BITPACK_OPERATE_QUALIFY_TYPE(b, T, .with, v)
+
+/// @}
+
+/**
+ * \defgroup bitpacks_macros_proxyop_construct Type-constructing proxy operator
+ * macros
+ *
+ * @{
+ */
+
+/**
+ * Operate between a `Field::Proxy` `proxy` and a given `value`, which will be
+ * wrapped with `proxy`'s `Field::Type`'s constructor.
+ *
+ * This will not work on `volatile` bitpacks; use `.read` first.
+ */
+#define BITPACK_OPERATE_WRAP(proxy, operator, value)                           \
+	({                                                                         \
+		using F = decltype(proxy)::Field::Type;                                \
+		(proxy) operator(F{value});                                            \
+	})
+
+/// A fusion of BITPACK_MEMBER_DECLTYPE and BITPACK_OPERATE_WRAP
+#define BITPACK_OPERATE_WRAP_DECLTYPE(b, T, operator, v)                       \
+	BITPACK_OPERATE_WRAP(BITPACK_MEMBER_DECLTYPE(b, T), operator, v)
+
+/// A fusion of BITPACK_MEMBER_DEPENDENT and BITPACK_OPERATE_WRAP
+#define BITPACK_OPERATE_WRAP_DEPENDENT(b, T, operator, v)                      \
+	BITPACK_OPERATE_WRAP(BITPACK_MEMBER_DEPENDENT(b, T), operator, v)
+
+/// A fusion of .member<>() and BITPACK_OPERATE_WRAP
+#define BITPACK_OPERATE_WRAP_TYPE(b, T, operator, v)                           \
+	BITPACK_OPERATE_WRAP((b).template member<T>(), operator, v)
+
+/// A specialization of BITPACK_OPERATE_WRAP using `.with` as the operator
+#define BITPACK_WRAP_WITH(proxy, value)                                        \
+	BITPACK_OPERATE_WRAP(proxy, .with, value)
+
+/**
+ * A specialization of BITPACK_OPERATE_WRAP_DECLTYPE using `.with` as the
+ * operator.
+ */
+#define BITPACK_WITH_WRAP_DECLTYPE(b, T, v)                                    \
+	BITPACK_OPERATE_WRAP_DECLTYPE(b, T, .with, v)
+
+/**
+ * A specialization of BITPACK_OPERATE_WRAP_DEPENDENT using `.with` as the
+ * operator
+ */
+#define BITPACK_WITH_WRAP_DEPENDENT(b, T, v)                                   \
+	BITPACK_OPERATE_WRAP_DEPENDENT(b, T, .with, v)
+
+/// A specialization of BITPACK_OPERATE_WRAP_TYPE using `.with` as the operator
+#define BITPACK_WITH_WRAP_TYPE(b, T, v)                                        \
+	BITPACK_OPERATE_WRAP_TYPE(b, T, .with, v)
+
+/// @}
+
+/**
+ * \defgroup bitpacks_macros_proxyop_directed Type-directed proxy operator
+ * macros
+ *
+ * @{
+ */
+
+/**
+ * Given a bitpack `b` -- not a Proxy of a Field therein -- and a value, operate
+ * between the bitpack's view of that value's type and the value.
+ */
+#define BITPACK_OPERATE_VALUE(b, operator, value)                              \
+	({ (b).template member<decltype(value)>() operator(value); })
+
+/**
+ * Given a bitpack `b` -- not a Proxy of a Field therein -- qualify the given
+ * value with the bitpack's type and then operate between the bitpack's Proxy of
+ * that qualified value's type and said value.
+ */
+#define BITPACK_OPERATE_VALUE_DECLTYPE(b, operator, value)                     \
+	BITPACK_OPERATE_VALUE(b, operator, decltype(b)::value)
+
+/**
+ * BITPACK_OPERATE_VALUE with dependent qualification for the type of the
+ * bitpack.
+ */
+#define BITPACK_OPERATE_VALUE_DEPENDENT(b, operator, value)                    \
+	BITPACK_OPERATE_VALUE(b, operator, typename decltype(b)::value)
+
+/// A specialization of BITPACK_OPERATE_VALUE using `.with` as the operator
+#define BITPACK_WITH_VALUE(b, value) BITPACK_OPERATE_VALUE(b, .with, value)
+
+/**
+ * A specialization of BITPACK_OPERATE_VALUE_DECLTYPE using `.with` as the
+ * operator
+ */
+#define BITPACK_WITH_VALUE_DECLTYPE(b, value)                                  \
+	BITPACK_OPERATE_VALUE_DECLTYPE(b, .with, value)
+
+/**
+ * A specialization of BITPACK_OPERATE_VALUE_DEPENDENT using `.with` as the
+ * operator.
+ */
+#define BITPACK_WITH_VALUE_DEPENDENT(b, value)                                 \
+	BITPACK_OPERATE_VALUE_DEPENDENT(b, .with, value)
+
+/// @}
+
+/**
+ * \defgroup bitpacks_macros_proxyop_enum "using enum" proxy operator macros
+ *
+ * @{
+ */
+
+/**
+ * Convenience for scoped enum fields, bringing the enumerators of the field
+ * type into scope while evaluating the value.
+ *
+ * Note that this uses `using enum` internally, and so cannot work with
+ * `Proxy`-s whose Field::Type-s are dependent.  Alas, this precludes the
+ * existence of a `BITPACK_*_ENUM_DEPENDENT` family of helpers.
+ *
+ * Probably prefer BITPACK_OPERATE_QUALIFY if you do not need repeated use of
+ * the enumeration's values within the passed `value`.
+ */
+#define BITPACK_OPERATE_ENUM(proxy, operator, value)                           \
+	({                                                                         \
+		using E = decltype(proxy)::Field::Type;                                \
+		static_assert(std::is_enum_v<E>);                                      \
+		using enum E;                                                          \
+		(proxy) operator(value);                                               \
+	})
+
+/// A fusion of BITPACK_MEMBER_DECLTYPE and BITPACK_OPERATE_ENUM
+#define BITPACK_OPERATE_ENUM_DECLTYPE(b, T, operator, v)                       \
+	BITPACK_OPERATE_ENUM(BITPACK_MEMBER_DECLTYPE(b, T), operator, v)
+
+/// A fusion of .member<>() and BITPACK_OPERATE_ENUM
+#define BITPACK_OPERATE_ENUM_TYPE(b, T, operator, v)                           \
+	BITPACK_OPERATE_ENUM((b).template member<T>(), operator, v)
+
+/// A specialization of BITPACK_OPERATE_ENUM using `.with` as the operator
+#define BITPACK_WITH_ENUM(proxy, value)                                        \
+	BITPACK_OPERATE_ENUM(proxy, .with, value)
+
+/**
+ * A specialization of BITPACK_OPERATE_ENUM_DECLTYPE using `.with` as the
+ * operator.
+ */
+#define BITPACK_WITH_ENUM_DECLTYPE(b, T, v)                                    \
+	BITPACK_OPERATE_ENUM_DECLTYPE(b, T, .with, v)
+
+/// A specialization of BITPACK_OPERATE_ENUM_TYPE using `.with` as the operator
+#define BITPACK_WITH_ENUM_TYPE(b, T, v)                                        \
+	BITPACK_OPERATE_ENUM_TYPE(b, T, .with, v)
+
+/// @}
+
+/**
+ * \defgroup bitpacks_macros_vararg Multi-field utility macros
+ *
+ * @{
+ */
+
+/**
+ * \defgroup bitpacks_macros_vararg_internal Internal helpers
+ *
+ * @{
+ */
+
+/**
+ * An in-situ probe for the #include-sion of <__macro_map.h>.
+ *
+ * While we could gate our behavior on `#if defined(CHERIOT_EVAL0)`, for
+ * example, that would require that <__macro_map.h> be included before us, which
+ * is slightly rude.  Instead, we can take creative advantage of the syntactic
+ * primitives __macro_map.h uses internally and some C++ quirks to (ab)usefully
+ * test the behavior of `CHERIOT_EVAL0` at each expansion of this macro.
+ *
+ * In terms of operation, this relies on `U CHERIOT_EVAL0(T);` meaning one of
+ *  two very different things and so dramatically changing what the subsequent
+ * `sizeof(T)` means.
+ *
+ *  - If CHERIOT_EVAL0 hasn't been #defined, then this defines a function named
+ *    CHERIOT_EVAL0 which takes a `struct T` and returns a `U`.  In this case,
+ *    the `T` in `sizeof(T)` means `struct T`, and that's 1 by definition,
+ *    since `sizeof(char)` is defined to be 1.
+ *
+ *  - If CHERIOT_EVAL0 has been defined as per <__macro_map.h>, then this is
+ *    preprocessed into `U T;`, a variable declaration, and the `T` in
+ *    `sizeof(T)` now refers to that variable and evaluates to 2.
+ */
+#define BITPACK_HAS_MACRO_MAP                                                  \
+	([]() {                                                                    \
+		struct BITPACK_HAS_MACRO_MAP_T                                         \
+		{                                                                      \
+			char t;                                                            \
+		};                                                                     \
+		struct BITPACK_HAS_MACRO_MAP_U                                         \
+		{                                                                      \
+			char u[2];                                                         \
+		};                                                                     \
+		BITPACK_HAS_MACRO_MAP_U CHERIOT_EVAL0(BITPACK_HAS_MACRO_MAP_T);        \
+		return sizeof(BITPACK_HAS_MACRO_MAP_T);                                \
+	}() > 1)
+
+/// Map function for BITPACK_MAP_DECLTYPE
+#define BITPACK_MAP_DECLTYPE_HELPER(x, b) decltype(b)::x
+
+/**
+ * Given bitpack `b`, qualify each additional argument with `decltype(b)`.  That
+ * is, `BITPACK_MAP_DECLTYPE(b, X, Y)` evalutes to
+ * `decltype(b)::X, decltype(b)::Y`.
+ *
+ * This requires #include <__macro_map.h> (and will give confusing error
+ * messages if not included).  (Because this is very much a C++ token level
+ * hack, unlike the other __macro_map users, it's hard for us to statically
+ * assert and give nice error messages.)
+ */
+#define BITPACK_MAP_DECLTYPE(b, ...)                                           \
+	CHERIOT_MAP_LIST_UD(BITPACK_MAP_DECLTYPE_HELPER, b, __VA_ARGS__)
+
+/// Map function for BITPACK_MAP_DEPENDENT
+#define BITPACK_MAP_DEPENDENT_HELPER(x, b) typename decltype(b)::x
+
+/**
+ * Given bitpack `b`, qualify each additional argument with `typename
+ * decltype(b)`.  That is, `BITPACK_DEPENDENT(b, X, Y)` evalutes to
+ * `typename decltype(b)::X, typename decltype(b)::Y`.
+ *
+ * This requires #include <__macro_map.h>.
+ */
+#define BITPACK_MAP_DEPENDENT(b, ...)                                          \
+	CHERIOT_MAP_LIST_UD(BITPACK_MAP_DEPENDENT_HELPER, b, __VA_ARGS__)
+
+/// Map function for BITPACK_WITHS
+#define BITPACK_MAP_WITHS_HELPER(x) .with(x)
+
+/// @}
+
+/**
+ * Construct a chain of .with() whose arguments are all qualified with the type
+ * of the bitpack.  #include <__macro_map.h> if you want to use this.
+ */
+#define BITPACK_WITHS(b, ...)                                                  \
+	({                                                                         \
+		static_assert(BITPACK_HAS_MACRO_MAP,                                   \
+		              "BITPACK_WITHS requires __macro_map.h");                 \
+		(b) CHERIOT_MAP(BITPACK_MAP_WITHS_HELPER, __VA_ARGS__);                \
+	})
+
+/**
+ * A version of BITPACK_WITHS where the arguments to `.with()` are qualified
+ * with the type of the bitpack.
+ */
+#define BITPACK_WITHS_DECLTYPE(b, ...)                                         \
+	BITPACK_WITHS(b, BITPACK_MAP_DECLTYPE(b, __VA_ARGS__))
+
+/**
+ * A version of BITPACK_WITHS where the arguments to `.with()` are dependently
+ * qualified with the type of the bitpack.
+ */
+#define BITPACK_WITHS_DEPENDENT(b, ...)                                        \
+	BITPACK_WITHS(b, BITPACK_MAP_DEPENDENT(b, __VA_ARGS__))
+
+/**
+ * @addtogroup macros_vararg_internal
+ * @{
+ */
+
+/// Helper for BITPACK_RELATE_MASKED, for computing individual field's masks
+#define BITPACK_RELATE_MASKED_HELPER(x, b)                                     \
+	| ({                                                                       \
+		using BT = decltype(b);                                                \
+		using FT = decltype(x);                                                \
+		BT::Field<FT, BT::field_info_for_type<FT>()>::FieldMask;               \
+	})
+
+/// @}
+
+/**
+ * Given a list of field values (which must be fully qualified names), compute
+ * the mask of these fields and the bitpack value holding these field values,
+ * then mask `b` with the computed mask, and then use `operator` to relate the
+ * result with the computed bitpack value.  The last value for each field is
+ * used.  #include <__macro_map.h> if you want to use this.
+ */
+#define BITPACK_RELATE_MASKED(b, operator, ...)                                \
+	({                                                                         \
+		static_assert(BITPACK_HAS_MACRO_MAP,                                   \
+		              "BITPACK_MASKED_REL requires __macro_map.h");            \
+		constexpr decltype(b.raw()) __bitpack_mask =                           \
+		  (0)CHERIOT_MAP_UD(BITPACK_RELATE_MASKED_HELPER, b, __VA_ARGS__);     \
+		constexpr auto __bitpack_query =                                       \
+		  BITPACK_WITHS((decltype(b))(0), __VA_ARGS__).raw();                  \
+		(b.raw() & __bitpack_mask) operator(__bitpack_query);                  \
+	})
+
+/**
+ * A version of BITPACK_RELATE_MASKED where the field values are qualified with
+ * the type of the bitpack.
+ */
+#define BITPACK_RELATE_MASKED_DECLTYPE(b, operator, ...)                       \
+	BITPACK_RELATE_MASKED(b, operator, BITPACK_MAP_DECLTYPE(b, __VA_ARGS__))
+
+/**
+ * A version of BITPACK_RELATE_MASKED where the field values are dependently
+ * qualified with the type of the bitpack.
+ */
+#define BITPACK_RELATE_MASKED_DEPENDENT(b, operator, ...)                      \
+	BITPACK_RELATE_MASKED(b, operator, BITPACK_MAP_DEPENDENT(b, __VA_ARGS__))
+
+/// @}
+/// @}
+/// @}

--- a/sdk/include/cdefs.h
+++ b/sdk/include/cdefs.h
@@ -138,6 +138,12 @@ using _Bool = bool;
 #	define __clang_ignored_warning_pop()
 #endif
 
+#if defined(CHERIOT_EXPERIMENTAL_APIS_WARN)
+#	define CHERIOT_EXPERIMENTAL(msg) __attribute__((deprecated(msg)))
+#else
+#	define CHERIOT_EXPERIMENTAL(msg)
+#endif
+
 #if !defined(CLANG_TIDY) && !__has_builtin(__builtin_cheri_top_get)
 #	error Your compiler is too old for this version of CHERIoT RTOS, please upgrade to a newer version
 #endif

--- a/sdk/include/platform/sunburst/platform-uart.hh
+++ b/sdk/include/platform/sunburst/platform-uart.hh
@@ -4,6 +4,7 @@
 #	define DEFAULT_UART_BAUD_RATE 921'600
 #endif
 
+#include <bitpack.hh>
 #include <platform/concepts/uart.hh>
 #include <utils.hh>
 
@@ -18,30 +19,72 @@
  */
 struct OpenTitanUart : private utils::NoCopyNoMove
 {
-	/**
-	 * Interrupt State Register.
-	 */
-	uint32_t interruptState;
-	/**
-	 * Interrupt Enable Register.
-	 */
-	uint32_t interruptEnable;
-	/**
-	 * Interrupt Test Register.
-	 */
-	uint32_t interruptTest;
+	struct Interrupts : Bitpack<uint32_t>
+	{
+		BITPACK_USUAL_PREFIX;
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(TransmitWatermark, 0);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveWatermark, 1);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(TransmitDone, 2);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveOverflowError, 3);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveFrameError, 4);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveBreakError, 5);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveTimeout, 6);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveParityError, 7);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(TransmitEmpty, 8);
+	};
+
+	struct InterruptState : BitpackDerived<Interrupts>
+	{
+		BITPACK_DERIVED_PREFIX;
+
+		// TransmitWatermark is a status, not an event, so RO, not RW1C.
+		BITPACK_DERIVED_FIELD_CONST_FOR_TYPE(TransmitWatermark, true);
+
+		// ReceiveWatermark is a status, not an event, so RO, not RW1C.
+		BITPACK_DERIVED_FIELD_CONST_FOR_TYPE(ReceiveWatermark, true);
+
+		// TransmitEmpty is a status, not an event, so RO, not RW1C.
+		BITPACK_DERIVED_FIELD_CONST_FOR_TYPE(TransmitEmpty, true);
+	};
+
+	InterruptState interruptState;
+	Interrupts     interruptEnable;
+	Interrupts     interruptTest;
+
 	/**
 	 * Alert Test Register (unused).
 	 */
 	uint32_t alertTest;
-	/**
-	 * Control Register.
-	 */
-	uint32_t control;
-	/**
-	 * Status Register.
-	 */
-	uint32_t status;
+
+	struct Control : Bitpack<uint32_t>
+	{
+		BITPACK_USUAL_PREFIX;
+		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(Transmit, 0);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(Receive, 1);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(NoiseFilter, 2);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(SystemLoopback, 3);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(LineLoopback, 4);
+		BITPACK_MEMBER_ADD_ENUM(Parity, uint8_t, 5, 6) {
+			None = 0b00,
+			Even = 0b01,
+			Odd  = 0b11,
+		};
+
+		BITPACK_MEMBER_ADD_NUMERIC(BreakLevel, uint8_t, 8, 9);
+		BITPACK_MEMBER_ADD_NUMERIC(Nco, uint16_t, 16, 31);
+	} control;
+
+	const struct Status : Bitpack<uint32_t>
+	{
+		BITPACK_USUAL_PREFIX;
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(TransmitFull, 0);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveFull, 1);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(TransmitEmpty, 2);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(TransmitIdle, 3);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveIdle, 4);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_CLEARED_ASSERTED(ReceiveEmpty, 5);
+	} status; // NOLINT(readability-identifier-naming)
+
 	/**
 	 * UART Read Data.
 	 */
@@ -50,14 +93,43 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 	 * UART Write Data.
 	 */
 	uint32_t writeData;
-	/**
-	 * UART FIFO Control Register.
-	 */
-	uint32_t fifoCtrl;
+
+	struct FIFOControl : Bitpack<uint32_t>
+	{
+		BITPACK_USUAL_PREFIX;
+
+		BITPACK_MEMBER_ADD_ENUM_BOOL(Receive, AsIs, Reset, 0);
+		BITPACK_MEMBER_ADD_ENUM_BOOL(Transmit, AsIs, Reset, 1);
+
+		BITPACK_MEMBER_ADD_ENUM(TransmitWatermark, uint8_t, 2, 4) {
+			Level1  = 0b000,
+			Level2  = 0b001,
+			Level4  = 0b010,
+			Level8  = 0b011,
+			Level16 = 0b100,
+			Level32 = 0b101,
+			Level64 = 0b110,
+		};
+		BITPACK_MEMBER_ADD_ENUM(ReceiveWatermark, uint8_t, 5, 7) {
+			Level1  = 0b000,
+			Level2  = 0b001,
+			Level4  = 0b010,
+			Level8  = 0b011,
+			Level16 = 0b100,
+		};
+	} fifoControl;
+
 	/**
 	 * UART FIFO Status Register.
 	 */
-	uint32_t fifoStatus;
+	const struct FIFOStatus : Bitpack<uint32_t>
+	{
+		BITPACK_USUAL_PREFIX;
+
+		BITPACK_MEMBER_ADD_NUMERIC(TransmitLevel, uint8_t, 0, 7);
+		BITPACK_MEMBER_ADD_NUMERIC(ReceiveLevel, uint8_t, 16, 23);
+	} fifoStatus; // NOLINT(readability-identifier-naming)
+
 	/**
 	 * Transmit Pin Override Control.
 	 *
@@ -73,104 +145,6 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 	 */
 	uint32_t timeoutControl;
 
-	/// OpenTitan UART Interrupts
-	typedef enum [[clang::flag_enum]] : uint32_t
-	{
-		/// Raised if the transmit FIFO is empty.
-		InterruptTransmitEmpty = 1 << 8,
-		/// Raised if the receiver has detected a parity error.
-		InterruptReceiveParityErr = 1 << 7,
-		/// Raised if the receive FIFO has characters remaining in the FIFO
-		/// without being
-		/// retreived for the programmed time period.
-		InterruptReceiveTimeout = 1 << 6,
-		/// Raised if break condition has been detected on receive.
-		InterruptReceiveBreakErr = 1 << 5,
-		/// Raised if a framing error has been detected on receive.
-		InterruptReceiveFrameErr = 1 << 4,
-		/// Raised if the receive FIFO has overflowed.
-		InterruptReceiveOverflow = 1 << 3,
-		/// Raised if the transmit FIFO has emptied and no transmit is ongoing.
-		InterruptTransmitDone = 1 << 2,
-		/// Raised if the receive FIFO is past the high-water mark.
-		InterruptReceiveWatermark = 1 << 1,
-		/// Raised if the transmit FIFO is past the high-water mark.
-		InterruptTransmitWatermark = 1 << 0,
-	} OpenTitanUartInterrupt;
-
-	/// FIFO Control Register Fields
-	enum [[clang::flag_enum]] : uint32_t
-	{
-		/// Reset the transmit FIFO.
-		FifoControlTransmitReset = 1 << 1,
-		/// Reset the receive FIFO.
-		FifoControlReceiveReset = 1 << 0,
-	};
-
-	/// Control Register Fields
-	enum : uint32_t
-	{
-		/// Sets the BAUD clock rate from the numerically controlled oscillator.
-		ControlNco = 0xff << 16,
-		/// Set the number of character times the line must be low
-		/// which will be interpreted as a break.
-		ControlReceiveBreakLevel = 0b11 << 8,
-		/// When set, odd parity is used, otherwise even parity is used.
-		ControlParityOdd = 1 << 7,
-		/// Enable party on both transmit and receive lines.
-		ControlParityEnable = 1 << 6,
-		/// When set, incoming received bits are forwarded to the transmit line.
-		ControlLineLoopback = 1 << 5,
-		/// When set, outgoing transmitted bits are routed back the receiving
-		/// line.
-		ControlSystemLoopback = 1 << 4,
-		/// Enable the noise filter on the receiving line.
-		ControlNoiseFilter = 1 << 2,
-		/// Enable receiving bits.
-		ControlReceiveEnable = 1 << 1,
-		/// Enable transmitting bits.
-		ControlTransmitEnable = 1 << 0,
-	};
-
-	/// Status Register Fields
-	enum : uint32_t
-	{
-		/// Receive FIFO is empty.
-		StatusReceiveEmpty = 1 << 5,
-		/// Receive logic is idle.
-		StatusReceiveIdle = 1 << 4,
-		/// Transmit FIFO is empty and all bits have been transmitted.
-		StatusTransmitIdle = 1 << 3,
-		/// Transmit FIFO is empty; transmission may still be occurring.
-		StatusTransmitEmpty = 1 << 2,
-		/// Receive FIFO is full.
-		StatusReceiveFull = 1 << 1,
-		/// Transmit FIFO is full.
-		StatusTransmitFull = 1 << 0,
-	};
-
-	/// The encoding for different transmit watermark levels.
-	enum class TransmitWatermark
-	{
-		Level1  = 0x0,
-		Level2  = 0x1,
-		Level4  = 0x2,
-		Level8  = 0x3,
-		Level16 = 0x4,
-	};
-
-	/// The encoding for different receive watermark levels.
-	enum class ReceiveWatermark
-	{
-		Level1  = 0x0,
-		Level2  = 0x1,
-		Level4  = 0x2,
-		Level8  = 0x3,
-		Level16 = 0x4,
-		Level32 = 0x5,
-		Level64 = 0x6,
-	};
-
 	/**
 	 * Configure parity.
 	 *
@@ -179,9 +153,8 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 	 */
 	void parity(bool enableParity = true, bool oddParity = false) volatile
 	{
-		control = (control & ~(ControlParityEnable | ControlParityOdd)) |
-		          (enableParity ? ControlParityEnable : 0) |
-		          (oddParity ? ControlParityOdd : 0);
+		using enum Control::Parity;
+		control.set(enableParity ? (oddParity ? Odd : Even) : None);
 	}
 
 	/**
@@ -194,16 +167,22 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 	void loopback(bool systemLoopback = true,
 	              bool lineLoopback   = false) volatile
 	{
-		control = (control & ~(ControlSystemLoopback | ControlLineLoopback)) |
-		          (systemLoopback ? ControlSystemLoopback : 0) |
-		          (lineLoopback ? ControlLineLoopback : 0);
+		control.alter([=](auto v) {
+			BITPACK_OPERATE_VALUE_DEPENDENT(
+			  v, =, SystemLoopback{systemLoopback});
+			BITPACK_OPERATE_VALUE_DEPENDENT(v, =, LineLoopback{lineLoopback});
+			return v;
+		});
 	}
 
 	/// Clears the contents of the receive and transmit FIFOs.
 	void fifos_clear() volatile
 	{
-		fifoCtrl =
-		  fifoCtrl | FifoControlTransmitReset | FifoControlReceiveReset;
+		fifoControl.alter([](auto v) {
+			BITPACK_OPERATE_VALUE_DECLTYPE(v, =, Transmit::Reset);
+			BITPACK_OPERATE_VALUE_DECLTYPE(v, =, Receive::Reset);
+			return v;
+		});
 	}
 
 	/**
@@ -212,9 +191,9 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 	 * When the number of bytes in the transmit FIFO reach this level,
 	 * the transmit watermark interrupt will fire.
 	 */
-	void transmit_watermark(TransmitWatermark level) volatile
+	void transmit_watermark(FIFOControl::TransmitWatermark level) volatile
 	{
-		fifoCtrl = static_cast<uint32_t>(level) << 5 | (fifoCtrl & 0x1f);
+		fifoControl.set(level);
 	}
 
 	/**
@@ -223,37 +202,63 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 	 * When the number of bytes in the receive FIFO reach this level,
 	 * the receive watermark interrupt will fire.
 	 */
-	void receive_watermark(ReceiveWatermark level) volatile
+	void receive_watermark(FIFOControl::ReceiveWatermark level) volatile
 	{
-		fifoCtrl = static_cast<uint32_t>(level) << 2 | (fifoCtrl & 0b11100011);
+		fifoControl.set(level);
 	}
 
-	/// Enable the given interrupt.
-	void interrupt_enable(OpenTitanUartInterrupt interrupt) volatile
+	/// Enable the given interrupt by name
+	template<typename Interrupt>
+	void interrupt_enable() volatile
 	{
-		interruptEnable = interruptEnable | interrupt;
+		interruptEnable.member<Interrupt>() = Interrupt{true};
 	}
 
-	/// Disable the given interrupt.
-	void interrupt_disable(OpenTitanUartInterrupt interrupt) volatile
+	/// Disable the given interrupt by name
+	template<typename Interrupt>
+	void interrupt_disable() volatile
 	{
-		interruptEnable = interruptEnable & ~interrupt;
+		interruptEnable.member<Interrupt>() = Interrupt{false};
+	}
+
+	/// Enable the given interrupt(s) by value
+	void interrupt_enable(Interrupts interrupt) volatile
+	{
+		interruptEnable.alter([interrupt](auto v) {
+			return decltype(v){v.raw() | interrupt.raw()};
+		});
+	}
+
+	/// Disable the given interrupt(s) by value
+	void interrupt_disable(Interrupts interrupt) volatile
+	{
+		interruptEnable.alter([interrupt](auto v) {
+			return decltype(v){v.raw() & ~interrupt.raw()};
+		});
 	}
 
 	void init(unsigned baudRate = DEFAULT_UART_BAUD_RATE) volatile
 	{
 		// Nco = 2^20 * baud rate / cpu frequency
-		const uint32_t Nco =
+		const uint16_t Nco =
 		  ((static_cast<uint64_t>(baudRate) << 20) / CPU_TIMER_HZ);
-		// Set the baud rate and enable transmit & receive
-		control = (Nco << 16) | (control & 0xFFFF) | ControlTransmitEnable |
-		          ControlReceiveEnable;
+
+		control.alter([=](auto v) {
+			BITPACK_OPERATE_VALUE_DEPENDENT(v, =, Nco{Nco});
+			BITPACK_OPERATE_VALUE_DECLTYPE(v, =, Transmit::Enabled);
+			BITPACK_OPERATE_VALUE_DECLTYPE(v, =, Receive::Enabled);
+			return v;
+		});
 	}
 
 	/// Turn off the transceivers
 	void disable() volatile
 	{
-		control &= ~(ControlTransmitEnable | ControlReceiveEnable);
+		control.alter([=](auto v) {
+			BITPACK_OPERATE_VALUE_DECLTYPE(v, =, Transmit::Disabled);
+			BITPACK_OPERATE_VALUE_DECLTYPE(v, =, Receive::Disabled);
+			return v;
+		});
 	}
 
 	/**
@@ -262,27 +267,29 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 	 */
 	void reset() volatile
 	{
-		control = 0;
+		control = decltype(control){0};
 	}
 
 	[[gnu::always_inline]] uint16_t transmit_fifo_level() volatile
 	{
-		return fifoStatus & 0xff;
+		return BITPACK_MEMBER_DECLTYPE(fifoStatus.read(), TransmitLevel).raw();
 	}
 
 	[[gnu::always_inline]] uint16_t receive_fifo_level() volatile
 	{
-		return ((fifoStatus >> 16) & 0xff);
+		return BITPACK_MEMBER_DECLTYPE(fifoStatus.read(), ReceiveLevel).raw();
 	}
 
 	bool can_write() volatile
 	{
-		return !(status & StatusTransmitFull);
+		return BITPACK_OPERATE_VALUE_DECLTYPE(
+		  status.read(), ==, TransmitFull::Cleared);
 	}
 
 	bool can_read() volatile
 	{
-		return !(status & StatusReceiveEmpty);
+		return BITPACK_OPERATE_VALUE_DECLTYPE(
+		  status.read(), ==, ReceiveEmpty::Cleared);
 	}
 
 	/**

--- a/tests/bitpacks-test.cc
+++ b/tests/bitpacks-test.cc
@@ -1,0 +1,448 @@
+#define TEST_NAME "Test bitpacks"
+#include "tests.hh"
+
+#include <bitpack.hh>
+
+static_assert(!BITPACK_HAS_MACRO_MAP);
+
+#include <__macro_map.h>
+
+static_assert(BITPACK_HAS_MACRO_MAP);
+
+/// An example "device" structure type, composed of two Bitpack "registers".
+struct Foo
+{
+	/*
+	 * Many bit-packed structures are just products of distinct types, so we
+	 * can tell C++ essentially exactly that: what types are and where they are
+	 * placed within the packed structure.
+	 */
+	struct Control : Bitpack<uint32_t>
+	{
+		BITPACK_USUAL_PREFIX;
+
+		enum class Drive : uint8_t
+		{
+			No   = 0,
+			Up   = 1,
+			Down = 2,
+			Both = 3,
+		};
+
+		template<>
+		constexpr FieldInfo field_info_for_type<Drive>()
+		{
+			return {0, 1};
+		}
+
+		enum class Flag0 : uint8_t
+		{
+			No  = 0,
+			Yes = 1,
+		};
+
+		template<>
+		constexpr FieldInfo field_info_for_type<Flag0>()
+		{
+			return {4, 4};
+		}
+
+		BITPACK_MEMBER_ADD_ENUM(Flag1, uint8_t, 5, 5) {
+			No  = 0,
+			Yes = 1,
+		};
+
+		struct Scalar : Numeric<uint8_t>
+		{
+			using Numeric::Numeric;
+		};
+
+		template<>
+		constexpr FieldInfo field_info_for_type<Scalar>()
+		{
+			return {8, 14};
+		}
+
+		BITPACK_MEMBER_ADD_NUMERIC(Scalar2, uint8_t, 15, 20);
+
+		/*
+		 * These will trip static assertions, since bool cannot represent more
+		 * than one bit.
+		 */
+		// BITPACK_MEMBER_ADD_NUMERIC(Scalar3, bool, 21, 22);
+		// BITPACK_MEMBER_ADD_ENUM_CLASS(Badenum, bool, 21, 22) { V = false };
+	} control;
+
+	/*
+	 * Explicit field accessors, without type-level computation, also work, and
+	 * are useful when types are reused within the product.
+	 */
+	struct More : Bitpack<uint32_t>
+	{
+		using Bitpack::Bitpack;
+		using Bitpack::operator=;
+
+		enum class ReusedE : uint8_t
+		{
+			A = 0,
+			B = 1,
+			C = 2,
+			D = 3,
+		};
+
+		// Nested bitpacks are also supported
+		struct ReusedT : Bitpack<uint8_t>
+		{
+			using Bitpack::Bitpack;
+			using Bitpack::operator=;
+
+			template<typename Self>
+			constexpr auto f1(this Self &&self)
+			{
+				return self.template member<ReusedE, {0, 1}>();
+			}
+
+			BITPACK_MEMBER_ADD(f1c, ReusedE, 0, 1, true);
+			BITPACK_MEMBER_ADD(f2, ReusedE, 4, 5);
+		};
+
+		BITPACK_MEMBER_ADD(r1, ReusedT, 0, 7);
+
+		using R2 = Field<ReusedT, {8, 15}>;
+
+		template<typename Self>
+		constexpr auto r2(this Self &&self)
+		{
+			return R2::Proxy(self);
+		}
+	} more;
+};
+static_assert(offsetof(Foo, control) == 0);
+static_assert(offsetof(Foo, more) == 4);
+static_assert(sizeof(Foo) == 8);
+
+template<typename F>
+static constexpr bool CanAssignFieldV =
+  std::is_assignable_v<F &, typename F::Field::Type &>;
+
+// We can assign into Foo::Control's Drive field...
+static_assert(CanAssignFieldV<decltype(std::declval<Foo::Control>()
+                                         .member<Foo::Control::Drive>())>);
+
+// We can assign into Foo::More::ReusedT's f1() field...
+static_assert(
+  CanAssignFieldV<decltype(std::declval<Foo::More::ReusedT>().f1())>);
+
+// ... but not an alias of it that's marked constant.
+static_assert(
+  !CanAssignFieldV<decltype(std::declval<Foo::More::ReusedT>().f1c())>);
+
+constexpr static auto C0 = Foo::Control();
+static_assert(C0.raw() == 0);
+
+// Construct a constant using type-directed interfaces, verbosely
+constexpr static auto C1 =
+  C0.with<Foo::Control::Scalar>({7}).with<Foo::Control::Drive>(
+    Foo::Control::Drive::Up);
+static_assert(C1.raw() == 0x701);
+
+static_assert(C1.with<Foo::Control::Scalar2>(0xA).raw() == 0x50701);
+
+/*
+ * OK, that's too chatty.  With some macro terror, we can get something much
+ * better, with the only moderately vexing need for an immediately-evaluated
+ * lambda, since statement expressions aren't supported at top-level scope.
+ */
+constexpr static auto C1a = []() {
+	return BITPACK_WITHS_DECLTYPE(C0, Scalar{7}, Drive::Up);
+}();
+static_assert(C1 == C1a);
+
+// Chain with()s for explicit (not-type-directed) fields
+constexpr static auto M1 =
+  Foo::More()
+    .r1()
+    .with([](auto r) { return r.f2().with(Foo::More::ReusedE::B); })
+    .r2()
+    .with([](auto r) { return r.f1().with(Foo::More::ReusedE::C); });
+static_assert(M1.raw() == 0x0210);
+
+// We can also build up values with chains of mutation
+constexpr static Foo F1 = []() {
+	auto f = Foo();
+
+	/*
+	 * Rawest form, with no deduction or type-level computation other than the
+	 * .member<>() resolution.
+	 */
+	f.control.member<Foo::Control::Drive>() = Foo::Control::Drive::Down;
+
+	/*
+	 * Slightly more baked: .set()'s template argument is deducable from its
+	 * argument's type; field information is computed therefrom.
+	 */
+	f.control.set(Foo::Control::Flag0::Yes);
+
+	/*
+	 * Convenience macros get rid of lots of those ::s through some abuse while
+	 * the compilation unit is still just a sequence of tokens.
+	 */
+	BITPACK_OPERATE_ENUM_DECLTYPE(f.control, Flag1, =, Yes);
+
+	/*
+	 * `.member<>` with a little syntactic sugar behind a macro.  Note that
+	 * `Numeric<T>` fields are implicitly convertible to their backing type T,
+	 * so we don't need anyhing fancier than their value.
+	 *
+	 * All bitpack fields are clamped to their field width, so even though the
+	 * Scalar field is a `Numeric<uint8_t>`, and we can set bits arbitrarily,
+	 * only seven of these eight bits make it into the backing storage (checked
+	 * implicitly below with our `static_assert`-s).
+	 */
+	BITPACK_MEMBER_DECLTYPE(f.control, Scalar) = 0xFF;
+
+	/*
+	 * Nested bitpack assignment, with explicit fields for both levels.
+	 *
+	 * Constant fields don't support assignment or .alter(), but do support
+	 * .with(), since that produces a new Bitpack value.
+	 */
+	f.more.r1() = Foo::More::ReusedT{}
+	                .f1c()
+	                .with(Foo::More::ReusedE::C)
+	                .f2()
+	                .with(Foo::More::ReusedE::B);
+
+	/*
+	 * Perhaps slightly more convenient?
+	 *
+	 * The argument type to the lambda must be specified and not `auto` or a
+	 * template parameter, as `using enum` (as inside BITPACK_ENUM_*) works only
+	 * with non-dependent types.
+	 */
+	f.more.r2().alter([](Foo::More::ReusedT r2) {
+		BITPACK_OPERATE_ENUM(r2.f1(), =, D);
+		return r2;
+	});
+	f.more.r2().alter([](Foo::More::ReusedT r2) {
+		BITPACK_OPERATE_ENUM(r2.f2(), =, B);
+		return r2;
+	});
+
+	return f;
+}();
+static_assert(BITPACK_MEMBER_DECLTYPE(F1.control, Scalar) == 0x7F);
+static_assert(F1.control.raw() == 0x7F32);
+static_assert(F1.more.raw() == 0x1312);
+
+__noinline static void test_volatile(volatile Foo *vfp)
+{
+	static_assert(std::is_same_v<volatile Foo::More &, decltype((vfp->more))>);
+
+	BITPACK_OPERATE_VALUE_DECLTYPE(vfp->control, =, Flag0::Yes);
+
+	TEST_EQUAL(vfp->control.read().raw(), 0x10U, "bad volatile handling?");
+
+	vfp->control.alter([](auto v) {
+		BITPACK_MEMBER_DEPENDENT(v, Scalar).alter([](auto v) { return v + 7; });
+		return BITPACK_WITHS_DEPENDENT(v, Scalar2{7});
+	});
+
+	TEST_EQUAL(vfp->control.read().raw(), 0x38710U, "bad volatile handling?");
+
+	volatile Foo::More &m = vfp->more;
+
+	// Fields of volatile bitpacks have volatile internal reference types
+	static_assert(
+	  std::is_same_v<volatile uint32_t &, decltype(m.r1())::RefType>);
+
+	// First write to vfp->more by populating its .r2() field from all zeros..a.
+	m.assign_from([](auto z) {
+		z.r2().assign_from(
+		  [](auto zr2) { return zr2.f2().with(Foo::More::ReusedE::C); });
+		return z;
+	});
+
+	// Read-modify-write vfp->more to update its .r1() field.
+	m.r1().alter([](auto r1) {
+		/*
+		 * m.r1() was volatile, but .alter() has performed a read, and so the
+		 * value shown to us is not volatile.
+		 *
+		 * We can, however, verify that our "this field is constant in an
+		 * otherwise non-constant Bitpack" logic works, so .f1c() qualifies its
+		 * reference to the bitpack's underlying storage as constant.
+		 */
+		static_assert(
+		  std::is_same_v<uint8_t &, typename decltype(r1.f1())::RefType>);
+		static_assert(std::is_same_v<const uint8_t &,
+		                             typename decltype(r1.f1c())::RefType>);
+
+		return r1.f1()
+		  .with(Foo::More::ReusedE::A)
+		  .f2()
+		  .with(Foo::More::ReusedE::D);
+	});
+
+	TEST_EQUAL(vfp->more.read().raw(), 0x2030U, "bad volatile handling?");
+
+	vfp->more = F1.more;
+
+	TEST_EQUAL(vfp->more.read().raw(), 0x1312U, "bad volatile handling?");
+
+	/*
+	 * Bitpacks' assignment operator rejects volatile RHS, so we can't just
+	 * write `vfp->more = vfp->more;` for example.  And, in fact, we can have
+	 * the compiler check that we can't do that...
+	 */
+	static_assert(
+	  !std::is_assignable_v<volatile Foo::More &, volatile Foo::More &>);
+	// Instead, we have to perform an explicit read.
+	static_assert(std::is_assignable_v<volatile Foo::More &, Foo::More &>);
+	vfp->more = vfp->more.read();
+}
+
+static void test_static_asserts()
+{
+	static_assert(
+	  BITPACK_OPERATE_ENUM(C1.member<Foo::Control::Drive>(), ==, Up));
+	static_assert(BITPACK_OPERATE_ENUM_DECLTYPE(C1, Control::Flag0, ==, No));
+	static_assert((BITPACK_WITH_ENUM_DECLTYPE(C1, Drive, Both) <=> C1) ==
+	              std::strong_ordering::greater);
+	static_assert(BITPACK_OPERATE_WRAP(
+	  F1.control.member<Foo::Control::Scalar>(), ==, 0x7F));
+	static_assert(
+	  BITPACK_OPERATE_WRAP_DECLTYPE(F1.control, Scalar, <=>, 0x7E) ==
+	  std::strong_ordering::greater);
+
+	static_assert(
+	  static_cast<uint32_t>(F1.control.get<Foo::Control::Flag1>()) == 1);
+
+	static_assert(BITPACK_RELATE_MASKED_DECLTYPE(C1, ==, Flag0::No, Scalar{7}));
+}
+
+/*
+ * Demonstrate a derived bitpack and how we can, in particular, describe a
+ * bitpack that differs only in the constness of a field therein.
+ */
+struct DerivedFC : BitpackDerived<Foo::Control>
+{
+	BITPACK_DERIVED_PREFIX;
+	BITPACK_DERIVED_FIELD_CONST_FOR_TYPE(Flag1, true);
+};
+
+#define FIELD_INFO_BY_DECLTYPE(BT, T)                                          \
+	[]() { return decltype(BITPACK_MEMBER_DECLTYPE((BT){}, T))::Field::Info; }()
+
+/*
+ * The derived bitpack continues to have types inherited from its parent and,
+ * if we do not do anyting, these have the same associated field info.
+ */
+static_assert(FIELD_INFO_BY_DECLTYPE(Foo::Control, Drive) ==
+              FIELD_INFO_BY_DECLTYPE(DerivedFC, Drive));
+
+// But we can also redefine the fields associated with types...
+static_assert(!FIELD_INFO_BY_DECLTYPE(Foo::Control, Flag1).isConst);
+static_assert(FIELD_INFO_BY_DECLTYPE(DerivedFC, Flag1).isConst);
+
+namespace MaybeBetterErgonomicsTypes
+{
+	/*
+	 * As much as it may be morally correct for field types to belong to the
+	 * `Bitpack`-based `struct`-ure to which they belong, C++ really doesn't
+	 * make that easy to use, thus all the C preprocessor macros and a lot of
+	 * the ::s in the above.  Let's try that experiment again with the types
+	 * floated out into a namespace to which we can apply `using namespace`
+	 * statements.
+	 */
+
+	enum class Drive : uint8_t
+	{
+		No   = 0,
+		Up   = 1,
+		Down = 2,
+		Both = 3,
+	};
+
+	enum class Flag0 : uint8_t
+	{
+		No  = 0,
+		Yes = 1,
+	};
+
+} // namespace MaybeBetterErgonomicsTypes
+
+struct MBE : Bitpack<uint32_t>
+{
+	using Bitpack::Bitpack;
+	using Bitpack::operator=;
+
+	template<typename FieldType>
+	static constexpr FieldInfo field_info_for_type() = delete;
+
+	template<>
+	constexpr FieldInfo field_info_for_type<MaybeBetterErgonomicsTypes::Drive>()
+	{
+		return {0, 1};
+	}
+
+	template<>
+	constexpr FieldInfo field_info_for_type<MaybeBetterErgonomicsTypes::Flag0>()
+	{
+		return {2, 2};
+	}
+};
+
+// If we assume the usual use case here is that the definitions (above) are in a
+// header and the users are in separate compliation units, we can bring the
+// namespace(s) involved into scope with using.  For the purpose of this test,
+// do so in a lambda and pass out anything we need for later consideration.
+static constexpr auto MBETops = []() {
+	using namespace MaybeBetterErgonomicsTypes;
+
+	constexpr auto MBE0 = MBE();
+	static_assert(MBE0.raw() == 0);
+
+	constexpr auto MBE1 = MBE0.with(Drive::Up).with(Flag0::Yes);
+	static_assert(MBE1.raw() == 0b1'01);
+
+	auto mbe2 = MBE1;
+	mbe2.member<Drive>().alter([](auto) { return Drive::Down; });
+	BITPACK_OPERATE_VALUE(mbe2, =, Flag0::No);
+
+	return std::make_tuple(MBE1, mbe2);
+}();
+
+static void test_maybe_better_ergonomics()
+{
+	using namespace MaybeBetterErgonomicsTypes;
+
+	constexpr static auto MBE1 = std::get<0>(MBETops);
+
+	/*
+	 * This is slightly better, but still, I think having some macros help,
+	 * trading repetition of the type for slightly longer spelling.
+	 */
+	static_assert(MBE1.member<Drive>() == Drive::Up);
+	static_assert(BITPACK_OPERATE_ENUM(MBE1.member<Drive>(), ==, Up));
+	static_assert(BITPACK_OPERATE_ENUM_TYPE(MBE1, Drive, ==, Up));
+
+	static_assert((BITPACK_WITH_ENUM_TYPE(MBE1, Drive, Both) <=> MBE1) ==
+	              std::strong_ordering::greater);
+
+	constexpr static auto MBE2 = std::get<1>(MBETops);
+	static_assert(MBE2.raw() == 0b0'10);
+
+	static_assert(BITPACK_RELATE_MASKED(MBE2, ==, Drive::Down));
+}
+
+int test_bitpacks()
+{
+	test_static_asserts();
+	test_maybe_better_ergonomics();
+
+	volatile Foo vf = Foo{};
+	test_volatile(&vf);
+
+	return 0;
+}

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -212,6 +212,8 @@ test("allocator", { name = "Allocator" })
 test("rust", { name = "Rust", not_most = true })
   add_files("rust-test.rs")
 
+test("bitpacks")
+
 includes(path.join(sdkdir, "lib"))
 
 rule("cheriot.tests")


### PR DESCRIPTION
Introduce a `Bitpack` class, representing a packed bit-field within an unsigned integral type.  `Bitpack`s are intended for use instead of C++ bit-fields or manual bit twiddling and should...

- not have any undefined or implementation-defined behavior or layout (besides endianness); `Field` definitions are interpreted as one might expect using `<<`, `|`, `&`, and `~` (see `Bitpack<>::Field<>::raw_view` and `raw_with` for the core of all this C++ syntax);

- readily serve as superclasses for classes fronting particular hardware control registers or other bit-packed types;

- work in `constexpr` context and in `volatile`-qualified forms;

- be reasonably ergonomic to use in as many contexts as possible.

The fundamental perspective is one of `Field::View` proxies to contiguous spans of bits within a `Bitpack<T>`'s underlying storage `T`.  Said spans are defined using `FieldInfo` structures.  Field proxies to fields of type `F` and with `FieldInfo I` may be explicitly constructed with `.view<F, I>()`, but there is also some convenience machinery for defining `Bitpack`s as _products_ of differently-typed fields, such that a proxy to a given field with type `F` can be accessed uniformly as `.view<F>()` (where, effectively, the `FieldInfo` `I` is computed from `F`).

There are also some gross C-preprocessor macros that aim to de-clutter use of `Bitpack`s, especially in combination with `enum class`es.

The raw implementation is in `sdk/include/bitpacks.hh` and a small smattering of tests (mostly checking operation in combination with `constexpr` and `volatile`) and demonstration of use is available in `tests/bitpacks-test.cc`.  It is probably sensible to review the two in parallel, as the implementation is probably confusing without examples of use, and the use is probably confusing without some understanding of the implementation.

This is still a little bit of an experiment and a request for comments / opinions, so please, fire away!