### PR TITLE
Enable sub-object bounds for the core components.

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -280,7 +280,8 @@ namespace displacement_proxy
  *       - Collected in a treebin ring, using either/both the TChunk linkages
  *         or/and the MChunk::ring links present in body().
  */
-struct __packed __aligned(MallocAlignment) MChunkHeader
+struct __packed __aligned(MallocAlignment)
+__cheri_no_subobject_bounds MChunkHeader
 {
 	/**
 	 * Each chunk has a 16-bit metadata field that is used to store a small

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -541,9 +541,9 @@ __cheriot_minimum_stack(0xb0) int futex_timed_wait(Timeout        *timeout,
 	return 0;
 }
 
-__cheriot_minimum_stack(0xc0) int futex_wake(uint32_t *address, uint32_t count)
+__cheriot_minimum_stack(0xd0) int futex_wake(uint32_t *address, uint32_t count)
 {
-	STACK_CHECK(0xc0);
+	STACK_CHECK(0xd0);
 	// Futex wake requires you to have a valid pointer, but doesn't require any
 	// permissions.  This allows some things to trigger spurious wakes, but
 	// ensures that the scheduler never needs a writeable capability to a

--- a/sdk/include/cdefs.h
+++ b/sdk/include/cdefs.h
@@ -67,6 +67,7 @@ using _Bool = bool;
 	  "cheriot_minimum_stack attribute not supported, please update your compiler"
 #	define __cheriot_minimum_stack(x)
 #endif
+#define __cheri_no_subobject_bounds __attribute__((cheri_no_subobject_bounds))
 
 // When running clang-tidy, we use the same compile flags for everything and so
 // will get errors about things being defined in the wrong compartment, so

--- a/sdk/include/ds/linked_list.h
+++ b/sdk/include/ds/linked_list.h
@@ -467,7 +467,7 @@ namespace ds::linked_list
 		 * interface in terms of pointers).  CHERI bounds on the returned
 		 * pointers are inherited from the pointer to `this` cons cell.
 		 */
-		class PtrAddr
+		class __cheri_no_subobject_bounds PtrAddr
 		{
 			ptraddr_t prev, next;
 


### PR DESCRIPTION
This adds a `cheriot.subobject-bounds` rule in xmake that enables sub-object bounds and opts out two data structures that do not work with sub-object bounds.