### PR TITLE
Add check to the loader for cap_relocs to privileged compartments

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -1050,17 +1050,17 @@ namespace
 
 			if constexpr (DebugLoader)
 			{
-				auto error = false;
+				auto hasSeenForbiddenCapRelocs = false;
 				for (auto &pC : image.privilegedCompartments)
 				{
 					if (contains(pC.code, reloc.addr) ||
 					    contains(pC.data, reloc.addr))
 					{
-						error = true;
+						hasSeenForbiddenCapRelocs = true;
 						Debug::log(
 						  "Capreloc with address {} should be applied to "
 						  "a privileged compartment with code region: {} "
-						  "- {} and data region: ",
+						  "- {} and data region: {} - {}",
 						  reloc.addr,
 						  pC.code.start(),
 						  pC.code.start() + pC.code.size(),
@@ -1069,10 +1069,9 @@ namespace
 					}
 				}
 
-				Debug::Invariant(!error,
+				Debug::Invariant(!hasSeenForbiddenCapRelocs,
 				                 "Encountered forbidden relocations to "
 				                 "privileged compartment(s)");
-				__builtin_unreachable();
 			}
 
 			// Find the compartment that this relocation applies to.


### PR DESCRIPTION
This PR adds a check to the loader to inform the user that cap_relocs to privileged compartments were found. These, by default, fail because the `.. image.libraries_and_compartments() ..` [here](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/main/sdk/core/loader/boot.cc#L1031) does _not_ iterate over privileged compartments.

For example, adding something like 
```
static auto foo = "hello";
const char** bar[] = {&foo};
...
<use bar>
...
```
to `allocator/main.cc` makes the loader hit [this assertion](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/main/sdk/core/loader/boot.cc#L1039).

For clarity, this patch *does not* allow such relocations, it just adds a more explicative message to the loader.
This check is executed only when `--debug-loader=y` is passed to `xmake config`, since all the code is gated under the definition and non-nullity of `DEBUG_LOADER`, which is set [here](https://github.com/CHERIoT-Platform/cheriot-rtos/blob/main/sdk/xmake.lua#L1168).