### PR TITLE
loader: package as object for auditing

### DIFF
--- a/sdk/core/loader/boot.S
+++ b/sdk/core/loader/boot.S
@@ -155,7 +155,7 @@
 	la_abs			s1, __thread_count
 	csetaddr		cs1, ca4, s1
 	clhu			s1, 0(cs1)
-	li			t0, -BOOT_THREADINFO_SZ
+	li			t0, -ThreadLoaderInfo_size
 	mul			s1, s1, t0
 	cincoffset		csp, csp, s1
 	// ca1 now contains the bounded capability to the threads array

--- a/sdk/core/loader/boot.S
+++ b/sdk/core/loader/boot.S
@@ -104,21 +104,23 @@
 	// to span two sections.
 	csetbounds		ca1, ca1, a3
 
-	// We just want to grab the EXE root. Offset in auipcc matters not.
-	auipcc			ca2, 0
-
 	/*
 	 * Set up ra to be the loader's C++ entry point.
 	 *
 	 * We are safe to clobber ra here because this is the root function on
 	 * the call stack.
 	 */
-		// First set the lower bound on the loader's PCC:
-	la_abs			s0, .loader_code_start
-	csetaddr		cra, ca2, s0
+		/*
+		 * First set the lower bound on the loader's PCC.  While here, leave the
+		 * executable root in ca2 for later use as an argument to the loader
+		 * entrypoint itself.
+		 */
+1:
+	auipcc			ca2, %cheriot_compartment_hi(.code_ephemeral_start)
+	cincoffset		ca2, ca2, %cheriot_compartment_lo_i(1b)
 		// Set the size
-	la_abs			s0, .loader_code_size
-	csetboundsexact	cra, cra, s0
+	la_abs			s0, .code_ephemeral_size
+	csetboundsexact	cra, ca2, s0
 		// Set the C++ entry point of loader
 	la_abs			s0, loader_entry_point
 	csetaddr		cra, cra, s0
@@ -128,9 +130,9 @@
 	 * specified in the header, and the permissions are *stack-flavored* (that
 	 * is, granting S(tore)L(ocal) and not GL(obal).
 	 */
-	la_abs			s0, .loader_data_start
+	la_abs			s0, .data_ephemeral_start
 	csetaddr		cgp, ca5, s0 // ca5 has the SL root.
-	la_abs			s0, .loader_data_size
+	la_abs			s0, .data_ephemeral_size
 	csetboundsexact	cgp, cgp, s0
 	srli			s0, s0, 1
 	cincoffset		cgp, cgp, s0
@@ -304,12 +306,14 @@
 .size start, . - start
 
 	.section .loader_trusted_stack, "a", @progbits
+	.p2align 3
 	.type bootTStack, @object
 	.size bootTStack, BOOT_TSTACK_SIZE
 bootTStack:
 	.fill BOOT_TSTACK_SIZE
 
 	.section .loader_stack, "a", @progbits
+	.p2align 4
 	.type bootStack, @object
 	.size bootStack, BOOT_STACK_SIZE
 bootStack:

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -58,9 +58,6 @@ namespace
 	              offsetof(TrustedStack, cra));
 	__END_DECLS
 
-	static_assert(
-	  CheckSize<sizeof(ThreadLoaderInfo), BOOT_THREADINFO_SZ>::Value);
-
 	/**
 	 * Reserved sealing types.
 	 */

--- a/sdk/core/loader/constants.h
+++ b/sdk/core/loader/constants.h
@@ -44,7 +44,7 @@ EXPORT_ASSEMBLY_SIZE(SchedulerEntryInfo, 32);
 EXPORT_ASSEMBLY_EXPRESSION(MIE_MEIE, priv::MIE_MEIE, 0x800);
 EXPORT_ASSEMBLY_EXPRESSION(MIE_MTIE, priv::MIE_MTIE, 0x080);
 EXPORT_ASSEMBLY_EXPRESSION(MSTATUS_MIE, priv::MSTATUS_MIE, 8);
-
 EXPORT_ASSEMBLY_EXPRESSION(ThreadHeapHazards_size,
                            HazardPointersPerThread * sizeof(void *),
                            16);
+EXPORT_ASSEMBLY_SIZE(ThreadLoaderInfo, 16);

--- a/sdk/core/loader/defines.h
+++ b/sdk/core/loader/defines.h
@@ -11,5 +11,3 @@
  */
 #define BOOT_TSTACK_SIZE                                                       \
 	(TrustedStack_offset_frames + (2 * TrustedStackFrame_size))
-
-#define BOOT_THREADINFO_SZ 16

--- a/sdk/core/loader/loader.ldscript
+++ b/sdk/core/loader/loader.ldscript
@@ -1,0 +1,33 @@
+SECTIONS
+{
+
+.code_persistent : CAPALIGN
+{
+    KEEP(*/boot.S.o(.loader_start .loader_start.*));
+}
+
+.trusted_stack : ALIGN(16)
+{
+    KEEP(*/boot.S.o(.loader_trusted_stack));
+}
+
+.stack : CAPALIGN
+{
+    KEEP(*/boot.S.o(.loader_stack));
+}
+
+.code_ephemeral : CAPALIGN
+{
+    HIDDEN(.code_ephemeral_start = .);
+    KEEP(*/boot.cc.o(.text .text.* .rodata SORT_BY_ALIGNMENT(.rodata.*)));
+}
+HIDDEN(.code_ephemeral_size = SIZEOF(.code_ephemeral));
+
+.data_ephemeral : CAPALIGN
+{
+    HIDDEN(.data_ephemeral_start = .);
+    KEEP(*/boot.cc.o(.data .data.* .sdata .sdata.* .sbss .sbss.* .bss .bss.*));
+}
+HIDDEN(.data_ephemeral_size = SIZEOF(.data_ephemeral));
+
+}

--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -19,4 +19,7 @@ SECTIONS
 	/DISCARD/ : {
     	*(.note.cheriot.compartment-name)
 	}
+
+	# Explicitly discard allocating sections from the loader not claimed elsewhere.
+	/DISCARD/ : { INPUT_SECTION_FLAGS (SHF_ALLOC) *.loader.o(*) }
 }

--- a/sdk/firmware.rocode.ldscript.in
+++ b/sdk/firmware.rocode.ldscript.in
@@ -1,8 +1,8 @@
 _start = .;
 
-.loader_start :
+.loader_code_persistent : CAPALIGN
 {
-    *(.loader_start);
+    */*.loader.o(.code_persistent);
 }
 
 .compartment_export_tables : ALIGN(8)

--- a/sdk/firmware.rwdata.ldscript.in
+++ b/sdk/firmware.rwdata.ldscript.in
@@ -5,14 +5,14 @@ __stack_space_start = .;
 
 .loader_trusted_stack : CAPALIGN
 {
-	*/loader/boot.S.o(.loader_trusted_stack);
+    */*.loader.o(.trusted_stack);
 }
 
 @thread_trusted_stacks@
 
 .loader_stack : ALIGN(16)
 {
-	*/loader/boot.S.o(.loader_stack);
+    */*.loader.o(.stack);
 }
 
 @thread_stacks@
@@ -208,20 +208,18 @@ __cap_relocs_end = .;
 }
 __compart_headers_size = __compart_headers_end - __compart_headers;
 
-# The loader code is placed in the data sections so that it can be used as heap after the loader runs
-.loader_code : CAPALIGN
+# These (code and data) need to be kept in separate sections, since the linker
+# resolves relocations as PCC- or CGP-relative based on the flags of the output
+# section containing the relocation symbol.
+.loader_ephemeral_code : CAPALIGN
 {
-    .loader_code_start = .;
-    */loader/boot.cc.o(.text .text.* .rodata .rodata.* .data.rel.ro);
+    */*.loader.o(.code_ephemeral);
 }
-.loader_code_size = SIZEOF(.loader_code);
 
-.loader_data : CAPALIGN
+.loader_ephemeral_data : CAPALIGN
 {
-    .loader_data_start = .;
-    */loader/boot.cc.o(.data .data.* .sdata .sdata.* .sbss .sbss.* .bss .bss.*);
+    */*.loader.o(.data_ephemeral);
 }
-.loader_data_size = SIZEOF(.loader_data);
 
 .library_export_tables : ALIGN(8)
 {

--- a/sdk/xmake.lua
+++ b/sdk/xmake.lua
@@ -962,7 +962,8 @@ rule ("cheriot.firmware.link")
 				return (dep:get("cheriot.type") == "library") or
 					(dep:get("cheriot.type") == "compartment") or
 					(dep:get("cheriot.type") == "privileged compartment") or
-					(dep:get("cheriot.type") == "privileged library")
+					(dep:get("cheriot.type") == "privileged library") or
+					(dep:get("cheriot.type") == "loader")
 			end)
 	end)
 
@@ -1462,13 +1463,21 @@ rule("cheriot.define-rtos-git-description")
 -- Common aspects of the CHERIoT loader target
 rule("cheriot.loader.base")
 	add_deps("cheriot.toolchain",
+	         "cheriot.reachability_check",
 	         "cheriot.component-debug",
 	         "cheriot.baremetal-abi",
 	         "cheriot.subobject-bounds")
 
 	on_load(function (target)
-		target:set("kind", "object")
 		target:set("default", false)
+
+		target:set("cheriot.type", "loader")
+
+		-- "binary"-kinded xmake targets get both compilation and linking phases
+		target:set("kind", "binary")
+
+		-- Use a target name ending in ".o" to convey our intent to the linker
+		target:set("extension", ".loader.o")
 
 		target:add("deps", "cheriot.board")
 
@@ -1480,6 +1489,14 @@ rule("cheriot.loader.base")
 
 		target:set("optimize", "fast")
 		target:set("languages", "c23", "cxx23")
+
+		-- When linking, generate a relocatable object and use the indicated
+		-- custom linker script (via xmake's built-in rule for such things,
+		-- fished out through its file-extension based lookup mechanism).
+		target:add("ldflags", "--relocatable", { force = true })
+		target:add("files",
+		           path.join(coredir, "loader/loader.ldscript"),
+		           { sourcekind = ".lds" })
 	end)
 
 	after_load(function (target)
@@ -1497,6 +1514,12 @@ target("cheriot.loader")
 	-- FIXME: We should be setting this based on a board config file.
 	add_files(path.join(coredir, "loader/boot.S"),
 	          path.join(coredir, "loader/boot.cc"))
+
+	-- For the baseline loader, remove any extraneous sections.  Other,
+	-- device- and/or situation-specific loaders may want to carry other
+	-- sections up to the final firmware image, so this isn't present up in the
+	-- "cheriot.loader.base" rule.
+	add_ldflags("--gc-sections")
 
 -- Helper function to define firmware.  Used as `target`.
 function firmware(name)


### PR DESCRIPTION
Arrange for there to be a single file for "the loader" rather than it just being an "object"-kind xmake target whose objects get used in dependent targets' link phases.  This makes it slightly easier to reason about and investigate "the loader" as a thing.