### PR TITLE
Fix adding the bare-metal flags in xmake.

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -205,8 +205,10 @@ rule("cheriot.baremetal-abi")
 	on_load(function (target)
 		for _, flags in ipairs({"cxflags", "asflags"}) do
 			target:add(flags,
-				{ "-target", "riscv32cheriot-unknown-unknown",
-					"-mabi=cheriot-baremetal" },
+				{ "-target", "riscv32cheriot-unknown-unknown" },
+				{ expand = false, force = true })
+			target:add(flags,
+				{ "-mabi=cheriot-baremetal" },
 				{ expand = false, force = true })
 		end
 	end)


### PR DESCRIPTION
xmake does a *monumentally* stupid and dangerous thing of assuming that it knows what flags mean and which ones are safe to deduplicate.  It sees the second `-target` and removes it, leaving the triple as an argument that clang then interprets as a file name.

See xmake discussion 4762.