### PR TITLE
Add a compartment that populates a buffer with entropy.

### DIFF
--- a/sdk/include/platform/arty-a7/platform-entropy.hh
+++ b/sdk/include/platform/arty-a7/platform-entropy.hh
@@ -1,9 +1,6 @@
 #pragma once
-#include <compartment-macros.h>
-#include <ds/xoroshiro.h>
 #include <interrupt.h>
 #include <platform/concepts/entropy.h>
-#include <riscvreg.h>
 
 DECLARE_AND_DEFINE_INTERRUPT_CAPABILITY(revokerInterruptEntropy,
                                         InterruptName::EthernetReceiveInterrupt,
@@ -17,16 +14,8 @@ DECLARE_AND_DEFINE_INTERRUPT_CAPABILITY(revokerInterruptEntropy,
  * nothing on the Arty A7 instantiation of CHERIoT SAFE that can be used as a
  * secure entropy source.
  */
-class EntropySource
+struct EntropySource : public TrivialInsecureEntropySource
 {
-	ds::xoroshiro::P128R64 prng;
-
-	public:
-	using ValueType = uint64_t;
-
-	/// Definitely not secure!
-	static constexpr bool IsSecure = false;
-
 	/// Constructor, tries to generate an independent sequence of random numbers
 	EntropySource()
 	{
@@ -36,28 +25,9 @@ class EntropySource
 	/// Reseed the PRNG
 	void reseed()
 	{
-		// Start from a not very random seed
-		uint64_t seed = rdcycle64();
-		prng.set_state(seed, seed >> 24);
 		uint32_t interrupts =
 		  *interrupt_futex_get(STATIC_SEALED_VALUE(revokerInterruptEntropy));
-		// Permute it with another not-very-random number
-		for (uint32_t i = 0; i < ((interrupts & 0xff00) >> 8); i++)
-		{
-			prng.long_jump();
-		}
-		for (uint32_t i = 0; i < (interrupts & 0xff); i++)
-		{
-			prng.jump();
-		}
-		// At this point, our random number is in a fairly predictable state,
-		// but with a fairly low probability of being the same predictable
-		// state as before.
-	}
-
-	ValueType operator()()
-	{
-		return prng();
+		TrivialInsecureEntropySource::reseed(interrupts);
 	}
 };
 

--- a/sdk/include/platform/concepts/entropy.h
+++ b/sdk/include/platform/concepts/entropy.h
@@ -2,6 +2,7 @@
 #include <array>
 #include <concepts>
 #include <cstdint>
+#include <ds/xoroshiro.h>
 
 /**
  * Concept for an Entropy source.
@@ -28,4 +29,65 @@ concept IsEntropySource = requires(T source) {
 	 * of this.
 	 */
 	{ source.reseed() };
+};
+
+/**
+ * A simple entropy source.  This wraps a few weak entropy sources to seed a
+ * PRNG.  It is absolutely not secure and should not be used for anything that
+ * depends on cryptographically secure random numbers!  Unfortunately, there is
+ * nothing on the Sonata instantiation of CHERIoT SAFE that can be used as a
+ * secure entropy source.
+ *
+ * This is provided as a generic implementation that can be used with an
+ * interrupt source to provide a slightly better version for testing on FPGA
+ * and simulation environments that don't have anything secure.
+ */
+class TrivialInsecureEntropySource
+{
+	ds::xoroshiro::P128R64 prng;
+
+	protected:
+	/// Reseed the PRNG with a provided set of jumps.
+	void reseed(uint16_t jumps)
+	{
+		// Start from a not very random seed
+		uint64_t seed = rdcycle64();
+		prng.set_state(seed, seed >> 24);
+		// Permute it with another not-very-random number
+		for (uint32_t i = 0; i < ((jumps & 0xff00) >> 8); i++)
+		{
+			prng.long_jump();
+		}
+		for (uint32_t i = 0; i < (jumps & 0xff); i++)
+		{
+			prng.jump();
+		}
+		// At this point, our random number is in a fairly predictable state,
+		// but with a fairly low probability of being the same predictable
+		// state as before.
+	}
+
+	public:
+	using ValueType = uint64_t;
+
+	/// Definitely not secure!
+	static constexpr bool IsSecure = false;
+
+	/// Constructor, tries to generate an independent sequence of random numbers
+	TrivialInsecureEntropySource()
+	{
+		reseed();
+	}
+
+	/// Reseed the PRNG.
+	void reseed()
+	{
+		reseed(rdcycle64());
+	}
+
+	/// Get the next value from the PRNG.
+	ValueType operator()()
+	{
+		return prng();
+	}
 };

--- a/sdk/include/platform/generic-riscv/platform-entropy.hh
+++ b/sdk/include/platform/generic-riscv/platform-entropy.hh
@@ -1,0 +1,7 @@
+#pragma once
+#include <platform/concepts/entropy.h>
+
+using EntropySource = TrivialInsecureEntropySource;
+
+static_assert(IsEntropySource<EntropySource>,
+              "EntropySource must be an entropy source");

--- a/sdk/include/randombytes.h
+++ b/sdk/include/randombytes.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cdefs.h>
+#include <stddef.h>
+#include <stdint.h>
+
+__BEGIN_DECLS
+
+/**
+ * Populate `output` with `n` bytes of entropy from the system's entropy source.
+ *
+ * This will be cryptographically secure entropy if and only if the system
+ * entropy source is cryptographically secure.
+ *
+ * Returns 0 on success.
+ */
+__cheriot_compartment("randombytes") int randombytes(uint8_t *output, size_t n);
+
+__END_DECLS

--- a/sdk/lib/randombytes/randombytes.cc
+++ b/sdk/lib/randombytes/randombytes.cc
@@ -1,0 +1,41 @@
+// Copyright CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <randombytes.h>
+
+#include <platform-entropy.hh>
+
+namespace
+{
+	auto entropy()
+	{
+		static EntropySource entropySource;
+		return entropySource();
+	}
+
+} // namespace
+
+int randombytes(uint8_t *output, size_t n)
+{
+	constexpr size_t         BytesPerCall = sizeof(EntropySource::ValueType);
+	EntropySource::ValueType value;
+	size_t                   bytesRemaining = 0;
+
+	auto next = [&]() {
+		if (bytesRemaining == 0)
+		{
+			bytesRemaining = BytesPerCall;
+			value          = entropy();
+		}
+		uint8_t nextByte = value;
+		value >>= 8;
+		bytesRemaining--;
+		return nextByte;
+	};
+
+	for (size_t i = 0; i < n; i++)
+	{
+		output[i] = next();
+	}
+	return 0;
+}

--- a/sdk/lib/randombytes/xmake.lua
+++ b/sdk/lib/randombytes/xmake.lua
@@ -1,0 +1,7 @@
+-- Copyright CHERIoT Contributors.
+-- SPDX-License-Identifier: MIT
+
+compartment("randombytes")
+	add_deps("cxxrt")
+	set_default(false)
+	add_files("randombytes.cc")

--- a/sdk/lib/xmake.lua
+++ b/sdk/lib/xmake.lua
@@ -19,6 +19,7 @@ includes(
 	"locks",
 	"microvium",
 	"queue",
+	"randombytes",
 	"softfloat",
 	"stdio",
 	"string",


### PR DESCRIPTION
This wraps the entropy driver.

At the same time, provide a generic entropy source that works everywhere and refactor the other insecure ones to use this rather than duplicating everything.