### PR TITLE
Fix mistake in benchmarks

### DIFF
--- a/benchmarks/compartment-call/caller.cc
+++ b/benchmarks/compartment-call/caller.cc
@@ -72,7 +72,7 @@ int __cheri_compartment("caller") run()
 		auto [full, callPath, returnPath] =
 		  CHERI::with_interrupts_disabled([&]() {
 			  auto start  = METRIC();
-			  auto middle = local_noop_return_metric();
+			  auto middle = callee_noop_return_metric();
 			  auto end    = METRIC();
 			  return std::tuple{end - start, middle - start, end - middle};
 		  });


### PR DESCRIPTION
This benchmark is supposed to measure the compartment latency but somehow we measure the function call latency instead. (We didn't have this bug when we made the paper's measurements.)