### PR TITLE
Add heap_free_all to the allocator fuzz tests.

### DIFF
--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -441,7 +441,7 @@ namespace
 			{
 				for (auto eachAllocation : allocations)
 				{
-					heap_free(quota, eachAllocation);
+					TEST_SUCCESS(heap_free(quota, eachAllocation));
 				}
 				allocations.clear();
 			}
@@ -485,7 +485,7 @@ namespace
 
 			cachedFrees[rand.next() % NCachedFrees] = p;
 
-			heap_free(heap.quota, p);
+			TEST_SUCCESS(heap_free(heap.quota, p));
 		};
 
 		auto doFreeAll = [&](HeapTestState &heap) {


### PR DESCRIPTION
This PR comes as a result of some discussion with regards to #599. 

It was mentioned that fuzzing for `heap_free_all` would be a helpful addition, and so this PR addresses that. Since we can't invoke `heap_free_all` on the default allocator capability (without messing up allocations we're using to test), I took this as an opportunity to add a layer of abstraction to allow for fuzzing multiple heap quotas. This also serves as preparation for testing sub-quotas (#140) when we want to pursue that.