### PR TITLE
Add initial support for user permissions on sealed objects.

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -1179,8 +1179,13 @@ namespace
 		  reinterpret_cast<TokenObjectType *>(headerThenPayload.get())};
 		payloadAfterHeader.address() += sizeof(TokenObjectHeader);
 
-		// Sealed points at payload but can access header, at negative offset
-		auto sealed = payloadAfterHeader.seal(allocatorSealingKey);
+		// Sealed points at payload but can access header, at negative offset.
+		auto sealed = [=]() {
+			auto res{payloadAfterHeader};
+			// Set all of the user permissions
+			res.address() += 7;
+			return res.seal(allocatorSealingKey);
+		}();
 
 		// Unsealed points at payload and can access only payload
 		TokenHandle<false> payload{payloadAfterHeader.get()};

--- a/sdk/core/token_library/token_unseal.S
+++ b/sdk/core/token_library/token_unseal.S
@@ -78,6 +78,10 @@ __sealingkey_dynamic:
 
   /* Unseal, clobbering authority */
   cunseal ca2, ca1, ca2
+  // Clear the low 3 bits.
+  cgetaddr a1, ca2
+  andi     a1, a1, ~0x7
+  csetaddr ca2, ca2, a1
 
   /* Verify tag of unsealed form */
   cgettag a3, ca2
@@ -169,6 +173,43 @@ _Z24token_obj_unseal_dynamicP12TokenKeyTypeU19__sealed_capabilityPv:
 	LoadCapPCC ca2, __sealingkey_dynamic
 	j          .Ltoken_unseal_internal
 
+/**
+ * An in-assembler implementation of
+ *
+ * void *__cheri_libcall
+ * token_permissions_and(struct TokenKeyType *, int);
+ *
+ * The name has been manually mangled as per the C++ rules.
+ */
+	.hidden  _Z21token_permissions_andU19__sealed_capabilityPvi
+	.globl   _Z21token_permissions_andU19__sealed_capabilityPvi
+_Z21token_permissions_andU19__sealed_capabilityPvi:
+	// Clear all bits that aren't valid permission bits in the mask.
+	andi       a1, a1, 7
+	// Set all bits in the address part of the mask.  This is now a mask that
+	// we can apply to the address to preserve the address and clear some
+	// permissions.
+	ori        a1, a1, 0xfffffff8
+	// Get the sealing key and set its address for the reseal operation
+	// This may result in a sealing key that is invalid, but that's fine: the
+	// unseal and seal will just give invalid capabilities.
+	LoadCapPCC ca2, __sealingkey_either
+	cgettype   a3, ca0
+	csetaddr   ca2, ca2, a3
+	// Unseal a0 into a0
+	cunseal    ca0, ca0, ca2
+	// Apply the mask to the address
+	cgetaddr   a3, ca0
+	and        a3, a3, a1
+	csetaddr   ca0, ca0, a3
+	// Reseal the result
+	cseal      ca0, ca0, ca2
+	// Clear the sealing key
+	zeroOne    a2
+	// Return, the resealed value is now in ca0.
+	cret
+
+
 /* TODO: Eventually this goes away, when the assembler can generate it for us */
 CHERIOT_EXPORT_LIBCALL \
   _Z16token_obj_unsealP12TokenKeyTypeP15TokenObjectType, \
@@ -203,3 +244,8 @@ CHERIOT_EXPORT_LIBCALL \
   _Z24token_obj_unseal_dynamicP12TokenKeyTypeU19__sealed_capabilityPv, \
   0 /* No stack usage */, \
   0b00010010 /* IRQs deferred, two argument registers */
+
+CHERIOT_EXPORT_LIBCALL \
+  _Z21token_permissions_andU19__sealed_capabilityPvi, \
+  0 /* No stack usage */, \
+  0b00000000 /* Interrupts enabled */

--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -220,7 +220,8 @@
 	 * original type.  This will be removed once the compiler understands      \
 	 * static sealed objects natively. */                                      \
 	extern valueType __sealed_type_placeholder_##name;                         \
-	extern __if_cxx("C") struct __##name##_type                                \
+	_Alignas(_Alignof(type) < 8 ? 8 : _Alignof(type)) extern __if_cxx(         \
+	  "C") struct __##name##_type                                              \
 	{                                                                          \
 		uint32_t key;                                                          \
 		uint32_t padding;                                                      \
@@ -260,7 +261,9 @@
 	extern __if_cxx("C") int __sealing_key_##compartment##_##keyName __asm(    \
 	  "__export.sealing_type." #compartment "." #keyName);                     \
 	__attribute__((section(".sealed_objects"), used)) __if_cxx(                \
-	  inline) struct __##name##_type                                           \
+	  inline) _Alignas(_Alignof(type) < 8                                      \
+	                     ? 8                                                   \
+	                     : _Alignof(type)) struct __##name##_type              \
 	  name = /* NOLINT(bugprone-macro-parentheses) */                          \
 	  {(uint32_t)&__sealing_key_##compartment##_##keyName,                     \
 	   0,                                                                      \

--- a/sdk/include/token.h
+++ b/sdk/include/token.h
@@ -117,6 +117,33 @@ __cheri_compartment("allocator")
   __cheri_libcall token_obj_unseal_dynamic(TokenKey, CHERI_SEALED(void *));
 
 /**
+ * Mask the user permissions of a sealed object. The first argument is the
+ * sealed capability, the second is a permission mask to apply.
+ */
+#ifndef __cplusplus
+CHERI_SEALED(void *)
+__cheri_libcall token_permissions_and(CHERI_SEALED(void *), int);
+#else
+extern "C++" template<typename T>
+CHERI_SEALED(T *)
+token_permissions_and(CHERI_SEALED(T *) object, int permissions)
+{
+	CHERI_SEALED(void *)
+	__cheri_libcall token_permissions_and(CHERI_SEALED(void *), int);
+	return static_cast<CHERI_SEALED(T *)>(
+	  token_permissions_and(object, permissions));
+}
+#endif
+
+/**
+ * Returns the user permissions bitmap for the sealed object.
+ */
+static inline int token_permissions_get(CHERI_SEALED(void *) object)
+{
+	return __builtin_cheri_address_get(object) & 0x7;
+}
+
+/**
  * Destroy the object given its key, freeing memory.
  *
  * The key must have the permit-unseal permission.

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -899,7 +899,7 @@ namespace
 		       (sealedPointer.base() + sizeof(TokenObjectHeader)),
 		     "Sealed handle {} has implausible offset",
 		     sealedPointer);
-		TEST(sealedPointer.address() ==
+		TEST((sealedPointer.address() & ~7) ==
 		       Capability{unsealedCapability}.address(),
 		     "Sealed handle {} does not point at payload {}",
 		     sealedPointer,
@@ -911,6 +911,8 @@ namespace
 		     "expected one ({} != {})",
 		     unsealedLarge,
 		     unsealedCapability);
+		// Make sure that removing a permission doesn't break deallocation
+		sealedPointer = token_permissions_and(sealedPointer.get(), 5);
 		int destroyed = token_obj_destroy(
 		  MALLOC_CAPABILITY, sealingCapability, sealedPointer);
 		TEST(destroyed == 0, "Failed to destroy large sealed capability");

--- a/tests/static_sealing_inner.cc
+++ b/tests/static_sealing_inner.cc
@@ -33,6 +33,19 @@ int test_static_sealed_object(Sealed<TestType> obj)
 	// Make sure that it's a single sealing type
 	TEST(keyCap.bounds() == 1, "Invalid bounds on {}", key);
 
+	debug_log("Permissions? {}", token_permissions_get(obj));
+	debug_log("Object? {}", obj.get());
+	TEST(token_permissions_get(obj) == 7,
+	     "Static sealed object is missing permissions: {} (should be 7)",
+	     token_permissions_get(obj));
+
+	obj = token_permissions_and(obj.get(), 5);
+	debug_log("Permissions? {}", token_permissions_get(obj));
+	debug_log("Object? {}", obj.get());
+	TEST(token_permissions_get(obj) == 5,
+	     "Static sealed object is missing permissions: {} (should be 5)",
+	     token_permissions_get(obj));
+
 	// Try to use it
 	Capability unsealed = token_unseal(key, obj);
 	debug_log("Unsealed object: {}", unsealed);


### PR DESCRIPTION
All sealed object handles have all three user permissions set when they are created.  They currently can have all three bits set.