### PR TITLE
Allow large stacks.

### DIFF
--- a/sdk/core/switcher/entry.S
+++ b/sdk/core/switcher/entry.S
@@ -451,13 +451,18 @@ __Z26compartment_switcher_entryz:
 	cgetbase           s1, csp
 	csetaddr           csp, csp, s1
 	sub                s1, s0, s1
-	csetboundsexact    ct2, csp, s1
+	csetboundsrounddown ct2, csp, s1
+	cgettop            s0, ct2
+	// Round down the top address to make sure it is still 16-byte aligned.
+	// This is *probably* not needed, but we need to do a proof on the
+	// csetboundsrounddown behaviour before removing this.  If it is removed,
+	// please link to the proof and leave the following line commented out.
+	andi               s0, s0, 0xfffffff0
 	csetaddr           csp, ct2, s0
 	/*
 	 * Atlas:
-	 *  s0: address of stack boundary between caller and callee frames, that is,
-	 *      the lowest address of the register spill from
-	 *      .Lswitch_entry_first_spill)
+	 *  s0: address of stack boundary between caller and callee frames,
+	 *      possibly rounded down to preserve alignment.
 	 *  sp: pointer to stack, with its limit and address set to the address in
 	 *      s0.  The base and permissions have not been altered from sp at
 	 *      entry, and the tag remains set since all manipulations have been

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -834,9 +834,11 @@ rule("cheriot.firmware")
 				"\n\t\tSHORT(.thread_${thread_id}_trusted_stack_end - .thread_${thread_id}_trusted_stack_start);" ..
 				"\n\n"
 
-		-- Stacks must be less than this size or truncating them in compartment
-		-- switch may encounter precision errors.
-		local stack_size_limit = 8176
+		-- Stacks must be less than this size or we cannot express them in the
+		-- loader metadata.  The checks in lld for valid stacks currently
+		-- reject anything larger than this, so provide a helpful error here,
+		-- rather than an unhelpful one later.
+		local stack_size_limit = 65280
 
 		-- Initial pass through thread sequence to derive values within each
 		local thread_priorities_set = {}


### PR DESCRIPTION
This requires a CHERIoT-Platform/llvm-project#289 to work (without that, the stacks are insufficiently aligned and the loader refuses to load them).

With this, you can have stacks up to 64 KiB.  Tested with the PQC code with a 60 KiB stack.  More than 64 KiB would require a small loader change to not use the 16-bit size (and an associated linker change to not refuse to link things with larger stacks).

The loader changes need careful review.  I believe I have checked the important things, specifically:

 - Stacks are restored using the old (pre-adjustment) stack pointer.
 - Spills happen before the stack pointer is moved down.
 - The callee stack check happens with the size of the rounded-down stack.

All of these should be confirmed in review.