### PR TITLE
GitHub CI: Don't skip `all-tests`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,7 +121,7 @@ jobs:
       run: ./scripts/run_clang_tidy_format.sh /cheriot-tools/bin
 
   all-checks:
-    needs: [run-tests, check-format]
+    needs: [run-tests, sonata-sram-hello, check-format]
     runs-on: ubuntu-latest
     steps:
     - name: Dummy step

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,17 @@ jobs:
 
   all-checks:
     needs: [run-tests, sonata-sram-hello, check-format]
+    # Use a GH Action "object filter" to project the .results of each needs-ed
+    # job, yielding a list of outcomes.  We can then use `jq` to filter that
+    # list for results other than "success" and check that that is the empty
+    # list.  `jq` will return 0, causing this job to succeed, if there are no
+    # non-"success" results, or 1, causing this job to fail, if there are.
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
-    - name: Dummy step
-      run: true
+    - name: Check that all needed jobs succeeded
+      shell: bash
+      env:
+        NEEDS_RESULTS: ${{ toJSON(needs.*.result) }}
+      run: |
+        jq -e '.|map(select(.!="success"))|(.==[])' <<<"${NEEDS_RESULTS}"


### PR DESCRIPTION
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks says

> When a job fails, any jobs that depend on the failed job are skipped and do not report a failure. A pull request that requires the check may not be blocked.

Which is _vexing_.  https://github.com/actions/runner/issues/2566 suggests there isn't a particularly great solution to this problem, so here's my stab at it: run `all-checks` `always()` and check that all `needs`-ed jobs have had `"success"` for their `.result`.  We can't do the requisite transforms in GH's action language, so push it over to `jq` via the shell.