### PR TITLE
Fix thread_millisecond_wait and add thread_wait_until

### DIFF
--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -155,16 +155,15 @@ static inline uint64_t thread_millisecond_wait(uint32_t milliseconds)
 	return milliseconds;
 #else
 	static const uint32_t CyclesPerMillisecond = CPU_TIMER_HZ / 1'000;
-	static const uint32_t CyclesPerTick        = CPU_TIMER_HZ / TICK_RATE_HZ;
 	__if_cxx(
 	  static_assert(CyclesPerMillisecond > 0, "CPU_TIMER_HZ is too low"););
 	uint32_t cycles  = milliseconds * CyclesPerMillisecond;
 	uint64_t start   = rdcycle64();
 	uint64_t end     = start + cycles;
 	uint64_t current = start;
-	while ((end > current) && (end - current > MS_PER_TICK))
+	while ((end > current) && (end - current > TIMERCYCLES_PER_TICK))
 	{
-		Timeout t = {0, ((uint32_t)(end - current)) / CyclesPerTick};
+		Timeout t = {0, ((uint32_t)(end - current)) / TIMERCYCLES_PER_TICK};
 		(void)thread_sleep(&t, ThreadSleepNoEarlyWake);
 		current = rdcycle64();
 	}

--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -139,6 +139,35 @@ static inline uint64_t thread_microsecond_spin(uint32_t microseconds)
 }
 
 /**
+ * Wait until the cycle counter (as returned by rdcycle64()) reaches the given
+ * value.
+ *
+ * This will yield for periods that are longer than a scheduler tick and then
+ * spin for the remainder of the time.
+ *
+ * Returns the number of milliseconds that the thread actually waited.
+ */
+static inline uint64_t thread_wait_until(uint64_t end)
+{
+	static const uint32_t CyclesPerMillisecond = CPU_TIMER_HZ / 1'000;
+	uint64_t              start                = rdcycle64();
+	uint64_t              current              = start;
+	// sleep for periods > 1 tick
+	while ((end > current) && (end - current > TIMERCYCLES_PER_TICK))
+	{
+		Timeout t = {0, ((uint32_t)(end - current)) / TIMERCYCLES_PER_TICK};
+		(void)thread_sleep(&t, ThreadSleepNoEarlyWake);
+		current = rdcycle64();
+	}
+	// Spin for the remaining time.
+	while (current < end)
+	{
+		current = rdcycle64();
+	}
+	return (current - start) / CyclesPerMillisecond;
+}
+
+/**
  * Wait for the specified number of milliseconds.  This will yield for periods
  * that are longer than a scheduler tick and then spin for the remainder of the
  * time.
@@ -155,25 +184,12 @@ static inline uint64_t thread_millisecond_wait(uint32_t milliseconds)
 	return milliseconds;
 #else
 	static const uint32_t CyclesPerMillisecond = CPU_TIMER_HZ / 1'000;
+	uint64_t              start                = rdcycle64();
+	uint32_t              cycles = milliseconds * CyclesPerMillisecond;
+	uint64_t              end    = start + cycles;
 	__if_cxx(
 	  static_assert(CyclesPerMillisecond > 0, "CPU_TIMER_HZ is too low"););
-	uint32_t cycles  = milliseconds * CyclesPerMillisecond;
-	uint64_t start   = rdcycle64();
-	uint64_t end     = start + cycles;
-	uint64_t current = start;
-	while ((end > current) && (end - current > TIMERCYCLES_PER_TICK))
-	{
-		Timeout t = {0, ((uint32_t)(end - current)) / TIMERCYCLES_PER_TICK};
-		(void)thread_sleep(&t, ThreadSleepNoEarlyWake);
-		current = rdcycle64();
-	}
-	// Spin for the remaining time.
-	while (current < end)
-	{
-		current = rdcycle64();
-	}
-	current = rdcycle64();
-	return (current - start) / CyclesPerMillisecond;
+	return thread_wait_until(end);
 #endif
 }
 


### PR DESCRIPTION
1. [Fix a bug in thread_millisecond_wait.](https://github.com/CHERIoT-Platform/cheriot-rtos/commit/cabebd78b0526d4c3c3f7ea92252fb6a5171e95f)
`(end-current) > MS_PER_TICK` was comparing cycles against
milliseconds which makes no sense.  The result is that we would call
thread_sleep with a timeout of 0 when we need to wait for between
MS_PER_TICK (e.g. 10) and TIMERCYCLES_PER_TICK cycles.  This does no
real harm except waste time doing a compartment call (which could fail
if we're out of trusted stack etc.).  Fix this and also use the
existing TIMERCYCLES_PER_TICK macro rather than inventing a new name.

4. [Add thread_wait_until to wait or spin until given cycle timer value.](https://github.com/CHERIoT-Platform/cheriot-rtos/commit/c511ef88fd44d12aad68caeabee84d78b534720c) 
This is sometimes what you want if you're aiming for a particular time
(e.g. the start of the next frame start in an animation) rather than a
particular period.  I've also refactored thread_millisecond_wait in
terms of this.  We should probably make this a scheduler primitive but
this works as an interim measure.