### PR TITLE
Fix missing return type in  `__atomic_load_cap` libcall declaration

### DIFF
--- a/sdk/lib/atomic/atomiccap.cc
+++ b/sdk/lib/atomic/atomiccap.cc
@@ -14,7 +14,7 @@ DECLARE_ATOMIC_LIBCALL(__atomic_compare_exchange_cap,
                        void *,
                        int,
                        int);
-DECLARE_ATOMIC_LIBCALL(__atomic_load_cap, void *const *, int)
+DECLARE_ATOMIC_LIBCALL(__atomic_load_cap, void *, void *const *, int)
 DECLARE_ATOMIC_LIBCALL(__atomic_store_cap, void, void **, void *, int)
 DECLARE_ATOMIC_LIBCALL(__atomic_exchange_cap, void *, void **, void *, int)
 


### PR DESCRIPTION
Fixes typo in libcall declaration, should match signature:

```
void *__atomic_load_cap(void *const *ptr, int)
```