### PR TITLE
Stop suppressing symbol exports in the final firmware image.

### DIFF
--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -28,10 +28,3 @@ SECTIONS
 	INCLUDE @firmware_high_ldscript@
 	.loadhigh_post_stub : ALIGN(4) { }
 }
-
-# No symbols should be exported
-VERSION {
-	VERSION_1 {
-		local: *;
-	};
-};


### PR DESCRIPTION
This is required to match the canonical audit reports.
