### PR TITLE
Use user permissions on message queues.

### DIFF
--- a/examples/06.producer-consumer/producer.cc
+++ b/examples/06.producer-consumer/producer.cc
@@ -23,9 +23,11 @@ int __cheri_compartment("producer") run()
 	Debug::Invariant(result == 0,
 	                 "Compartment call to queue_create_sealed failed: {}",
 	                 result);
-	// Pass the queue handle to the consumer.
-	Debug::Invariant(set_queue(queue) == 0,
-	                 "Compartment call to set_queue failed");
+	// Pass the queue handle to the consumer.  The receiver has permission to
+	// receive only, not to send or deallocate.
+	Debug::Invariant(
+	  set_queue(queue_permissions_and(queue, MessageQueuePermitReceive)) == 0,
+	  "Compartment call to set_queue failed");
 	Debug::log("Starting producer loop");
 	// Loop, sending some numbers to the other thread.
 	for (int i = 1; i < 200; i++)

--- a/sdk/lib/queue/queue.cc
+++ b/sdk/lib/queue/queue.cc
@@ -372,6 +372,17 @@ namespace
 
 } // namespace
 
+int queue_stop(struct MessageQueue *handle)
+{
+	HighBitFlagLock producerLock{handle->producer};
+	producerLock.upgrade_for_destruction();
+
+	HighBitFlagLock consumerLock{handle->consumer};
+	consumerLock.upgrade_for_destruction();
+
+	return 0;
+}
+
 int queue_destroy(AllocatorCapability  heapCapability,
                   struct MessageQueue *handle)
 {
@@ -385,11 +396,7 @@ int queue_destroy(AllocatorCapability  heapCapability,
 		return ret;
 	}
 
-	HighBitFlagLock producerLock{handle->producer};
-	producerLock.upgrade_for_destruction();
-
-	HighBitFlagLock consumerLock{handle->consumer};
-	consumerLock.upgrade_for_destruction();
+	queue_stop(handle);
 
 	// This should not fail because of the `heap_can_free` check, unless we
 	// run out of stack.


### PR DESCRIPTION
This deprecates the old APIs for restricted endpoints, which added an indirection layer.  Now, sealed queue endpoint handles are capabilities with permissions for send, receive, and deallocated.