### PR TITLE
futex: accept volatile pointers

### DIFF
--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -454,10 +454,11 @@ __cheriot_minimum_stack(0x90) int __cheri_compartment("scheduler")
 	return 0;
 }
 
-__cheriot_minimum_stack(0xb0) int futex_timed_wait(Timeout        *timeout,
-                                                   const uint32_t *address,
-                                                   uint32_t        expected,
-                                                   uint32_t        flags)
+__cheriot_minimum_stack(0xb0) int futex_timed_wait(
+  Timeout                 *timeout,
+  const volatile uint32_t *address,
+  uint32_t                 expected,
+  uint32_t                 flags)
 {
 	STACK_CHECK(0xb0);
 	if (!check_timeout_pointer(timeout) ||
@@ -541,7 +542,8 @@ __cheriot_minimum_stack(0xb0) int futex_timed_wait(Timeout        *timeout,
 	return 0;
 }
 
-__cheriot_minimum_stack(0xd0) int futex_wake(uint32_t *address, uint32_t count)
+__cheriot_minimum_stack(0xd0) int futex_wake(const volatile uint32_t *address,
+                                             uint32_t                 count)
 {
 	STACK_CHECK(0xd0);
 	// Futex wake requires you to have a valid pointer, but doesn't require any

--- a/sdk/include/cheri.h
+++ b/sdk/include/cheri.h
@@ -373,10 +373,10 @@ enum CHERISealingType
  * To reduce code size, this function is provided as part of the compartment
  * helper library.
  */
-bool __cheri_libcall check_pointer(const void *ptr,
-                                   size_t      space,
-                                   uint32_t    rawPermissions,
-                                   bool        checkStackNeeded);
+bool __cheri_libcall check_pointer(const volatile void *ptr,
+                                   size_t               space,
+                                   uint32_t             rawPermissions,
+                                   bool                 checkStackNeeded);
 
 /**
  * Check that the argument is a valid pointer to a `Timeout` structure.  This

--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -492,7 +492,7 @@ namespace CHERI
 		/**
 		 * Constructs a PermissionSet with the permissions of the given pointer.
 		 */
-		static PermissionSet permission_set_from_pointer(const void *p)
+		static PermissionSet permission_set_from_pointer(const volatile void *p)
 		{
 			auto perms = __builtin_cheri_perms_get(p);
 			auto mask  = PermissionSet::valid_permissions_mask();

--- a/sdk/include/futex.h
+++ b/sdk/include/futex.h
@@ -42,10 +42,10 @@ enum [[clang::flag_enum]] FutexWaitFlags
  *  - `-ETIMEOUT` if the timeout expires.
  */
 [[cheriot::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
-  futex_timed_wait(Timeout        *ticks,
-                   const uint32_t *address,
-                   uint32_t        expected,
-                   uint32_t flags  __if_cxx(= FutexNone));
+  futex_timed_wait(Timeout                 *ticks,
+                   const volatile uint32_t *address,
+                   uint32_t                 expected,
+                   uint32_t flags           __if_cxx(= FutexNone));
 
 /**
  * Compare the value at `address` to `expected` and, if they match, sleep the
@@ -56,8 +56,8 @@ enum [[clang::flag_enum]] FutexWaitFlags
  *
  * This returns 0 on success or `-EINVAL` if the arguments are invalid.
  */
-__always_inline static int futex_wait(const uint32_t *address,
-                                      uint32_t        expected)
+__always_inline static int futex_wait(const volatile uint32_t *address,
+                                      uint32_t                 expected)
 {
 	Timeout t = {0, UnlimitedTimeout};
 	return futex_timed_wait(&t, address, expected, FutexNone);
@@ -80,4 +80,4 @@ __always_inline static int futex_wait(const uint32_t *address,
  * woken.  `-EINVAL` is returned for invalid arguments.
  */
 [[cheriot::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
-  futex_wake(uint32_t *address, uint32_t count);
+  futex_wake(const volatile uint32_t *address, uint32_t count);

--- a/sdk/lib/compartment_helpers/check_pointer.cc
+++ b/sdk/lib/compartment_helpers/check_pointer.cc
@@ -7,14 +7,14 @@ using namespace CHERI;
  *
  * See `cheri.hh` for more information.
  */
-bool check_pointer(const void *ptr,
-                   size_t      space,
-                   uint32_t    rawPermissions,
-                   bool        checkStackNeeded)
+bool check_pointer(const volatile void *ptr,
+                   size_t               space,
+                   uint32_t             rawPermissions,
+                   bool                 checkStackNeeded)
 {
-	auto permissions = PermissionSet::from_raw(rawPermissions);
-	Capability<const void> cap{ptr};
-	bool                   isValid = cap.is_valid() && !cap.is_sealed();
+	auto       permissions = PermissionSet::from_raw(rawPermissions);
+	Capability cap{ptr};
+	bool       isValid = cap.is_valid() && !cap.is_sealed();
 	// Skip the stack check if we're requiring a global capability.  By
 	// construction, such a thing cannot be derived from the stack
 	// pointer.


### PR DESCRIPTION
This isn't required but makes the API more flexible. This needs to be propagated in a few other places such as check_pointer and permission_set_from_pointer.