### PR TITLE
Tweaks and fixes to the core API benchmarks.

### DIFF
--- a/benchmarks/compartment-call/callee.cc
+++ b/benchmarks/compartment-call/callee.cc
@@ -15,34 +15,6 @@ int callee_stack_using_return_metric(size_t stackUse)
 	return METRIC();
 }
 
-int callee_check_pointer_return_metric(void *p)
-{
-	using namespace CHERI;
-
-	if (!check_pointer<PermissionSet{Permission::Load}>(p))
-	{
-		return -EINVAL;
-	}
-
-	return METRIC();
-}
-
-int callee_ephemeral_claim_return_metric(void *p)
-{
-	Timeout t{UnlimitedTimeout};
-	heap_claim_ephemeral(&t, p);
-
-	return METRIC();
-}
-
-int callee_claim_release_return_metric(void *p)
-{
-	heap_claim(MALLOC_CAPABILITY, p);
-	heap_free(MALLOC_CAPABILITY, p);
-
-	return METRIC();
-}
-
 int callee_dereference(int *p)
 {
 	return *p;


### PR DESCRIPTION
Various fixes and tweaks to the core API benchmarks. Described in commit messages.

Note that none of these issues affect the paper's measurements, these happened during the merge of the patch we used for the paper's numbers (https://github.com/CHERIoT-Platform/cheriot-rtos/pull/515).