### PR TITLE
Add initialiser framework.

### DIFF
--- a/sdk/core/loader/boot.S
+++ b/sdk/core/loader/boot.S
@@ -6,6 +6,19 @@
 #include "../switcher/trusted-stack-assembly.h"
 #include <cheri-builtins.h>
 
+
+/**
+ * Machine-mode stack high water mark CSR
+ */
+#define CSR_MSHWM  0xbc1
+
+/**
+ * Machine mode stack high water mark stack base CSR
+ */
+#define CSR_MSHWMB 0xbc2
+
+
+
 .include "assembly-helpers.s"
 
     .section .loader_start, "ax", @progbits
@@ -72,8 +85,7 @@
 	 *
 	 *  - a5/x15: holds the RW cap root without GL(obal) permission.
 	 *
-	 * In particular, ra/x1, a0/x10, and a1/x11 are free and may be clobbered,
-	 * as platform code is quite likely to want to use .Lfill_block, below.
+	 * In particular, ra/x1, a0/x10, and a1/x11 are free and may be clobbered.
 	 */
 #if __has_include(<platform-early_boot.inc>)
 #	include <platform-early_boot.inc>
@@ -131,40 +143,61 @@
 
 	// ca4 still has the RW memory root; nothing to change
 
+	// Reserve 16 bytes at the top of the stack to later hold the hazard pointer slot
+	cincoffset		csp, csp, -16
+
 	/*
 	 * The first argument (ca0) is a SchedEntryInfo out parameter.  Make space
-	 * for it at the base of the stack, where we can easily find it again after
-	 * the call returns.
+	 * for it at the top of the current stack frame, where we can easily find
+	 * it again after the call returns.
 	 */
+	// First make space for the thread infos
 	la_abs			s1, __thread_count
 	csetaddr		cs1, ca4, s1
 	clhu			s1, 0(cs1)
 	li			t0, -BOOT_THREADINFO_SZ
 	mul			s1, s1, t0
-	addi			s1, s1, -SchedulerEntryInfo_offset_threads
 	cincoffset		csp, csp, s1
-	neg			s1, s1
-	csetbounds		ca0, csp, s1
+	// ca1 now contains the bounded capability to the threads array
+	neg				s1, s1
+	csetboundsexact	ct0, csp, s1
+	// Make space for the scheduler info
+	cincoffset		csp, csp, -SchedulerEntryInfo_size
+	csc				ct0, SchedulerEntryInfo_offset_threads(csp)
+	csetbounds		ca0, csp, SchedulerEntryInfo_size
 
 	// Call to loader_entry_point.
 	cjalr			cra
 
 	/*
-	 * Load the two return values (pcc and cgp for the scheduler entry point).
+	 * Prepare a trusted stack for the idle thread.  This structure is almost
+	 * entirely present to simplify the scheduler.  Unlike other trusted stacks
+	 * in the system, it does not make reference to a compartment export table.
 	 *
-	 * Drop these elements from the on-stack SchedulerEntryInfo, leaving only
-	 * its array of ThreadInfo-s (pointed to by sp).
+	 * This clobbers mtdc's initial value of the RW root.
 	 */
-	clc				cs0, 0(csp)
-	clc				cgp, 8(csp)
-	cincoffset		csp, csp, SchedulerEntryInfo_offset_threads
-
-	// Zero the stack (except for the aforementioned threadInfo-s).
-	cgetbase		a0, csp
-	csetaddr		ca0, csp, a0
-	cmove			ca1, csp
-	cjal			.Lfill_block
-	// Nothing in the loader stores to the stack after this point
+	la_abs			a3, bootTStack
+	li				a1, BOOT_TSTACK_SIZE
+	cspecialr		ca0, mscratchc // mscratch still has the RW (G+SL) root
+	csetaddr		ca3, ca0, a3
+	csetboundsexact	ca3, ca3, a1
+	li				a1, TSTACKOFFSET_FIRSTFRAME + TrustedStackFrame_size
+	csh				a1, TrustedStack_offset_frameoffset(ca3)
+	cspecialw		mtdc, ca3
+	// Initialise the stack high-water mark registers
+	cgetbase		a1, csp
+	csrw			CSR_MSHWMB, a1
+	csrw			CSR_MSHWM, sp
+	/*
+	 * Set up dummy hazard-pointer space in this trusted stack frame.
+	 * The switcher wants to zero this on call and return, so make sure that it
+	 * exists, to avoid a branch in the switcher.
+	 */
+	cgettop			a2, csp
+	addi			a2, a2, -16
+	csetaddr		ca2, csp, a2
+	csetbounds		ca2, ca2, 16
+	csc				ca2, TrustedStack_offset_hazardPointers(ca3)
 
 	/*
 	 * Clear most capability roots.
@@ -183,63 +216,78 @@
 	la_abs			a1, __export_mem_heap
 	csetaddr		ca0, ca0, a1
 	la_abs			a1, __export_mem_heap_end
-	cjal			.Lfill_block
+.Lzero_heap:
+	csc				c0, 0(ca0)
+	cincoffset		ca0, ca0, 8
+	bltu			a0, a1, .Lzero_heap
+
+
+	// Get the array of initialisers and the switcher PCC
+	clc				cs0, SchedulerEntryInfo_offset_switcherPCC(csp)
+	clc				cs1, SchedulerEntryInfo_offset_initialiserList(csp)
+	// Loop prelude
+.Lnext_initialiser:
+	// Get the end of the initialiser list
+	cgettop			t1, cs1
+	// Loop exit 
+	bge				s1, t1, .Ldone_initialisers
+
+	// Loop body
+	// Load the sealed capability for the entry point
+	clc				ct1, 0(cs1)
+	// Call the switcher
+	cjalr			cs0
+	// Increment the array pointer
+	cincoffset		cs1, cs1, 8
+
+	// Loop
+	j				.Lnext_initialiser
+.Ldone_initialisers:
 
 	/*
-	 * Prepare a trusted stack for the idle thread.  This structure is almost
-	 * entirely present to simplify the scheduler.  Unlike other trusted stacks
-	 * in the system, it does not make reference to a compartment export table.
-	 *
-	 * This clobbers mtdc's initial value of the RW root.
+	 * Load the scheduler entry point (as a cross-compartment function pointer,
+	 * for use with the compartment switcher) and its argument.
 	 */
-	la_abs			a3, bootTStack
-	li				a1, BOOT_TSTACK_SIZE
-	csetaddr		ca3, ca0, a3 // ca0 still has the RW (G+SL) root
-	csetboundsexact	ca3, ca3, a1
-	li				a1, TSTACKOFFSET_FIRSTFRAME
-	csh				a1, TrustedStack_offset_frameoffset(ca3)
-	cspecialw		mtdc, ca3
-
-	// Move the scheduler's (bounded) PCC into the register we'll jump to later.
-	cmove			cra, cs0
+	clc				ct1, SchedulerEntryInfo_offset_schedulerExportEntry(csp)
+	clc				ca0, SchedulerEntryInfo_offset_threads(csp)
 
 	/*
-	 * Pass, as the first argument, the array of ThreadInfo-s from what was the
-	 * on-stack SchedulerEntryInfo.
-	 *
-	 * This clobbers a0's copy of the RW root; all roots are now gone.
+	 * Move the stack pointer up over the return from the C++ loader.  This
+	 * will be zeroed by the switcher.  The stack now contains only the thread
+	 * handles.  This stack will be used for the scheduler after this call, so
+	 * accidentally leaking that doesn't matter.
 	 */
-	addi			s1, s1, -SchedulerEntryInfo_offset_threads
-	csetbounds		ca0, csp, s1
+	cincoffset		csp, csp, SchedulerEntryInfo_size
 
-	/*
-	 * The machine is now about to approximate the behavor of the idle thread
-	 * (mtdc, sp) making a compartment call into the scheduler compartment (ra
-	 * and gp) and in particular its initialization hook, scheduler_entry.
-	 * This is not a proper cross-call, especially in that neither the call nor
-	 * return will go via the switcher's cross-call path (or use the trusted
-	 * stack), because we are not a fully-fledged RTOS thread.
-	 *
-	 * Clear all other registers before invoking.  This ensures that the
-	 * scheduler does not, for example, get access to capability roots.
-	 */
-	zeroAllRegistersExcept	ra, sp, gp, a0
-	cjalr			cra
+	// Clear s1, so its old contents are't spilled on the stack
+	zeroOne         s1
+
+	// Call the scheduler initialisation function.
+	cjalr			cs0
 
 	/*
 	 * Done scheduler setup.  Now prepare to be the idle thread.
 	 *
 	 * Drop our reference to the stack, as it is now exclusively property of the
 	 * scheduler, having been installed over in switcher/entry.S's
-	 * switcher_scheduler_entry_csp.
+	 * switcher_scheduler_entry_csp.  Zero some additional registers for defence in depth:
+	 * 
+	 *  - s0 contains the switcher pcc.
+	 *  - a0 and a1 may contain return values from the switcher or scheduler
+	 *    (should not be capabilities).
+	 *  - All temporary registers or other argument registers are zeroed by the switcher.
 	 */
-	zeroOne			sp
+	zeroRegisters  sp, s0, a0, a1
 
 	// Enable external and timer interrupts.
 	li				t1, (MIE_MEIE | MIE_MTIE)
 	csrs			mie, t1
 	// Globally enable interrupts.
 	csrsi			mstatus, MSTATUS_MIE
+
+	// Note: In theory, we should drop ASR permission from pcc here, but we
+	// don't really need to because there's no data processed by the wfi loop
+	// that would allow an attacker to do anything useful.
 
 	/*
 	 * Yield to the scheduler to start real tasks, if a well-timed interrupt
@@ -253,11 +301,6 @@
 	wfi
 	j				.Lidle_loop
 
-.Lfill_block:
-	csc				c0, 0(ca0)
-	cincoffset		ca0, ca0, 8
-	bltu			a0, a1, .Lfill_block
-	cret
 .size start, . - start
 
 	.section .loader_trusted_stack, "a", @progbits

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -472,6 +472,47 @@ namespace
 	Capability<void> trustedStackKey;
 
 	/**
+	 * Find an export table target.  This looks for the address within
+	 * all of the export tables in the image.  The `size` parameter is used if
+	 * this is an MMIO import, the `lib` parameter is used to derive
+	 * capabilities for the library compartment.
+	 */
+	void *find_export_entry_point(const ImgHdr &image, ImportEntry &entry)
+	{
+		/// Build an export table entry for the given compartment.
+		auto buildExportEntry = [&](const auto &compartment) {
+			auto exportEntry     = build(compartment.exportTable, entry.address)
+			                         .template cast<ExportEntry>();
+			auto interruptStatus = exportEntry->interrupt_status();
+			Debug::Invariant(
+			  (interruptStatus == InterruptStatus::Disabled),
+			  "Initialisation functions must have interrupts disabled");
+			Debug::Invariant(exportEntry->argument_register_count() == 0,
+			                 "Exported initialiser must have 0 arguments");
+			exportEntry.without_permissions(Permission::Store);
+			return exportEntry.seal(exportSealingKey);
+		};
+
+		for (auto &compartment : image.privilegedCompartments)
+		{
+			if (contains<ExportEntry>(compartment.exportTable, entry.address))
+			{
+				return buildExportEntry(compartment);
+			}
+		}
+
+		for (auto &compartment : image.compartments())
+		{
+			if (contains<ExportEntry>(compartment.exportTable, entry.address))
+			{
+				return buildExportEntry(compartment);
+			}
+		}
+		Debug::Invariant(false, "Invalid initialiser: {}", entry.address);
+		return nullptr;
+	}
+
+	/**
 	 * Find an export table target.  This looks for the `target` address within
 	 * all of the export tables in the image.  The `size` parameter is used if
 	 * this is an MMIO import, the `lib` parameter is used to derive
@@ -865,6 +906,12 @@ namespace
 		// Space per thread for hazard pointers.
 		static constexpr size_t HazardPointerSpace =
 		  HazardPointersPerThread * sizeof(void *);
+		Debug::Invariant(
+		  hazardPointers.length() == image.thread_count() * HazardPointerSpace,
+		  "Hazard pointer space is {}, should be {} for {} threads",
+		  hazardPointers.length(),
+		  image.thread_count() * HazardPointerSpace,
+		  image.thread_count());
 
 		/*
 		 * Construct a return sentry with which to populate initial thread
@@ -1408,10 +1455,24 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 		populate_imports(imgHdr, compartment, switcherPCC);
 	}
 
+	Debug::log("Initialisers: {}--{}",
+	           imgHdr.initialisers.start(),
+	           imgHdr.initialisers.end());
+	auto importEntryRange = build_range<ImportEntry>(imgHdr.initialisers);
+	ret.initialiserList   = importEntryRange.begin();
+	for (auto &importEntries : importEntryRange)
+	{
+		Debug::log("Initialiser import: {}", &importEntries);
+		Debug::log("Initialiser import: {}", importEntries.address);
+		*reinterpret_cast<void **>(&importEntries) =
+		  find_export_entry_point(imgHdr, importEntries);
+	}
+
 	Debug::log("Creating boot threads\n");
+	Debug::log("Thread infos: {}", ret.threads);
 	boot_threads_create(imgHdr, ret.threads);
 	// Provide the switcher with the capabilities for entering the scheduler.
-	void *schedCGP = build_cgp(imgHdr.scheduler());
+	void *schedulerCGP = build_cgp(imgHdr.scheduler());
 	auto  exceptionEntryOffset =
 	  build<ExportEntry>(
 	    imgHdr.scheduler().exportTable,
@@ -1431,7 +1492,7 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 	*build<void *>(imgHdr.switcher.code, imgHdr.switcher.scheduler_pcc()) =
 	  schedExceptionEntry;
 	*build<void *>(imgHdr.switcher.code, imgHdr.switcher.scheduler_cgp()) =
-	  schedCGP;
+	  schedulerCGP;
 	// The scheduler will inherit our stack once we're done with it
 	Capability<void> csp = ({
 		register void *cspRegister asm("csp");
@@ -1446,7 +1507,7 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 	Debug::log(
 	  "Scheduler exception entry configured:\nPCC: {}\nCGP: {}\nCSP: {}",
 	  schedExceptionEntry,
-	  schedCGP,
+	  schedulerCGP,
 	  csp);
 
 #ifdef SOFTWARE_REVOKER
@@ -1495,8 +1556,6 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 	asm volatile("cspecialw mtcc, %0" ::"C"(exceptionEntry.get()));
 	Debug::log("Set exception entry point to {}", exceptionEntry);
 
-	// Construct and enter the scheduler compartment.
-	auto schedPCC = build_pcc(imgHdr.scheduler());
 	// Set the scheduler entry point to the scheduler_entry export.
 	// TODO: We should probably have a separate scheduler linker script that
 	// exposes this.  If the scheduler is no longer creating threads, we can
@@ -1505,10 +1564,14 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 	auto exportEntry = build<ExportEntry>(
 	  imgHdr.scheduler().exportTable,
 	  LA_ABS(__export_scheduler__Z15scheduler_entryPK16ThreadLoaderInfo));
-	schedPCC.address() += exportEntry->functionStart;
+	exportEntry.without_permissions(Permission::Store);
+	Debug::Invariant(
+	  exportEntry->argument_register_count() == 1,
+	  "Export entry for loader must take one argument, takes: {}",
+	  exportEntry->argument_register_count());
+	ret.schedulerExportEntry = exportEntry.seal(exportSealingKey);
 
-	Debug::log("Will return to scheduler entry point: {}", schedPCC);
+	ret.switcherPCC = switcherPCC;
 
-	ret.schedPCC = schedPCC;
-	ret.schedCGP = schedCGP;
+	Debug::log("Will return to scheduler entry point: {}", exportEntry);
 }

--- a/sdk/core/loader/constants.h
+++ b/sdk/core/loader/constants.h
@@ -13,20 +13,38 @@ namespace
 	/// The return type of the loader, to pass information to the scheduler.
 	struct SchedulerEntryInfo
 	{
-		/// scheduler initial entry point for thread initialisation
-		void *schedPCC;
-		/// scheduler CGP for thread initialisation
-		void *schedCGP;
-		/// thread descriptors for all threads
-		ThreadLoaderInfo threads[];
+		/// The sentry to the switcher
+		void *switcherPCC;
+		/// The export entry for the scheduler entry
+		void *schedulerExportEntry;
+		/// Start of initialiser list.
+		void *initialiserList;
+		/// Thread descriptors for all threads
+		ThreadLoaderInfo *threads;
 	};
-
 	using namespace loader;
+	/*
+	 * This structure will be allocated on the stack from assembly.  Make sure
+	 * that its size is a multiple of 16 bytes to ensure that the stack is
+	 * always 16-byte aligned.
+	 */
+	static_assert(sizeof(ThreadLoaderInfo) % 16 == 0);
+	static_assert(sizeof(SchedulerEntryInfo) % 16 == 0);
+
+	static constexpr size_t HazardPointersPerThread = 2;
 
 } // namespace
 #endif
 
-EXPORT_ASSEMBLY_OFFSET(SchedulerEntryInfo, threads, 16);
+EXPORT_ASSEMBLY_OFFSET(SchedulerEntryInfo, switcherPCC, 0);
+EXPORT_ASSEMBLY_OFFSET(SchedulerEntryInfo, schedulerExportEntry, 8);
+EXPORT_ASSEMBLY_OFFSET(SchedulerEntryInfo, initialiserList, 16);
+EXPORT_ASSEMBLY_OFFSET(SchedulerEntryInfo, threads, 24);
+EXPORT_ASSEMBLY_SIZE(SchedulerEntryInfo, 32);
 EXPORT_ASSEMBLY_EXPRESSION(MIE_MEIE, priv::MIE_MEIE, 0x800);
 EXPORT_ASSEMBLY_EXPRESSION(MIE_MTIE, priv::MIE_MTIE, 0x080);
 EXPORT_ASSEMBLY_EXPRESSION(MSTATUS_MIE, priv::MSTATUS_MIE, 8);
+
+EXPORT_ASSEMBLY_EXPRESSION(ThreadHeapHazards_size,
+                           HazardPointersPerThread * sizeof(void *),
+                           16);

--- a/sdk/core/loader/defines.h
+++ b/sdk/core/loader/defines.h
@@ -5,10 +5,11 @@
 
 #define BOOT_STACK_SIZE 1024
 /**
- * The trusted stack size for the loader. Since the loader, the scheduler and
- * the idle thread must not do compartment calls, this trusted stack only needs
- * to have a register frame and not trusted stack frames.
+ * The trusted stack size for the loader.
+ * This is used for calling initialisers and so must be one deep.  The switcher
+ * expects the parent frame to always exist, so it must actually be two deep.
  */
-#define BOOT_TSTACK_SIZE TrustedStack_offset_frames
+#define BOOT_TSTACK_SIZE                                                       \
+	(TrustedStack_offset_frames + (2 * TrustedStackFrame_size))
 
 #define BOOT_THREADINFO_SZ 16

--- a/sdk/core/loader/types.h
+++ b/sdk/core/loader/types.h
@@ -343,6 +343,14 @@ namespace loader
 			{
 				return static_cast<size_t>(smallSize) << Shift;
 			}
+
+			/**
+			 * Returns the end address.
+			 */
+			[[nodiscard]] ptraddr_t end() const
+			{
+				return startAddress + size();
+			}
 		};
 
 		static_assert(IsAddressRange<ShiftedAddressRange<0>>,
@@ -615,7 +623,7 @@ namespace loader
 			// This is a random 32-bit number and should be changed whenever
 			// the compartment header layout changes to provide some sanity
 			// checking.
-			return magic == 0x46391da0;
+			return magic == 0xb0531162;
 		}
 
 		/**
@@ -629,6 +637,11 @@ namespace loader
 		 * the `compartments` array that are stateful compartments.
 		 */
 		uint16_t compartmentCount;
+
+		/**
+		 * The firmware initialiser list.
+		 */
+		ShiftedAddressRange<0> initialisers;
 
 		/**
 		 * The raw compartment header that's generated in the final link step.
@@ -801,6 +814,14 @@ namespace loader
 			{
 				return {threadConfigs, &threadConfigs[threadCount]};
 			}
+
+			/**
+			 * Returns the number of threads in this image.
+			 */
+			[[nodiscard]] auto count() const
+			{
+				return threadCount;
+			}
 		};
 
 		/// Convenience type for a range of compartment headers.
@@ -829,6 +850,13 @@ namespace loader
 			return reinterpret_cast<const ThreadInfo *>(
 			         &compartmentHeaders[libraryCount + compartmentCount])
 			  ->threads();
+		}
+
+		[[nodiscard]] auto thread_count() const
+		{
+			return reinterpret_cast<const ThreadInfo *>(
+			         &compartmentHeaders[libraryCount + compartmentCount])
+			  ->count();
 		}
 	};
 
@@ -1113,6 +1141,15 @@ namespace loader
 			uint8_t status =
 			  (flags & InterruptStatusMask) >> InterruptStatusShift;
 			return static_cast<InterruptStatus>(status);
+		}
+
+		/**
+		 * Returns the number of argument registers.
+		 */
+		unsigned argument_register_count()
+		{
+			// The low three bits are the number of registers to preserve.
+			return flags & 0x7;
 		}
 
 		/**

--- a/sdk/firmware.rwdata.ldscript.in
+++ b/sdk/firmware.rwdata.ldscript.in
@@ -63,6 +63,14 @@ __shared_objects_start = .;
 @shared_objects@
 __shared_objects_end = .;
 
+# In theory, these could be placed in the region that's reused for stack.
+.cheriot_compartment_initialisers : ALIGN(8)
+{
+	.initialiser_start = .;
+	*.compartment(SORT_BY_INIT_PRIORITY(.cheriot_initialiser.*));
+	.initialiser_end = .;
+}
+
 . = ALIGN(64);
 
 # Everything after this point can be discarded after the loader has
@@ -173,12 +181,15 @@ __cap_relocs_end = .;
     # Magic number, used to detect mismatches between linker script and
     # loader versions.
     # New versions of this can be generated with:
-    # head /dev/random | shasum | cut -c 0-8
-    LONG(0x46391da0);
+    # head /dev/random | shasum | cut -c 1-8
+    LONG(0xb0531162);
     # Number of library headers.
     SHORT(@library_count@);
     # Number of compartment headers.
     SHORT(@compartment_count@);
+	# Address of the start and end of the global initialiser table
+	LONG(.initialiser_start);
+	SHORT(.initialiser_end - .initialiser_start);
     @compartment_headers@
 }
 
@@ -225,3 +236,4 @@ __compart_headers_size = __compart_headers_end - __compart_headers;
 
     @library_exports@
 }
+

--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -524,3 +524,18 @@
 			ret;                                                               \
 		})
 #endif
+
+/**
+ * Declare a CHERIoT initialiser function.  This macro can be used in place of
+ * a prototype for a function called `function`.  Initialiser functions are
+ * called in ascending priority order.
+ */
+#define CHERIOT_INITIALISER(function, priority)                                \
+	__asm("  .section .cheriot_initialiser." #priority ",\"aR\",@progbits\n"   \
+	      "  .p2align  3\n"                                                    \
+	      "  .word __export_" COMPARTMENT_NAME_STRING "_" #function "\n"       \
+	      "  .word 0\n"                                                        \
+	      "  .previous\n");                                                    \
+	__if_cxx(extern "C") __cheriot_callback                                    \
+	  [[cheriot::interrupt_state(disabled)]] void                              \
+	  function()

--- a/sdk/include/platform/sunburst/platform-early_boot.inc
+++ b/sdk/include/platform/sunburst/platform-early_boot.inc
@@ -8,4 +8,7 @@
 	la_abs     a0, __export_mem_shadow
 	csetaddr   ca0, ca4, a0
 	la_abs     a1, __export_mem_shadow_end
-	cjal       .Lfill_block
+.Lzero_shadow:
+	csc        c0, 0(ca0)
+	cincoffset ca0, ca0, 8
+	bltu       a0, a1, .Lzero_shadow

--- a/tests/misc-test.cc
+++ b/tests/misc-test.cc
@@ -459,7 +459,26 @@ namespace
 
 	const char *testString = "Hello world";
 
+	bool initialiserRun1;
+	bool initialiserRun2;
+
 } // namespace
+
+//__cheriot_callback extern "C" void initialiser1()
+CHERIOT_INITIALISER(initialiser1, 123)
+{
+	debug_log("Running initialiser1");
+	// Make sure that this has run
+	initialiserRun1 = true;
+}
+
+//__cheriot_callback extern "C" void initialiser2()
+CHERIOT_INITIALISER(initialiser2, 456)
+{
+	debug_log("Running initialiser2");
+	// Make sure that this has run after initialiser1
+	initialiserRun2 = initialiserRun1;
+}
 
 volatile decltype(testString) *volatileString = &testString;
 
@@ -519,6 +538,9 @@ int test_misc()
 		TEST(!switcherReturnSentry.permissions().contains(Permission::Global),
 		     "Switcher return sentry should be local");
 	}
+
+	TEST(initialiserRun1, "initialiser1 ran");
+	TEST(initialiserRun2, "initialiser1 ran before initialiser2");
 
 	CHERI::Capability largeRW{largeBuffer};
 	CHERI::Capability largeRO{LargeConstBuffer};


### PR DESCRIPTION
This is the MVP version, and allows compartments to expose entry points that are run in an order based on priority.

This includes some refactoring of the boot.S code to ensure that we've zeroed the heap and dropped privileges before the initialisers are called.

It also calls the scheduler initialisation routine as a cross-compartment call.  This gives us some additional defence in depth against accidental leakage from the loader into the scheduler.