### PR TITLE
Add tests and fixes for heap_free edge cases

### DIFF
--- a/sdk/include/token.h
+++ b/sdk/include/token.h
@@ -157,7 +157,7 @@ int __cheri_compartment("allocator")
                     CHERI_SEALED(void *));
 
 /**
- * Check whether the pair of a sealing key and a heap capability can unseal a
+ * Check whether the pair of a sealing key and a heap capability can free a
  * sealed object.
  *
  * Returns 0 on success, `-EINVAL` if the key or object is not valid, or one of


### PR DESCRIPTION
  heap_free and heap_claim: test, document and fix some edge cases.
  
  1) Use the capability base to look up the chunk to heap_free instead
  of the address. This guarantees the address is within the bounds of
  the original allocation, unlike the address. Same goes for heap_claim.
  
  2) Test that an attempt to free with a 'one-past-the-end' zero length
  capability fails.
  
  3) Test that an attempt to free fails if the bounds are not the full
  allocation.
  
  4) Test that it's OK to free a pointer to the interior of an
  allocation if it still has the full bounds.
  
  5) Don't allow claim or free of sealed capabilities: there's no reason
  to claim a sealed capability and for free the correct API is to use
  token_obj_destroy with the correct sealing key. Add the necessary
  checks and tests for this. Note that freeing fails for a different reason when
  using the unsealed handle to a sealed token: the unsealed handle does
  not encompass the whole allocation (including header) so the free
  fails with a different error code. Note that taking a claim to a
  suballocation and subsequently releasing it using heap_free is allowed.
