### PR TITLE
loader/boot.S tweaks

### DIFF
--- a/sdk/core/loader/boot.S
+++ b/sdk/core/loader/boot.S
@@ -9,73 +9,119 @@
 .include "assembly-helpers.s"
 
     .section .loader_start, "ax", @progbits
-    .globl start
-    .p2align 2
-    .type start,@function
-start:
-	// Most hardware will have zeroed all general-purposes registers at this
-	// point, but any code between here and the call into the scheduler has
-	// access to the root capabilities and so we are not concerned about
-	// information / capability leakage.
-#if __has_include(<platform-early_boot.inc>)
-#	include <platform-early_boot.inc>
+
+/*
+ * Platforms may wish to hook the boot code before we've said anything at all.
+ *
+ * The "interface" provided to this #include is that the effects of the above
+ * #include-s are in scope, as are the local symbols of this file, and that we
+ * have introduced the ".loader_start" linker .section, which is presumed not to
+ * have contents defined in any other file and is placed by the
+ * sdk/firmware.rocode.ldscript.in file immediately after the well-known
+ * "_start" symbol.
+ *
+ * This #include is therefore in a good position to insert very early
+ * instructions if necessary and/or to define other .sections related to the
+ * boot process.  It could even move this loader to a different .section.
+ */
+#if __has_include(<platform-early_boot_prestart.inc>)
+#       include <platform-early_boot_prestart.inc>
 #endif
 
+    .p2align 2
+    .type .Lstart,@function
+.Lstart:
+
+	/*
+	 * Any code between here and the call into the scheduler entry point (as
+	 * returned by the loader), including the loader itself, has access to the
+	 * root capabilities.
+	 */
+
+	// Load and keep the RW memory root in ca4 throughout
+	cspecialr		ca4, mtdc
+
+	// Build the RW root without GL(obal) in a5
+	li				a5, ~CHERI_PERM_GLOBAL
+	candperm		ca5, ca4, a5
+
+	// Prepare a C execution stack
 	la_abs			a3, bootStack
 	li				a1, BOOT_STACK_SIZE
-	cspecialr		ca4, mtdc // Keep the RW memory root in ca4 throughout
-	li				a2, ~CHERI_PERM_STORE_LOCAL
-	li				a5, ~CHERI_PERM_GLOBAL
-	// Keep G in ca2 and SL in ca5.
-	candperm		ca2, ca4, a2
-	candperm		ca5, ca4, a5
 	csetaddr		csp, ca5, a3
 	csetboundsexact	csp, csp, a1
 	cincoffset		csp, csp, a1 // Move to the end and grow downwards.
 
-	// Prepare a trusted stack for the loader.
-	la_abs			a3, bootTStack
-	li				a1, BOOT_TSTACK_SIZE
-	csetaddr		ca3, ca4, a3 // ca4 still has the RW (G+SL!) root
-	csetboundsexact	ca3, ca3, a1
-	li				a1, TSTACKOFFSET_FIRSTFRAME
-	csh				a1, TrustedStack_offset_frameoffset(ca3)
-	cspecialw		mtdc, ca3
+	/*
+	 * Platforms may wish to hook the boot code after we've gotten into "start".
+	 * This is the right place to fill in any essential architectural features
+	 * whose on-reset values are unspecified (likely to simplify gateware).
+	 *
+	 * This #include is expected to generate instructions, but of course other
+	 * fancy stunts are possible (such as defining .subsections of .loader_start
+	 * for new symbols).
+	 *
+	 * At this point, the following register allocations are in place and are
+	 * expected to be preserved by any code emitted by this #include:
+	 *
+	 *  - sp/x2 : holds the stack pointer with which the loader will run; this
+	 *            can be used as scratch space by the emitted code and need not
+	 *            be zeroed upon exit.
+	 *
+	 *  - a4/x14: holds the RW cap root.
+	 *
+	 *  - a5/x15: holds the RW cap root without GL(obal) permission.
+	 *
+	 * In particular, ra/x1, a0/x10, and a1/x11 are free and may be clobbered,
+	 * as platform code is quite likely to want to use .Lfill_block, below.
+	 */
+#if __has_include(<platform-early_boot.inc>)
+#	include <platform-early_boot.inc>
+#endif
 
-	// Prepare a bounded pointer to the header.
+	// Prepare a bounded, data RO, local pointer to the header.
 	la_abs			a1, __compart_headers
 	la_abs			a3, __compart_headers_end
 	sub				a3, a3, a1
-	csetaddr		ca1, ca2, a1 // ca2 still has the G root.
+	li				a2, ~(CHERI_PERM_STORE | \
+					      CHERI_PERM_LOAD_STORE_CAP | \
+					      CHERI_PERM_GLOBAL)
+	candperm		ca2, ca4, a2
+	csetaddr		ca1, ca2, a1
 	// FIXME: This should be a set bounds exact, but we currently don't have a
 	// 'pad to capability alignment' command in the linker script and it needs
 	// to span two sections.
 	csetbounds		ca1, ca1, a3
-	// Set up $cra to be the loader's C++ entry point.
-	// We are safe to clobber $cra here because this is the root function on
-	// the call stack.
-	// First set the lower bound on the loader's PCC:
-	auipcc			cra, 0
+
+	// We just want to grab the EXE root. Offset in auipcc matters not.
+	auipcc			ca2, 0
+
+	/*
+	 * Set up ra to be the loader's C++ entry point.
+	 *
+	 * We are safe to clobber ra here because this is the root function on
+	 * the call stack.
+	 */
+		// First set the lower bound on the loader's PCC:
 	clw				s0, IMAGE_HEADER_LOADER_CODE_START_OFFSET(ca1)
-	csetaddr		cra, cra, s0
-	// Set the size
+	csetaddr		cra, ca2, s0
+		// Set the size
 	clhu			s0, IMAGE_HEADER_LOADER_CODE_SIZE_OFFSET(ca1)
 	csetboundsexact	cra, cra, s0
-	// Set the C++ entry point of loader
+		// Set the C++ entry point of loader
 	la_abs			s0, loader_entry_point
 	csetaddr		cra, cra, s0
-	// Base and size of the GP of loader
-	// Old sails don't support unaligned loads, so we have to load the base as
-	// bytes
-	clbu			s0, IMAGE_HEADER_LOADER_DATA_START_OFFSET+3(ca1)
-	sll				s0, s0, 8
-	clbu			s1, IMAGE_HEADER_LOADER_DATA_START_OFFSET+2(ca1)
-	add				s0, s0, s1
-	sll				s0, s0, 8
-	clbu			s1, IMAGE_HEADER_LOADER_DATA_START_OFFSET+1(ca1)
-	add				s0, s0, s1
-	sll				s0, s0, 8
-	clbu			s1, IMAGE_HEADER_LOADER_DATA_START_OFFSET+0(ca1)
+
+	/*
+	 * Build the loader's globals pointer.  The base address and length are
+	 * specified in the header, and the permissions are *stack-flavored* (that
+	 * is, granting S(tore)L(ocal) and not GL(obal).
+	 *
+	 * Old sails don't support unaligned loads, so load the base as half-words.
+	 */
+	clhu			s0, IMAGE_HEADER_LOADER_DATA_START_OFFSET+2(ca1)
+	sll				s0, s0, 16
+	clhu			s1, IMAGE_HEADER_LOADER_DATA_START_OFFSET+0(ca1)
 	add				s0, s0, s1
 	clhu			s1, IMAGE_HEADER_LOADER_DATA_SIZE_OFFSET(ca1)
 	csetaddr		cgp, ca5, s0 // ca5 has the SL root.
@@ -83,78 +129,131 @@ start:
 	srli			s1, s1, 1
 	cincoffset		cgp, cgp, s1
 
-	// We just want to grab the EXE root. Offset in auipcc matters not.
-	auipcc			ca2, 0
-	cgetbase		t1, ca2
-	csetaddr		ca2, ca2, t1
-	// mscratchc still has the sealing root; take it and stash the RW root
-	cmove			ca3, ca4
-	cspecialrw		ca3, mscratchc, ca3
-	// ca4 still has the RW memory root; nothing to change
-	// The return value is SchedEntryInfo, the space for it is in ca0
-	// See the comment at the start of `loader_entry_point` in `boot.cc`.
+	/*
+	 * mscratchc still has the sealing root; take it and stash the RW root.
+	 * This is one instruction faster below than leaving the only copy in mtdc.
+	 */
+	cspecialrw		ca3, mscratchc, ca4
 
+	// ca4 still has the RW memory root; nothing to change
+
+	/*
+	 * The first argument (ca0) is a SchedEntryInfo out parameter.  Make space
+	 * for it at the base of the stack, where we can easily find it again after
+	 * the call returns.
+	 */
 	la_abs			s1, __thread_count
 	csetaddr		cs1, ca4, s1
 	clhu			s1, 0(cs1)
 	li			t0, -BOOT_THREADINFO_SZ
 	mul			s1, s1, t0
 	addi			s1, s1, -SchedulerEntryInfo_offset_threads
-
 	cincoffset		csp, csp, s1
 	neg			s1, s1
 	csetbounds		ca0, csp, s1
 
-	// Jump to loader_entry_point.
+	// Call to loader_entry_point.
 	cjalr			cra
 
-	// Load the two return values (pcc and cgp for the scheduler entry point)
+	/*
+	 * Load the two return values (pcc and cgp for the scheduler entry point).
+	 *
+	 * Drop these elements from the on-stack SchedulerEntryInfo, leaving only
+	 * its array of ThreadInfo-s (pointed to by sp).
+	 */
 	clc				cs0, 0(csp)
 	clc				cgp, 8(csp)
 	cincoffset		csp, csp, SchedulerEntryInfo_offset_threads
 
-	// Reset the stack pointer to point to the top and clear it
+	// Zero the stack (except for the aforementioned threadInfo-s).
 	cgetbase		a0, csp
 	csetaddr		ca0, csp, a0
 	cmove			ca1, csp
 	cjal			.Lfill_block
 	// Nothing in the loader stores to the stack after this point
 
-	// Zero the entire heap and clear roots.
-	cspecialr		ca0, mscratchc // RW root temporarily held here
+	/*
+	 * Clear most capability roots.
+	 *
+	 * - mtcc (aka mtvecc, mtvec) has been set by the loader_entry_point.
+	 * - mtdc is going to be set below.
+	 * - mscratchc holds a copy of mtdc, the RW (G+SL) root, which we briefly
+	 *   want again, so take it while writing zero
+	 * - mepcc is safe to zero
+	 */
+	zeroOne			a0
+	cspecialw		mepcc, ca0
+	cspecialrw		ca0, mscratchc, ca0
+
+	// Zero the entire heap
 	la_abs			a1, __export_mem_heap
 	csetaddr		ca0, ca0, a1
 	la_abs			a1, __export_mem_heap_end
 	cjal			.Lfill_block
-	// Clear the remaining roots.
-	// mtdc is serving its purpose since being set above, and mtcc
-	// has been set by the loader_entry_point.
-	zeroOne			a0
-	cspecialw		mepcc, ca0
-	cspecialw		mscratchc, ca0
 
-	// Move the scheduler's PCC into the register we'll jump to later.
+	/*
+	 * Prepare a trusted stack for the idle thread.  This structure is almost
+	 * entirely present to simplify the scheduler.  Unlike other trusted stacks
+	 * in the system, it does not make reference to a compartment export table.
+	 *
+	 * This clobbers mtdc's initial value of the RW root.
+	 */
+	la_abs			a3, bootTStack
+	li				a1, BOOT_TSTACK_SIZE
+	csetaddr		ca3, ca0, a3 // ca0 still has the RW (G+SL) root
+	csetboundsexact	ca3, ca3, a1
+	li				a1, TSTACKOFFSET_FIRSTFRAME
+	csh				a1, TrustedStack_offset_frameoffset(ca3)
+	cspecialw		mtdc, ca3
+
+	// Move the scheduler's (bounded) PCC into the register we'll jump to later.
 	cmove			cra, cs0
-	// c1 is cra (new PCC), c2 is csp, c3 is cgp.
-	// All other registers will be cleared in the clear-regs block
 
-	// Pass the array of threadInfos as first argument.
-	addi			s1, s1, -16
+	/*
+	 * Pass, as the first argument, the array of ThreadInfo-s from what was the
+	 * on-stack SchedulerEntryInfo.
+	 *
+	 * This clobbers a0's copy of the RW root; all roots are now gone.
+	 */
+	addi			s1, s1, -SchedulerEntryInfo_offset_threads
 	csetbounds		ca0, csp, s1
 
-	// a0 is used to pass arguments to the scheduler entry.
+	/*
+	 * The machine is now about to approximate the behavor of the idle thread
+	 * (mtdc, sp) making a compartment call into the scheduler compartment (ra
+	 * and gp) and in particular its initialization hook, scheduler_entry.
+	 * This is not a proper cross-call, especially in that neither the call nor
+	 * return will go via the switcher's cross-call path (or use the trusted
+	 * stack), because we are not a fully-fledged RTOS thread.
+	 *
+	 * Clear all other registers before invoking.  This ensures that the
+	 * scheduler does not, for example, get access to capability roots.
+	 */
 	zeroAllRegistersExcept	ra, sp, gp, a0
 	cjalr			cra
 
-	// Done scheduler setup. Now prepare an idle thread.
+	/*
+	 * Done scheduler setup.  Now prepare to be the idle thread.
+	 *
+	 * Drop our reference to the stack, as it is now exclusively property of the
+	 * scheduler, having been installed over in switcher/entry.S's
+	 * switcher_scheduler_entry_csp.
+	 */
 	zeroOne			sp
-	li				t1, (MIE_MEIE | MIE_MTIE)
+
 	// Enable external and timer interrupts.
+	li				t1, (MIE_MEIE | MIE_MTIE)
 	csrs			mie, t1
 	// Globally enable interrupts.
 	csrsi			mstatus, MSTATUS_MIE
-	// Yield to the scheduler to start real tasks.
+
+	/*
+	 * Yield to the scheduler to start real tasks, if a well-timed interrupt
+	 * hasn't already kicked off the machinery.  We are enough like a real RTOS
+	 * thread that we can do this just like stdlib.h's yield().
+	 */
 	ecall
+
 	// The idle thread sleeps and only waits for interrupts.
 .Lidle_loop:
 	wfi

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -1112,7 +1112,7 @@ namespace
 } // namespace
 
 // The parameters are passed by the boot assembly sequence.
-// XXX: arguments have capptr templates, 4 roots
+// XXX: root arguments might want better types
 extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
                                    const ImgHdr       &imgHdr,
                                    void               *almightyPCC,
@@ -1249,9 +1249,6 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 		  auto key =
 		    CHERI::Capability{build<void, Root::Type::Seal>(lower, length)};
 		  key.permissions() &= permissions;
-		  // FIXME: Some compartments need only permit-unseal (e.g. the
-		  // compartment switcher).  Drop permit-seal and keep only
-		  // permit-unseal once these are separated.
 		  Debug::log("Sealing key: {}", key);
 		  *location = key;
 		  return key;

--- a/sdk/include/platform/sunburst/platform-early_boot.inc
+++ b/sdk/include/platform/sunburst/platform-early_boot.inc
@@ -1,7 +1,11 @@
-	// The shadow memory may not be zeroed, ensure it is before we start or
-	// random capability loads will fail.
+	/*
+	 * The shadow memory may not be zeroed; ensure it is before we start or
+	 * random capability loads will fail.
+	 *
+	 * boot.S will have ensured that ca4 holds the RW root cap at this point,
+	 * and provides the .Lfill_block symbol.
+	 */
 	la_abs     a0, __export_mem_shadow
-	cspecialr  ca4, mtdc
 	csetaddr   ca0, ca4, a0
 	la_abs     a1, __export_mem_shadow_end
 	cjal       .Lfill_block


### PR DESCRIPTION
- Add platform-early_boot_prestart.inc hook

- Move platform-early_boot.inc hook after some common code (and update the one use of this hook in the tree).

  Add more documentation for the expected behavior of this hook.

- Tweak the permissions on the image header pointer we hand to the loader as a bit of documenting intent.

- Stop loading a misaligned long by bytes when we can load it by half-words instead

- Micro-optimize a few instructions away

- Move some code around and add more commentary