### PR TITLE
scheduler: fix overflow in next timer value calculation.

### DIFF
--- a/sdk/core/scheduler/timer.h
+++ b/sdk/core/scheduler/timer.h
@@ -187,6 +187,7 @@ namespace
 		{
 			return -1;
 		}
-		return Timer::time() + (timeout * TIMERCYCLES_PER_TICK);
+		return Timer::time() +
+		       (static_cast<uint64_t>(timeout) * TIMERCYCLES_PER_TICK);
 	}
 } // namespace


### PR DESCRIPTION
There was a potential overflow of a 32-bit integer in the calculation of the next timer comparison value if a timeout for large-ish number of ticks was requested (corresponding to minutes, depending on the frequency of mtime).  This would have resulted in a shorter timeout than expected.  Fix this by casting to a 64-bit integer before multiplying.  Note that the scheduler already assumes that a 64-bit mtime counter will never overflow.