### PR TITLE
platforms: move IsUart concept to concepts/uart.hh

### DIFF
--- a/sdk/include/platform/concepts/uart.hh
+++ b/sdk/include/platform/concepts/uart.hh
@@ -1,0 +1,19 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <concepts>
+#include <stdint.h>
+
+/**
+ * Concept for checking that a UART driver exposes the right interface.
+ */
+template<typename T>
+concept IsUart = requires(volatile T *v, uint8_t byte) {
+	{ v->init() };
+	{ v->can_write() } -> std::same_as<bool>;
+	{ v->can_read() } -> std::same_as<bool>;
+	{ v->blocking_read() } -> std::same_as<uint8_t>;
+	{ v->blocking_write(byte) };
+};

--- a/sdk/include/platform/generic-riscv/platform-uart.hh
+++ b/sdk/include/platform/generic-riscv/platform-uart.hh
@@ -3,20 +3,8 @@
 
 #pragma once
 
-#include <concepts>
+#include <platform/concepts/uart.hh>
 #include <stdint.h>
-
-/**
- * Concept for checking that a UART driver exposes the right interface.
- */
-template<typename T>
-concept IsUart = requires(volatile T *v, uint8_t byte) {
-	{ v->init() };
-	{ v->can_write() } -> std::same_as<bool>;
-	{ v->can_read() } -> std::same_as<bool>;
-	{ v->blocking_read() } -> std::same_as<uint8_t>;
-	{ v->blocking_write(byte) };
-};
 
 /**
  * Generic 16550A memory-mapped register layout.

--- a/sdk/include/platform/sunburst/platform-uart.hh
+++ b/sdk/include/platform/sunburst/platform-uart.hh
@@ -1,13 +1,10 @@
 #pragma once
-#pragma push_macro("CHERIOT_PLATFORM_CUSTOM_UART")
-#define CHERIOT_PLATFORM_CUSTOM_UART
-#include_next <platform-uart.hh>
-#pragma pop_macro("CHERIOT_PLATFORM_CUSTOM_UART")
 
 #ifndef DEFAULT_UART_BAUD_RATE
 #	define DEFAULT_UART_BAUD_RATE 921'600
 #endif
 
+#include <platform/concepts/uart.hh>
 #include <utils.hh>
 
 /**


### PR DESCRIPTION
Since the sunburst UART is not a 16550, it can now avoid #include_next