### PR TITLE
Correcting mis-spelling of -ETIMEDOUT. 

### DIFF
--- a/sdk/include/futex.h
+++ b/sdk/include/futex.h
@@ -39,7 +39,7 @@ enum [[clang::flag_enum]] FutexWaitFlags
  *  - 0 on success: either `*address` and `expected` differ or a wake is
  *    received.
  *  - `-EINVAL` if the arguments are invalid.
- *  - `-ETIMEOUT` if the timeout expires.
+ *  - `-ETIMEDOUT` if the timeout expires.
  */
 [[cheriot::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
   futex_timed_wait(Timeout                 *ticks,

--- a/sdk/include/multiwaiter.h
+++ b/sdk/include/multiwaiter.h
@@ -93,7 +93,7 @@ typedef CHERI_SEALED(struct MultiWaiterInternal *) MultiWaiter;
  *  - On success, this function returns `0`.
  *  - If the arguments are invalid, this function returns `-EINVAL`.
  *  - If the timeout is reached without any events being triggered then this
- *    returns `-ETIMEOUT`.
+ *    returns `-ETIMEDOUT`.
  */
 [[cheriot::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
   multiwaiter_wait(Timeout                  *timeout,

--- a/sdk/include/queue.h
+++ b/sdk/include/queue.h
@@ -147,7 +147,7 @@ int __cheri_libcall queue_destroy(AllocatorCapability  heapCapability,
  * to copy the number of bytes specified by `elementSize` when the queue was
  * created from `src`.
  *
- * Returns 0 on success.  On failure, returns `-ETIMEOUT` if the timeout was
+ * Returns 0 on success.  On failure, returns `-ETIMEDOUT` if the timeout was
  * exhausted, `-EINVAL` on invalid arguments.
  *
  * This expects to be called with a valid queue handle.  It does not validate
@@ -163,7 +163,7 @@ int __cheri_libcall queue_send(Timeout             *timeout,
  * when the queue was created from `src`.
  *
  * Returns the number of elements sent on success.  On failure, returns
- * `-ETIMEOUT` if the timeout was exhausted, `-EINVAL` on invalid arguments.
+ * `-ETIMEDOUT` if the timeout was exhausted, `-EINVAL` on invalid arguments.
  *
  * This expected to be called with a valid queue handle.  It does not validate
  * that this is correct.
@@ -179,7 +179,7 @@ int __cheri_libcall queue_send_multiple(Timeout             *timeout,
  * copied to `dst`, which must have sufficient permissions and space to hold
  * the message.
  *
- * Returns 0 on success, `-ETIMEOUT` if the timeout was exhausted, `-EINVAL` on
+ * Returns 0 on success, `-ETIMEDOUT` if the timeout was exhausted, `-EINVAL` on
  * invalid arguments.
  */
 int __cheri_libcall queue_receive(Timeout             *timeout,
@@ -192,7 +192,7 @@ int __cheri_libcall queue_receive(Timeout             *timeout,
  * `elementSize` when the queue was created to `dst`.
  *
  * Returns the number of elements sent on success.  On failure, returns
- * `-ETIMEOUT` if the timeout was exhausted, `-EINVAL` on invalid arguments.
+ * `-ETIMEDOUT` if the timeout was exhausted, `-EINVAL` on invalid arguments.
  *
  * This expected to be called with a valid queue handle.  It does not validate
  * that this is correct.


### PR DESCRIPTION
ETIMEDOUT was mis-spelled as ETIMEOUT in a few headers. This caught me out a couple of weeks back as I was reading the header file.