### PR TITLE
Change set_optimize value from Oz to smaller to remove warning.

### DIFF
--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -138,7 +138,7 @@ testCheckOption("model-output")
 
 -- Force -Oz irrespective of build config.  At -O0, we blow out our stack and
 -- require much stronger alignment.
-set_optimize("Oz")
+set_optimize("smallest")
 
 --Capture the directory containing this script for later use.  We need this to
 --find the location of the linker scripts and so on.


### PR DESCRIPTION
When compiling I get the following warning 
_unknown optimize value 'Oz', it may be 'fast'_

Oz should map to smallest, not fast, so _Oz_ was changed to _smallest_.

Test with `xmake -rvD` to ensure -Oz is selected.