### PR TITLE
Set __SOFTFP__ in order to use soft expansions for higher-level FP operations in our soft-float library.

### DIFF
--- a/sdk/lib/softfloat/xmake.lua
+++ b/sdk/lib/softfloat/xmake.lua
@@ -9,6 +9,7 @@ function softfloat_library(size, name)
 		set_default(false)
 		add_cxflags("-include " .. softfloatheader)
 		add_files("../../third_party/compiler-rt/fp_mode.c")
+		add_defines("__SOFTFP__")
 end
 
 function softfloat_op_library(op)


### PR DESCRIPTION
This both gets us better expansions, and is more compatible for the f64-in-cap-registers change.
