### PR TITLE
Add sub quotas.

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -5,6 +5,7 @@
 
 #include "alloc_config.h"
 #include "compartment-macros.h"
+#include "heap_offset.h"
 #include "revoker.h"
 #include <algorithm>
 #include <cdefs.h>
@@ -251,6 +252,15 @@ namespace displacement_proxy
 } // namespace displacement_proxy
 
 /**
+ * Forward declare claims in an anonymous namespace for use with HeapOffsets in
+ * MChunkHeader.
+ */
+namespace
+{
+	class Claim;
+} // namespace
+
+/**
  * Every chunk, in use or not, includes a minimal header.  That is, this is a
  * classic malloc, not something like a slab or sizeclass allocator or a
  * "BIBOP"-inspired design.
@@ -317,7 +327,7 @@ __cheri_no_subobject_bounds MChunkHeader
 	bool isPrevInUse : 1;
 	bool isCurrInUse : 1;
 	/// Head of a linked list of claims on this allocation
-	uint16_t claims;
+	HeapOffset<Claim> claims;
 
 	__always_inline auto cell_prev()
 	{
@@ -1340,7 +1350,7 @@ class MState
 				Capability heap{heapStart};
 				heap.address() = ptr.address();
 				auto chunk     = MChunkHeader::from_body(heap);
-				if (chunk->claims > 0)
+				if (!chunk->claims.is_null())
 				{
 					/*
 					 * The chunk was freed but ended up in

--- a/sdk/core/allocator/heap_offset.h
+++ b/sdk/core/allocator/heap_offset.h
@@ -1,0 +1,75 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <debug.hh>
+#include <stdint.h>
+
+/**
+ * Object representing a compressed pointer to a heap resident object of type T.
+ *
+ * A HeapOffset with `value = 0` represents a `nullptr`.
+ */
+template<typename T>
+struct HeapOffset
+{
+	/// The compressed pointer value as an offset into the allocator heap.
+	uint16_t value = 0;
+
+	/**
+	 * Return true if the underlying value is 0, that is, if this offset
+	 * represents a `nullptr`.
+	 */
+	[[nodiscard]] bool is_null() const
+	{
+		return value == 0;
+	}
+
+	/**
+	 * Decode this offset and return a pointer to T, or `nullptr` if null.
+	 */
+	[[nodiscard]] T *get() const;
+
+	/**
+	 * Encode a pointer to a heap-allocated T as a HeapOffset.
+	 * Asserts that `ptr` is correctly aligned and is within the
+	 * representable range of 16 bits.
+	 */
+	[[nodiscard]] static HeapOffset<T> from(T *ptr);
+
+	/**
+	 * Comparison operators compare the underlying compressed pointer value.
+	 */
+	bool operator==(const HeapOffset &other) const
+	{
+		return value == other.value;
+	}
+
+	bool operator!=(const HeapOffset &other) const
+	{
+		return value != other.value;
+	}
+
+	/**
+	 * Dereference operators allow this to be used as any other pointer.
+	 */
+	T *operator->() const
+	{
+		return get();
+	}
+
+	T &operator*() const
+	{
+		return *get();
+	}
+};
+
+template<typename T>
+struct DebugFormatArgumentAdaptor<HeapOffset<T>>
+{
+	__always_inline static DebugFormatArgument construct(const HeapOffset<T> &h)
+	{
+		return DebugFormatArgumentAdaptor<uint16_t>::construct(h.value);
+	}
+};

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -35,25 +35,194 @@ using namespace CHERI;
 Revocation::Revoker revoker;
 namespace
 {
-	/**
-	 * Internal view of an allocator capability.
-	 *
-	 * TODO: For now, these are statically allocated. Eventually we will have
-	 * some that are dynamically allocated. These should be ref counted so that
-	 * we can avoid repeated validity checks.
-	 */
+	/// Internal view of an allocator capability.
 	struct PrivateAllocatorCapabilityState
 	{
 		/// The remaining quota for this capability.
 		size_t quota;
 		/// A unique identifier for this pool.
 		uint16_t identifier;
+		/// Pointers forming DLL for dynamically allocated sub quotas.
+		HeapOffset<PrivateAllocatorCapabilityState> next;
+		HeapOffset<PrivateAllocatorCapabilityState> prev;
 	};
 
 	static_assert(sizeof(PrivateAllocatorCapabilityState) <=
 	              sizeof(AllocatorCapabilityState));
 	static_assert(alignof(PrivateAllocatorCapabilityState) <=
 	              alignof(AllocatorCapabilityState));
+
+	/**
+	 * Represents the assignable ID space for heap resident quotas.
+	 */
+	class SubQuotaIdSpace
+	{
+		static constexpr uint16_t IdMax =
+		  (1 << (MChunkHeader::OwnerIDWidth)) - 1;
+		// FIXME: If we can determine the number of static quotas in the
+		// loader and provide this to the allocator, we can reclaim most of
+		// this ID space.
+		static constexpr uint16_t IdMin =
+		  (1 << (MChunkHeader::OwnerIDWidth - 1));
+		// Full span of the sub-quota ID range as a uint32_t to avoid
+		// truncation when projecting IDs when wrapping around.
+		static constexpr uint32_t IdRange = IdMax - IdMin + 1;
+
+		HeapOffset<PrivateAllocatorCapabilityState> head = {};
+
+		/**
+		 * Helper function that inserts the given quota object after `anchor`
+		 * and assigns it `id`.
+		 */
+		__always_inline void node_insert_after(
+		  PrivateAllocatorCapabilityState            *anchor,
+		  PrivateAllocatorCapabilityState            *node,
+		  HeapOffset<PrivateAllocatorCapabilityState> nodeOffset,
+		  uint16_t                                    id)
+		{
+			Debug::Assert(id >= IdMin && id <= IdMax,
+			              "Provided ID {} is outside sub-quota range [{}, {}]",
+			              id,
+			              IdMin,
+			              IdMax);
+			node->identifier = id;
+			node->next       = anchor->next;
+			node->prev =
+			  HeapOffset<PrivateAllocatorCapabilityState>::from(anchor);
+			anchor->next->prev = nodeOffset;
+			anchor->next       = nodeOffset;
+		}
+
+		/**
+		 * Helper function for picking the offset into a given range of free
+		 * IDs. Here we take the midpoint.
+		 */
+		[[nodiscard]] __always_inline static uint16_t offset_pick(uint32_t gap)
+		{
+			return static_cast<uint16_t>(gap / 2);
+		}
+
+		public:
+		[[nodiscard]] __always_inline static constexpr bool
+		is_sub_quota_id(uint16_t value)
+		{
+			return value >= IdMin;
+		}
+
+		[[nodiscard]] __always_inline bool is_empty() const
+		{
+			return head.is_null();
+		}
+
+		/**
+		 * Insert `node` into the sorted ring. Node is assigned an ID chosen by
+		 * policy described by `offset_pick`. Returns true on success, false if
+		 * the ID space is exhausted.
+		 */
+		[[nodiscard]] __noinline bool
+		id_allocate(PrivateAllocatorCapabilityState *node)
+		{
+			Debug::Assert(node != nullptr, "id_allocate called with null node");
+			Debug::Assert(node->next.is_null() && node->prev.is_null(),
+			              "Node {} already appears to be in ring",
+			              node->identifier);
+
+			auto nodeOffset =
+			  HeapOffset<PrivateAllocatorCapabilityState>::from(node);
+
+			// Ring is empty, so use full ID range for picking offset
+			if (head.is_null())
+			{
+				auto offset = offset_pick(IdRange);
+				Debug::Assert(
+				  offset < IdRange,
+				  "offset_pick returned offset {} outside IdRange {}",
+				  offset,
+				  IdRange);
+				uint16_t id      = static_cast<uint16_t>(IdMin + offset);
+				node->identifier = id;
+				node->next       = nodeOffset;
+				node->prev       = nodeOffset;
+				head             = nodeOffset;
+				return true;
+			}
+
+			auto *start   = head.get();
+			auto *current = start;
+
+			do
+			{
+				auto *next = current->next.get();
+				Debug::Assert(current == next ||
+				                current->identifier != next->identifier,
+				              "Duplicate identifiers in sub-quota ring: {}",
+				              current->identifier);
+
+				// project next's ID above current to handle wraparound nicely
+				uint32_t nextIdProjected = next->identifier;
+				if (nextIdProjected <= current->identifier)
+				{
+					nextIdProjected += IdRange;
+				}
+
+				uint32_t gap = nextIdProjected - current->identifier - 1;
+
+				if (gap > 0)
+				{
+					uint16_t offset = offset_pick(gap);
+					Debug::Assert(offset < gap,
+					              "offset_pick returned offset outside "
+					              "gap [{}, {})",
+					              current->identifier + 1,
+					              next->identifier);
+					uint32_t wideId = current->identifier + 1 + offset;
+					uint16_t id =
+					  (wideId > IdMax)
+					    ? static_cast<uint16_t>(IdMin + (wideId - IdMax - 1))
+					    : static_cast<uint16_t>(wideId);
+
+					// insert the node into the list and advance the head
+					// pointer to the inserted node, such that we reduce
+					// clustering.
+					node_insert_after(current, node, nodeOffset, id);
+					head = nodeOffset;
+					return true;
+				}
+
+				// no free ID range
+				current = next;
+			} while (current != start);
+
+			return false;
+		}
+
+		/**
+		 * Remove `node` from the sorted ring and clear its link pointers.
+		 */
+		void __noinline id_release(PrivateAllocatorCapabilityState *node)
+		{
+			Debug::Assert(node != nullptr, "id_release called with null node");
+			Debug::Assert(!head.is_null(), "release called on empty ring");
+			Debug::Assert(!node->next.is_null() && !node->prev.is_null(),
+			              "Node with ID {} appears not to be in the ring.",
+			              node->identifier);
+
+			if (head.get() == node)
+			{
+				head = (node->next.get() == node)
+				         ? HeapOffset<PrivateAllocatorCapabilityState>{}
+				         : node->next;
+			}
+
+			node->prev->next = node->next;
+			node->next->prev = node->prev;
+			node->next       = {};
+			node->prev       = {};
+		}
+	};
+
+	/// The sub quota ID space
+	SubQuotaIdSpace subQuotaIds;
 
 	// the global memory space
 	MState *gm;
@@ -391,6 +560,10 @@ namespace
 					// Failed to acquire lock within allowed timeout.
 					return -ETIMEDOUT;
 				}
+				if (!Capability{capability}.is_valid())
+				{
+					return -EPERM;
+				}
 				continue;
 			}
 		} while (may_block(timeout));
@@ -428,13 +601,13 @@ namespace
 		if (state->identifier == 0)
 		{
 			static uint32_t nextIdentifier = 1;
-			// Cleave the ID space in half, with upper range reserved for
-			// dynamically allocated subquotas.
-			// FIXME: If we can determine the number of static quotas in the
-			// loader and provide this to the allocator, we can reclaim most of
-			// this ID space.
-			if (nextIdentifier >= (1 << (MChunkHeader::OwnerIDWidth - 1)))
+
+			if (SubQuotaIdSpace::is_sub_quota_id(nextIdentifier))
 			{
+				// If this ID is a sub quota ID, then we've run out of IDs for
+				// our static quotas.
+				Debug::log<DebugLevel::Warning>(
+				  "Exhausted static quota ID space.");
 				return nullptr;
 			}
 			state->identifier = nextIdentifier++;
@@ -502,6 +675,27 @@ namespace
 		}
 
 		/**
+		 * Transfers ownership of this claim. Cannot be transferred to allocator
+		 * ownership.
+		 */
+		void ownership_transfer(uint16_t newOwner)
+		{
+			Debug::Assert(
+			  newOwner != QuotaIdentifierAllocatorOwned,
+			  "newOwner of claim cannot be QuotaIdentifierAllocatorOwned, "
+			  "since the allocator cannot make claims.");
+			allocatorIdentifier = newOwner;
+		}
+
+		/**
+		 * Returns the number of references for this claim.
+		 */
+		[[nodiscard]] uint32_t reference_count() const
+		{
+			return referenceCount;
+		}
+
+		/**
 		 * Returns the value of the compressed next pointer.
 		 */
 		[[nodiscard]] HeapOffset<Claim> encoded_next() const
@@ -518,12 +712,13 @@ namespace
 			/**
 			 * Placeholder value for end iterators.
 			 */
-			HeapOffset<Claim> endPlaceholder = {};
+			static inline const HeapOffset<Claim> EndPlaceholder = {};
 
 			/**
 			 * A pointer to the encoded next pointer.
 			 */
-			HeapOffset<Claim> *encodedNextPointer = &endPlaceholder;
+			HeapOffset<Claim> *encodedNextPointer =
+			  const_cast<HeapOffset<Claim> *>(&EndPlaceholder);
 
 			public:
 			/**
@@ -557,10 +752,9 @@ namespace
 			}
 
 			/// Iteration termination condition.
-			__always_inline bool operator!=(const Iterator Other)
+			__always_inline bool operator!=(const Iterator &other)
 			{
-				return encodedNextPointer->value !=
-				       Other.encodedNextPointer->value;
+				return *encodedNextPointer != *other.encodedNextPointer;
 			}
 
 			/**
@@ -830,6 +1024,7 @@ namespace
 			}
 			return 0;
 		}
+
 		return -EPERM;
 	}
 
@@ -846,6 +1041,7 @@ namespace
 			                                heapCapability);
 			return -EPERM;
 		}
+
 		// Validate the pointer. We do not permit freeing sealed pointers.
 		Capability<void> mem{rawPointer};
 		if (!mem.is_valid() || mem.is_sealed())
@@ -1167,62 +1363,22 @@ namespace
 	using TokenHandle = CHERI::Capability<TokenObjectType, false>;
 
 	/**
-	 * Helper that allocates a sealed object and returns the sealed and
-	 * unsealed capabilities to the object.  Requires that the sealing key have
-	 * all of the permissions in `permissions`.
+	 * Must be called with the lock held. This function is intended to be called
+	 * from within the allocator, with an unsealed AllocatorCapabilityState
+	 * reference.
 	 */
-	std::pair<SealedTokenHandle, TokenHandle<false>>
-	  __noinline allocate_sealed_unsealed(Timeout            *timeout,
-	                                      AllocatorCapability heapCapability,
-	                                      SealingKey          key,
-	                                      size_t              requestedSize,
-	                                      PermissionSet       permissions)
+	__noinline std::pair<SealedTokenHandle, TokenHandle<false>>
+	           allocate_sealed_unsealed_internal(
+	             LockGuard<decltype(lock)>      &&g,
+	             Timeout                         *timeout,
+	             PrivateAllocatorCapabilityState *capability,
+	             SealingKey                       key,
+	             size_t                           sealedSize)
 	{
-		if (!check_timeout_pointer(timeout))
-		{
-			return {nullptr, nullptr};
-		}
-
-		if (!permissions.can_derive_from(key.permissions()))
-		{
-			Debug::log<DebugLevel::Warning>(
-			  "Operation requires {}, cannot derive from {}", permissions, key);
-			return {nullptr, nullptr};
-		}
-
-		// Round up the size to the next representable size.  This ensures
-		// that, once we've added the header space, we have an allocation where
-		// both the object (from the end) and the header (with padding at the
-		// start) are representable.
-		size_t unsealedSize = CHERI::representable_length(requestedSize);
-		// Very large sizes may be rounded 'up' to zero.  Don't allow this.
-		if (unsealedSize == 0)
-		{
-			Debug::log<DebugLevel::Warning>(
-			  "Requested size {} is not representable", requestedSize);
-			return {nullptr, nullptr};
-		}
-
-		// It shouldn't be possible to overflow the add due to the way the
-		// rounding works, but this is not guaranteed in future capability
-		// encodings, so we'll do a tiny bit of extra work here to avoid
-		// accidentally introducing a security vulnerability in a future
-		// encoding.
-		size_t sealedSize;
-		if (__builtin_add_overflow(
-		      sizeof(TokenObjectHeader), unsealedSize, &sealedSize))
-		{
-			Debug::log<DebugLevel::Warning>(
-			  "Requested size {} is too large to include header",
-			  requestedSize);
-			return {nullptr, nullptr};
-		}
-
-		LockGuard g{lock};
-		auto     *capability =
-		  malloc_capability_unseal(heapCapability, AllocatorPermitAllocate);
 		if (capability == nullptr)
 		{
+			Debug::log<DebugLevel::Warning>(
+			  "sealed_unsealed Failed to unseal capability.");
 			return {nullptr, nullptr};
 		}
 
@@ -1281,6 +1437,84 @@ namespace
 			      nullptr, nullptr};
 		    });
 	}
+
+	/**
+	 * Helper for determining the size of the sealed object allocation needed
+	 * for the requested size.
+	 */
+	__always_inline std::optional<size_t>
+	                sealed_allocation_size(size_t requestedSize)
+	{
+		// Round up the size to the next representable size.  This ensures
+		// that, once we've added the header space, we have an allocation where
+		// both the object (from the end) and the header (with padding at the
+		// start) are representable.
+		size_t unsealedSize = CHERI::representable_length(requestedSize);
+		// Very large sizes may be rounded 'up' to zero.  Don't allow this.
+		if (unsealedSize == 0)
+		{
+			Debug::log<DebugLevel::Warning>(
+			  "Requested size {} is not representable", requestedSize);
+			return std::nullopt;
+		}
+
+		// It shouldn't be possible to overflow the add due to the way the
+		// rounding works, but this is not guaranteed in future capability
+		// encodings, so we'll do a tiny bit of extra work here to avoid
+		// accidentally introducing a security vulnerability in a future
+		// encoding.
+		size_t sealedSize;
+		if (__builtin_add_overflow(
+		      sizeof(TokenObjectHeader), unsealedSize, &sealedSize))
+		{
+			Debug::log<DebugLevel::Warning>(
+			  "Requested size {} is too large to include header",
+			  requestedSize);
+			return std::nullopt;
+		}
+
+		return sealedSize;
+	}
+
+	/**
+	 * Helper that allocates a sealed object and returns the sealed and
+	 * unsealed capabilities to the object.  Requires that the sealing key have
+	 * all of the permissions in `permissions`.
+	 */
+	std::pair<SealedTokenHandle, TokenHandle<false>>
+	  __noinline allocate_sealed_unsealed(Timeout            *timeout,
+	                                      AllocatorCapability heapCapability,
+	                                      SealingKey          key,
+	                                      size_t              requestedSize,
+	                                      PermissionSet       permissions)
+	{
+		if (!check_timeout_pointer(timeout))
+		{
+			return {nullptr, nullptr};
+		}
+
+		if (!permissions.can_derive_from(key.permissions()))
+		{
+			Debug::log<DebugLevel::Warning>(
+			  "Operation requires {}, cannot derive from {}", permissions, key);
+			return {nullptr, nullptr};
+		}
+
+		auto sealedSize = sealed_allocation_size(requestedSize);
+		if (!sealedSize.has_value())
+		{
+			return {nullptr, nullptr};
+		}
+
+		{
+			LockGuard g{lock};
+			auto     *capability =
+			  malloc_capability_unseal(heapCapability, AllocatorPermitAllocate);
+			return allocate_sealed_unsealed_internal(
+			  std::move(g), timeout, capability, key, sealedSize.value());
+		}
+	}
+
 } // namespace
 
 TokenKey token_key_new()
@@ -1316,6 +1550,7 @@ __cheriot_minimum_stack(0x290) CHERI_SEALED(void *)
 	STACK_CHECK(0x290);
 	if (!check_timeout_pointer(timeout))
 	{
+		Debug::log<DebugLevel::Warning>("Timeout invalid.");
 		return nullptr;
 	}
 	auto [sealed, obj] = allocate_sealed_unsealed(
@@ -1442,6 +1677,225 @@ __cheriot_minimum_stack(TokenObjDestroyStackUsage) int token_obj_can_destroy(
 	unsealed.address() = unsealed.base();
 
 	return heap_can_free(heapCapability, unsealed);
+}
+
+__cheriot_minimum_stack(0x270) AllocatorCapability
+  split_quota(Timeout *timeout, AllocatorCapability parent, size_t size)
+{
+	STACK_CHECK(0x270);
+	if (!check_timeout_pointer(timeout))
+	{
+		return reinterpret_cast<AllocatorCapability>(-EINVAL);
+	}
+
+	LockGuard g{lock};
+
+	auto *parentCap = malloc_capability_unseal(parent, AllocatorPermitAllocate);
+	if (parentCap == nullptr)
+	{
+		return reinterpret_cast<AllocatorCapability>(-EPERM);
+	}
+
+	auto sealedSize =
+	  sealed_allocation_size(sizeof(PrivateAllocatorCapabilityState));
+
+	if (!sealedSize.has_value() ||
+	    parentCap->quota < (size + sealedSize.value()))
+	{
+		return reinterpret_cast<AllocatorCapability>(-ENOMEM);
+	}
+
+	auto key = STATIC_SEALING_TYPE(MallocKey);
+
+	auto [sealedWrapped, unsealedWrapped] = allocate_sealed_unsealed_internal(
+	  std::move(g), timeout, parentCap, key, sealedSize.value());
+
+	if (!sealedWrapped.is_valid())
+	{
+		return reinterpret_cast<AllocatorCapability>(-EINVAL);
+	}
+
+	// Slightly ugly solution. SealedTokenHandle doesn't expose .get() so we pun
+	// through pointer for correct return value.
+	auto sealed = *reinterpret_cast<AllocatorCapability *>(&sealedWrapped);
+	// Casting to Private lets us write to our prev/next pointers.
+	auto *unsealed = reinterpret_cast<PrivateAllocatorCapabilityState *>(
+	  unsealedWrapped.get());
+
+	// Allocate the quota to the child
+	parentCap->quota -= size;
+	unsealed->quota = size;
+
+	if (subQuotaIds.id_allocate(unsealed))
+	{
+		return sealed;
+	}
+
+	// the unsealed capability returned from allocate_sealed_unsealed_internal
+	// is interior to the actual allocation made. It cannot be used to free
+	// because of this, so we unseal our sealed capability to get the full
+	// bounds.
+	TokenHandle<true> unsealedFull =
+	  unseal_internal(STATIC_SEALING_TYPE(MallocKey), sealedWrapped);
+	unsealedFull.address() = unsealedFull.base();
+	Debug::log<DebugLevel::Warning>(
+	  "Failed to allocate ID in split_quota, freeing {}", unsealedFull);
+
+	int ret = heap_free_internal(parent, unsealedFull, true);
+
+	if (ret < 0)
+	{
+		Debug::log<DebugLevel::Warning>(
+		  "Failed to free allocated child after ID allocation failure. "
+		  "Free manually with recombine_quota.");
+		return reinterpret_cast<AllocatorCapability>(-EINVAL);
+	}
+
+	parentCap->quota += size;
+	return reinterpret_cast<AllocatorCapability>(-ENOMEM);
+}
+
+__cheriot_minimum_stack(0x1a0) int recombine_quota(AllocatorCapability child,
+                                                   AllocatorCapability parent)
+{
+	STACK_CHECK(0x1a0);
+	LockGuard g{lock};
+
+	auto parentState =
+	  malloc_capability_unseal(parent, AllocatorPermitAllocate);
+
+	auto *childState = malloc_capability_unseal(child, AllocatorPermitAllocate);
+
+	if (childState == nullptr || parentState == nullptr)
+	{
+		return -EPERM;
+	}
+
+	uint16_t childID  = childState->identifier;
+	uint16_t parentID = parentState->identifier;
+	if (!SubQuotaIdSpace::is_sub_quota_id(childID))
+	{
+		return -EINVAL;
+	}
+
+	// Sealed pointer was an internal address, we want to free from base.
+	TokenHandle<true> unsealedChild =
+	  unseal_internal(STATIC_SEALING_TYPE(MallocKey),
+	                  reinterpret_cast<CHERI_SEALED(TokenObjectType *)>(child));
+	unsealedChild.address() = unsealedChild.base();
+
+	// Check that parent is authorized to free child, but don't really free
+	int ret = heap_free_internal(parent, unsealedChild, false);
+	if (ret != 0)
+	{
+		return ret;
+	}
+
+	// Walk the heap and transfer ownership of chunks from child to parent.
+	{
+		auto      chunk   = gm->heapStart.cast<MChunkHeader>();
+		ptraddr_t heapEnd = chunk.top();
+
+		do
+		{
+			if (chunk->is_in_use())
+			{
+				if (chunk->ownerID == childID)
+				{
+					// Child is the owner of this chunk. An owner never appears
+					// in a claims list for an allocation it owns, so we check
+					// only for a parent claim.
+					auto [parentNext, parentClaim] =
+					  claim_find(parentID, *chunk);
+					if (parentClaim != nullptr)
+					{
+						// Parent has a claim on allocation. Convert child's
+						// ownership into an additional reference on parent's
+						// existing claim.
+						chunk->set_owner(0);
+						childState->quota += chunk->size_get();
+						parentClaim->reference_add();
+					}
+					else
+					{
+						// There is no parent claim on the allocation and so we
+						// can simply reassign ownership.
+						chunk->set_owner(parentID);
+					}
+				}
+				else
+				{
+					// Child does not own this chunk, check for a child claim
+					auto [childNext, childClaim] = claim_find(childID, *chunk);
+					if (childClaim != nullptr)
+					{
+						auto [parentNext, parentClaim] =
+						  claim_find(parentID, *chunk);
+						if (parentClaim != nullptr)
+						{
+							// Both parent and child have claims on this
+							// allocation. Absorb the child's claim into the
+							// parents and destroy the child's claim object. We
+							// loop here since claim counts are expected to be
+							// small, and we want to respect the saturation
+							// logic.
+							for (uint32_t i = 0;
+							     i < childClaim->reference_count();
+							     ++i)
+							{
+								parentClaim->reference_add();
+							}
+							*childNext = childClaim->encoded_next();
+							childState->quota += chunk->size_get();
+							Claim::destroy(*childState, childClaim);
+						}
+						else if (chunk->ownerID == parentID)
+						{
+							// Parent is the owner of this allocation. We need
+							// to convert that ownership to a claim and add a
+							// reference. The parent has already paid for this
+							// allocation, as has the child, so we refund the
+							// size to the child to avoid double counting.
+							chunk->set_owner(0);
+							childClaim->ownership_transfer(parentID);
+							childClaim->reference_add();
+							childState->quota += chunk->size_get();
+						}
+						else
+						{
+							// Only child has a claim on this allocation, so we
+							// can transfer ownership of the claim to the
+							// parent.
+							childClaim->ownership_transfer(parentID);
+						}
+					}
+					// Else: child has no relation to this chunk. Nothing to do.
+				}
+			}
+			chunk = static_cast<MChunkHeader *>(chunk->cell_next());
+		} while (chunk.address() < heapEnd);
+	}
+
+	// Record the current quota of the childState after the fold operation
+	// has potentially destroyed claims
+	size_t quota      = childState->quota;
+	childState->quota = 0;
+
+	// Release the child ID
+	subQuotaIds.id_release(childState);
+
+	// Now really free the child
+	ret = heap_free_internal(parent, unsealedChild, true);
+
+	if (ret != 0)
+	{
+		Debug::log<DebugLevel::Warning>("Failed to destroy sub quota {}",
+		                                child);
+		return ret;
+	}
+
+	parentState->quota += quota;
+	return 0;
 }
 
 size_t heap_available()

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -3,6 +3,7 @@
 
 #include "alloc.h"
 #include "cheri.hh"
+#include "heap_offset.h"
 #include "revoker.h"
 #include "token.h"
 #include <allocator.h>
@@ -427,7 +428,12 @@ namespace
 		if (state->identifier == 0)
 		{
 			static uint32_t nextIdentifier = 1;
-			if (nextIdentifier >= (1 << MChunkHeader::OwnerIDWidth))
+			// Cleave the ID space in half, with upper range reserved for
+			// dynamically allocated subquotas.
+			// FIXME: If we can determine the number of static quotas in the
+			// loader and provide this to the allocator, we can reclaim most of
+			// this ID space.
+			if (nextIdentifier >= (1 << (MChunkHeader::OwnerIDWidth - 1)))
 			{
 				return nullptr;
 			}
@@ -443,6 +449,12 @@ namespace
 	class Claim
 	{
 		/**
+		 * Ensure the heap offsets behave as expected.
+		 */
+		static_assert(sizeof(HeapOffset<Claim>) == sizeof(uint16_t));
+		static_assert(alignof(HeapOffset<Claim>) == alignof(uint16_t));
+
+		/**
 		 * The identifier of the owning allocation capability.
 		 */
 		uint16_t allocatorIdentifier = 0;
@@ -450,7 +462,7 @@ namespace
 		 * Next 'pointer' encoded as a shifted offset from the start of the
 		 * heap.
 		 */
-		uint16_t encodedNext = 0;
+		HeapOffset<Claim> encodedNext = {};
 		/**
 		 * Saturating reference count.  We use one to indicate a single
 		 * reference count rather than zero to slightly simplify the logic at
@@ -467,7 +479,7 @@ namespace
 		 * Private constructor, creates a new claim with a single reference
 		 * count.
 		 */
-		Claim(uint16_t identifier, uint16_t nextClaim)
+		Claim(uint16_t identifier, HeapOffset<Claim> nextClaim)
 		  : allocatorIdentifier(identifier), encodedNext(nextClaim)
 		{
 		}
@@ -492,7 +504,7 @@ namespace
 		/**
 		 * Returns the value of the compressed next pointer.
 		 */
-		[[nodiscard]] uint16_t encoded_next() const
+		[[nodiscard]] HeapOffset<Claim> encoded_next() const
 		{
 			return encodedNext;
 		}
@@ -506,13 +518,12 @@ namespace
 			/**
 			 * Placeholder value for end iterators.
 			 */
-			static inline const uint16_t EndPlaceholder = 0;
+			HeapOffset<Claim> endPlaceholder = {};
 
 			/**
 			 * A pointer to the encoded next pointer.
 			 */
-			uint16_t *encodedNextPointer =
-			  const_cast<uint16_t *>(&EndPlaceholder);
+			HeapOffset<Claim> *encodedNextPointer = &endPlaceholder;
 
 			public:
 			/**
@@ -524,7 +535,7 @@ namespace
 			__always_inline Iterator(const Iterator &other) = default;
 
 			/// Constructor from an explicit next pointer.
-			__always_inline Iterator(uint16_t *nextPointer)
+			__always_inline Iterator(HeapOffset<Claim> *nextPointer)
 			  : encodedNextPointer(nextPointer)
 			{
 			}
@@ -534,7 +545,7 @@ namespace
 			 */
 			__always_inline Claim *operator*()
 			{
-				return Claim::from_encoded_offset(*encodedNextPointer);
+				return encodedNextPointer->get();
 			}
 
 			/**
@@ -542,13 +553,14 @@ namespace
 			 */
 			__always_inline Claim *operator->()
 			{
-				return Claim::from_encoded_offset(*encodedNextPointer);
+				return encodedNextPointer->get();
 			}
 
 			/// Iteration termination condition.
 			__always_inline bool operator!=(const Iterator Other)
 			{
-				return *encodedNextPointer != *Other.encodedNextPointer;
+				return encodedNextPointer->value !=
+				       Other.encodedNextPointer->value;
 			}
 
 			/**
@@ -567,14 +579,14 @@ namespace
 			 */
 			Iterator &operator=(Claim *claim)
 			{
-				*encodedNextPointer = claim->encode_address();
+				*encodedNextPointer = HeapOffset<Claim>::from(claim);
 				return *this;
 			}
 
 			/**
 			 * Returns the next pointer that this iterator refers to.
 			 */
-			uint16_t *pointer()
+			HeapOffset<Claim> *pointer()
 			{
 				return encodedNextPointer;
 			}
@@ -588,7 +600,7 @@ namespace
 		 * failure.
 		 */
 		static Claim *create(PrivateAllocatorCapabilityState &capability,
-		                     uint16_t                         next)
+		                     HeapOffset<Claim>                next)
 		{
 			auto space = gm->mspace_dispatch(
 			  sizeof(Claim), capability.quota, QuotaIdentifierAllocatorOwned);
@@ -642,48 +654,16 @@ namespace
 			}
 			return referenceCount == 0;
 		}
-
-		/**
-		 * Decode an encoded offset and return a pointer to the claim.
-		 */
-		static Claim *from_encoded_offset(uint16_t offset)
-		{
-			if (offset == 0)
-			{
-				return nullptr;
-			}
-			Capability<Claim> ret{gm->heapStart.cast<Claim>()};
-			ret.address() += offset << MallocAlignShift;
-			ret.bounds() = sizeof(Claim);
-			return ret;
-		}
-
-		/**
-		 * Encode the address of this object in a 16-bit value.
-		 */
-		uint16_t encode_address()
-		{
-			ptraddr_t address = Capability{this}.address();
-			address -= gm->heapStart.address();
-			Debug::Assert((address & MallocAlignMask) == 0,
-			              "Claim at address {} is insufficiently aligned",
-			              address);
-			address >>= MallocAlignShift;
-			Debug::Assert(address <= std::numeric_limits<uint16_t>::max(),
-			              "Encoded claim address is too large: {}",
-			              address);
-			return address;
-		}
 	};
 	static_assert(sizeof(Claim) <= (1 << MallocAlignShift),
 	              "Claims should fit in the smallest possible allocation");
 
 	/**
-	 * Find a claim if one exists.  Returns a reference to the next pointer
+	 * Find a claim if one exists.  Returns a pointer to the next HeapOffset
 	 * that refers to this claim.
 	 */
-	std::pair<uint16_t &, Claim *> claim_find(uint16_t      owner,
-	                                          MChunkHeader &chunk)
+	std::pair<HeapOffset<Claim> *, Claim *> claim_find(uint16_t      owner,
+	                                                   MChunkHeader &chunk)
 	{
 		for (Claim::Iterator i{&chunk.claims}, end; i != end; ++i)
 		{
@@ -702,10 +682,10 @@ namespace
 				 * See discussion at
 				 * https://github.com/CHERIoT-Platform/llvm-project/issues/320
 				 */
-				return {__builtin_no_change_bounds(*i.pointer()), claim};
+				return {__builtin_no_change_bounds(i.pointer()), claim};
 			}
 		}
-		return {chunk.claims, nullptr};
+		return {&chunk.claims, nullptr};
 	}
 
 	/**
@@ -733,7 +713,7 @@ namespace
 			}
 			owner.quota -= size;
 		}
-		claim = Claim::create(owner, next);
+		claim = Claim::create(owner, *next);
 		if (claim != nullptr)
 		{
 			Debug::log("Allocated new claim for {}", chunk.body());
@@ -744,7 +724,7 @@ namespace
 				chunk.ownerID = 0;
 				claim->reference_add();
 			}
-			next = claim->encode_address();
+			*next = HeapOffset<Claim>::from(claim);
 			return true;
 		}
 		// If we failed to allocate the claim object, undo adding this to our
@@ -785,7 +765,7 @@ namespace
 		// delete the claim unconditionally.
 		if (freeAll || claim->reference_remove())
 		{
-			next        = claim->encoded_next();
+			*next       = claim->encoded_next();
 			size_t size = chunk.size_get();
 			owner.quota += size;
 			Claim::destroy(owner, claim);
@@ -824,7 +804,7 @@ namespace
 			}
 			size_t chunkSize = chunk.size_get();
 			chunk.ownerID    = 0;
-			if (chunk.claims == 0)
+			if (chunk.claims.is_null())
 			{
 				int ret = gm->mspace_free(chunk, bodySize);
 				// If free fails, don't manipulate the quota.
@@ -844,7 +824,7 @@ namespace
 		// claim.
 		if (claim_drop(owner, chunk, reallyFree, freeAll))
 		{
-			if ((chunk.claims == 0) && (chunk.ownerID == 0))
+			if ((chunk.claims.is_null()) && (chunk.ownerID == 0))
 			{
 				return gm->mspace_free(chunk, bodySize);
 			}
@@ -895,6 +875,38 @@ namespace
 	}
 
 } // namespace
+
+template<typename T>
+T *HeapOffset<T>::get() const
+{
+	if (value == 0)
+	{
+		return nullptr;
+	}
+	Capability<T> ret{gm->heapStart.cast<T>()};
+	ret.address() += value << MallocAlignShift;
+	ret.bounds() = sizeof(T);
+	return ret;
+}
+
+template<typename T>
+HeapOffset<T> HeapOffset<T>::from(T *ptr)
+{
+	if (ptr == nullptr)
+	{
+		return HeapOffset{0};
+	}
+	ptraddr_t address = Capability{ptr}.address();
+	address -= gm->heapStart.address();
+	Debug::Assert((address & MallocAlignMask) == 0,
+	              "HeapOffset target at address {} is insufficiently aligned",
+	              address);
+	address >>= MallocAlignShift;
+	Debug::Assert(address <= std::numeric_limits<uint16_t>::max(),
+	              "Encoded heap address is too large: {}",
+	              address);
+	return HeapOffset{static_cast<uint16_t>(address)};
+}
 
 __cheriot_minimum_stack(0xa0) ssize_t
   heap_quota_remaining(AllocatorCapability heapCapability)

--- a/sdk/include/allocator.h
+++ b/sdk/include/allocator.h
@@ -71,6 +71,55 @@ allocator_permissions_and(AllocatorCapability heapCapability, int permissions)
 }
 
 /**
+ * Split off a sub quota object from the provided parent. The requested size
+ * will be subtracted from the parent's quota, along with the size of the
+ * sub-quota itself. The child is an object allocated using the parent quota,
+ * and so counts against the quota of the parent until a corresponding call to
+ * `recombine_quota`.
+ *
+ * The allocator capability returned from this function on success may be used
+ * in place of a static allocation capability in any heap API, but care should
+ * be taken: the quota is a heap allocated object, and so may be freed.
+ *
+ * This will return an AllocatorCapability that refers to the newly created sub
+ * quota on success.
+ *
+ * Returns `-EPERM` if `parent` is not a valid allocator capability or does not
+ * have `AllocatorPermitAllocate` permission, `-ENOMEM` if `parent` has
+ * insufficient quota to accommodate the requested `size` plus the overhead of
+ * the sub-quota object itself, or `-EINVAL` if either  `timeout` is not a valid
+ * timeout pointer or the internal allocation fails for any reason (including
+ * timeout).
+ *
+ * Similarly to `heap_allocate`, `-ENOTENOUGHSTACK` may be returned if the
+ * stack is insufficiently large to run the function. See `heap_allocate`.
+ */
+AllocatorCapability __cheri_compartment("allocator")
+  split_quota(Timeout *timeout, AllocatorCapability parent, size_t size);
+
+/**
+ * Recombine the provided child quota with its parent. This operation frees
+ * the underlying object, and returns all loaned quota to the parent.
+ *
+ * Allocations currently owned by the child quota will have their ownership
+ * transferred to the parent. Likewise, claims will be transferred. If either
+ * parent or child have a claim on an object, and the other does too, then
+ * the result will be a claim with two references attributed to the parent.
+ *
+ * Returns zero on success.
+ *
+ * Returns `-EPERM` if either `child` or `parent` is not a valid allocator
+ * capability or `child` is not derived from `parent`, or `-EINVAL` if
+ * `child` is not a dynamically allocated sub-quota (for example, if a
+ * static allocator capability is passed).
+ *
+ * Similarly to `heap_allocate`, `-ENOTENOUGHSTACK` may be returned if the
+ * stack is insufficiently large to run the function. See `heap_allocate`.
+ */
+int __cheri_compartment("allocator")
+  recombine_quota(AllocatorCapability child, AllocatorCapability parent);
+
+/**
  * Add a claim to an allocation.  The object will be counted against the quota
  * provided by the first argument until a corresponding call to `heap_free`.
  * Note that this can be used with interior pointers.

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -1471,6 +1471,466 @@ namespace
 		debug_log("End of permission restriction tests");
 	}
 
+	__noinline void test_sub_quota_operations()
+	{
+		debug_log("Beginning sub quota ID management structure tests");
+
+		Timeout               t{UnlimitedTimeout};
+		ds::xoroshiro::P32R16 rand = {};
+
+		/**
+		 * Basic functionality
+		 */
+
+		const size_t                     ArrSize = 64;
+		std::vector<AllocatorCapability> quotas;
+		quotas.resize(ArrSize);
+		AllocatorCapability child, child2, c0, c1, c2;
+
+		size_t initialQuota = heap_quota_remaining(MALLOC_CAPABILITY);
+
+		// Simple create then recombine
+		child = split_quota(&t, MALLOC_CAPABILITY, 0);
+		TEST(Capability{child}.is_valid(), "Sub quota creation failed.");
+
+		TEST_EQUAL(recombine_quota(child, MALLOC_CAPABILITY),
+		           0,
+		           "Sub quota destruction failed.");
+
+		// Create then recombine large number
+		for (size_t i = 0; i < ArrSize; ++i)
+		{
+			quotas[i] = split_quota(&t, MALLOC_CAPABILITY, 0);
+			TEST(Capability{quotas[i]}.is_valid(),
+			     "Sub quota creation failed at index {}",
+			     i);
+		}
+
+		for (size_t i = 0; i < ArrSize; ++i)
+		{
+			TEST(recombine_quota(quotas[i], MALLOC_CAPABILITY) == 0,
+			     "Sub quota destruction failed at index {}",
+			     i);
+		}
+
+		/**
+		 * Failure cases
+		 */
+		debug_log("Testing sub_quota API parameter validation");
+		size_t quotaRemaining = 0;
+
+		// create sub quota
+		child = split_quota(nullptr, MALLOC_CAPABILITY, 0);
+		TEST(!Capability{child}.is_valid(),
+		     "Creating sub quota with null timeout succeded");
+		TEST_EQUAL(static_cast<int>(reinterpret_cast<intptr_t>(child)),
+		           -EINVAL,
+		           "Creating sub quota with null timeout succeded");
+		child = split_quota(&t, nullptr, 0);
+		TEST(!Capability{child}.is_valid(),
+		     "Creating sub quota with null parent succeeded");
+		TEST_EQUAL(static_cast<int>(reinterpret_cast<intptr_t>(child)),
+		           -EPERM,
+		           "Creating sub quota with null parent succeeded");
+
+		// invalid sizes
+		child = split_quota(&t, MALLOC_CAPABILITY, MALLOC_QUOTA);
+		TEST(!Capability{child}.is_valid(),
+		     "Creating sub quota larger than parent succeeded");
+		TEST_EQUAL(
+		  static_cast<int>(reinterpret_cast<intptr_t>(child)),
+		  -ENOMEM,
+		  "Creating sub quota with quota greater than parent succeeded");
+
+		quotaRemaining = heap_quota_remaining(MALLOC_CAPABILITY);
+		child          = split_quota(
+		  &t, MALLOC_CAPABILITY, static_cast<size_t>(quotaRemaining));
+		TEST(!Capability{child}.is_valid(),
+		     "Creating sub quota whose quota + metadata exceeds parents quota "
+		     "succeded");
+		TEST_EQUAL(static_cast<int>(reinterpret_cast<intptr_t>(child)),
+		           -ENOMEM,
+		           "Creating sub quota whose quota + metadata exceeds parents "
+		           "quota succeded");
+
+		// recombine sub quota
+		child = split_quota(&t, MALLOC_CAPABILITY, 0);
+		TEST(Capability{child}.is_valid(),
+		     "Sub quota creation failed for null parent recombine test");
+		TEST_EQUAL(recombine_quota(nullptr, MALLOC_CAPABILITY),
+		           -EPERM,
+		           "recombining sub quota with null child succeeded");
+		TEST_EQUAL(recombine_quota(child, nullptr),
+		           -EPERM,
+		           "recombining sub quota with null parent succeeded");
+		child2 = split_quota(&t, MALLOC_CAPABILITY, 0);
+		TEST(Capability{child2}.is_valid(),
+		     "Sub quota creation failed for null parent recombine test");
+		TEST_EQUAL(recombine_quota(child, child2),
+		           -EPERM,
+		           "recombining sub quota with sibling as parent succeeded")
+		TEST_EQUAL(recombine_quota(child2, MALLOC_CAPABILITY),
+		           0,
+		           "Cleanup recombine of child2 failed.");
+		TEST_EQUAL(recombine_quota(child, MALLOC_CAPABILITY),
+		           0,
+		           "Cleanup recombine child failed.");
+
+		/**
+		 * Quota Accounting
+		 */
+		debug_log("Testing sub quota accounting");
+
+		size_t splitSize = 4096;
+
+		// Expect quota exactly restored after create + recombine
+		quotaRemaining = heap_quota_remaining(MALLOC_CAPABILITY);
+		child          = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		TEST(Capability{child}.is_valid(), "Sub quota creation failed");
+		TEST_EQUAL(recombine_quota(child, MALLOC_CAPABILITY),
+		           0,
+		           "Sub quota recombine failed");
+		TEST_EQUAL(heap_quota_remaining(MALLOC_CAPABILITY),
+		           static_cast<ssize_t>(quotaRemaining),
+		           "Parent quota not fully restored after create + recombine");
+
+		// Child reports exactly the requested quota
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		TEST(Capability{child}.is_valid(), "Sub quota creation failed");
+		TEST_EQUAL(heap_quota_remaining(child),
+		           splitSize,
+		           "Child quota_remaining does not equal requested size");
+		TEST_EQUAL(recombine_quota(child, MALLOC_CAPABILITY),
+		           0,
+		           "Sub quota recombine failed");
+
+		// Parent quota reduced by both the child size and the metadata overhead
+		quotaRemaining = heap_quota_remaining(MALLOC_CAPABILITY);
+		child          = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		TEST(Capability{child}.is_valid(), "Sub quota creation failed");
+		ssize_t parentAfterChild = heap_quota_remaining(MALLOC_CAPABILITY);
+		// difference must be strictly greater than splitSize due to
+		// sealed-size overhead
+		TEST(static_cast<size_t>(quotaRemaining - parentAfterChild) > splitSize,
+		     "Parent quota reduction does not account for metadata overhead");
+		TEST_EQUAL(recombine_quota(child, MALLOC_CAPABILITY),
+		           0,
+		           "Sub quota recombine failed");
+
+		/**
+		 * Linked-list integrity
+		 */
+		debug_log("Testing sub quota linked list integrity");
+		// Insertion order recombination tested earlier in suite.
+
+		// Create head, recombine so list is empty, create again.
+		child = split_quota(&t, MALLOC_CAPABILITY, 0);
+		TEST(Capability{child}.is_valid(), "Sub quota creation failed");
+		TEST_EQUAL(recombine_quota(child, MALLOC_CAPABILITY),
+		           0,
+		           "recombine of only child failed");
+		child2 = split_quota(&t, MALLOC_CAPABILITY, 0);
+		TEST(Capability{child2}.is_valid(),
+		     "split_quota failed after list became empty");
+		TEST_EQUAL(recombine_quota(child2, MALLOC_CAPABILITY),
+		           0,
+		           "recombine failed after list-empty re-creation");
+
+		// Recombine a non-head child. Neighbours' prev/next pointers
+		// must be updated so the remaining children can still be recombined
+		c0 = split_quota(&t, MALLOC_CAPABILITY, 0);
+		c1 = split_quota(&t, MALLOC_CAPABILITY, 0);
+		c2 = split_quota(&t, MALLOC_CAPABILITY, 0);
+		TEST(Capability{c0}.is_valid(), "Sub quota c0 creation failed");
+		TEST(Capability{c1}.is_valid(), "Sub quota c1 creation failed");
+		TEST(Capability{c2}.is_valid(), "Sub quota c2 creation failed");
+		TEST_EQUAL(recombine_quota(c1, MALLOC_CAPABILITY),
+		           0,
+		           "recombine of middle sub quota failed");
+		TEST_EQUAL(recombine_quota(c0, MALLOC_CAPABILITY),
+		           0,
+		           "recombine of c0 after middle removed failed");
+		TEST_EQUAL(recombine_quota(c2, MALLOC_CAPABILITY),
+		           0,
+		           "recombine of c2 after middle removed failed");
+	}
+
+	/**
+	 */
+	__noinline void test_sub_quota_semantics()
+	{
+		debug_log("Beginning sub quota semantics tests");
+
+		Timeout               t{UnlimitedTimeout};
+		ds::xoroshiro::P32R16 rand = {};
+
+		const size_t                     ArrSize   = 64;
+		size_t                           splitSize = 4096;
+		AllocatorCapability              child;
+		void                            *ptr;
+		std::vector<AllocatorCapability> quotas;
+		quotas.resize(ArrSize);
+		std::vector<void *> ptrs;
+		ptrs.resize(ArrSize);
+
+		/**
+		 * Basic quota usage
+		 */
+		debug_log("Testing basic sub quota usage for allocation and free.");
+
+		size_t initialQuota   = heap_quota_remaining(MALLOC_CAPABILITY);
+		size_t allocationSize = 128;
+
+		// Allocating from child reduces its quota and freeing restores it
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		TEST(Capability{child}.is_valid(), "Sub quota creation failed");
+		ptr = heap_allocate(&t, child, allocationSize);
+		TEST(Capability{ptr}.is_valid(), "Allocation from child quota failed");
+
+		TEST(heap_quota_remaining(child) < splitSize - allocationSize,
+		     "Child quota not reduced after allocation");
+		TEST_SUCCESS(heap_free(child, ptr));
+		TEST_EQUAL(heap_quota_remaining(child),
+		           splitSize,
+		           "Child quota not restored after free");
+		TEST_EQUAL(recombine_quota(child, MALLOC_CAPABILITY),
+		           0,
+		           "Sub quota recombine failed");
+
+		// Parent capability should not be able to free childs allocations
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		TEST(Capability{child}.is_valid(), "Sub quota creation failed");
+		ptr = heap_allocate(&t, child, allocationSize);
+		TEST(Capability{ptr}.is_valid(), "Child failed to allocate");
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr),
+		           -EPERM,
+		           "Parent successfully freed allocation of child.");
+		TEST_SUCCESS(heap_free(child, ptr));
+		TEST_EQUAL(
+		  recombine_quota(child, MALLOC_CAPABILITY), 0, "Recombine failed");
+
+		// Objects owned by the child are transferred to the parent's ownership
+		// on recombine.
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		ptr   = heap_allocate(&t, child, allocationSize);
+		TEST(Capability{ptr}.is_valid(), "Child failed to allocate");
+		TEST_EQUAL(
+		  recombine_quota(child, MALLOC_CAPABILITY), 0, "Recombine failed");
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr),
+		           0,
+		           "Parent failed to free transferred child allocation");
+
+		debug_log("Testing sub quota interactions with claims API.");
+		// If a child has a claim on an object it doesn't own, that claim is
+		// transferred to the parent. Test with parent as owner and sibling as
+		// owner.
+
+		// Parent owns object
+		ptr = heap_allocate(&t, MALLOC_CAPABILITY, allocationSize);
+		TEST(Capability{ptr}.is_valid(), "Parent allocation failed");
+
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		AllocatorCapability child2 =
+		  split_quota(&t, MALLOC_CAPABILITY, splitSize);
+
+		void *ptr2 = heap_allocate(&t, child, allocationSize);
+
+		// Child claims sibling allocation
+		TEST_EQUAL(heap_claim(child2, ptr2),
+		           allocationSize,
+		           "Child failed to claim Parent object");
+		// Child claims parent allocation
+		TEST_EQUAL(heap_claim(child, ptr),
+		           allocationSize,
+		           "Child failed to claim Parent object");
+
+		// Recombine child with sibling claim
+		TEST_EQUAL(
+		  recombine_quota(child2, MALLOC_CAPABILITY), 0, "Recombine failed");
+
+		// Parent should hold claim with single reference on allocation.
+		TEST_EQUAL(
+		  heap_free(child, ptr2), 0, "Free on claimed allocation failed");
+		TEST(Capability{ptr2}.is_valid_temporal(),
+		     "Capability freed while claimed");
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr2),
+		           0,
+		           "Free on claimed allocation with no owner failed");
+
+		// Recombine child with parent claim
+		TEST_EQUAL(
+		  recombine_quota(child, MALLOC_CAPABILITY), 0, "Recombine failed");
+
+		// Parent should now hold claim with 2 references. Freeing twice
+		// should release both claims.
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr), 0, "Free 1 failed");
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr), 0, "Free 2 failed");
+
+		// If both parent and child claim the same object, the reference counts
+		// are summed on recombine.
+		ptr = heap_allocate(&t, MALLOC_CAPABILITY, allocationSize);
+		TEST(Capability{ptr}.is_valid(), "Parent allocation failed");
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+
+		TEST_EQUAL(heap_claim(MALLOC_CAPABILITY, ptr),
+		           allocationSize,
+		           "Parent failed to claim");
+		TEST_EQUAL(
+		  heap_claim(child, ptr), allocationSize, "Child failed to claim");
+
+		TEST_EQUAL(
+		  recombine_quota(child, MALLOC_CAPABILITY), 0, "Recombine failed");
+
+		// 1 (Parent Owner) + 1 (Parent Claim) + 1 (Child Claim) = 3 refs
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr), 0, "Free 1 failed");
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr), 0, "Free 2 failed");
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr), 0, "Free 3 failed");
+
+		// If child owns an object and parent has a claim, the ownership should
+		// be converted into an additional reference on the parent's claim.
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		ptr   = heap_allocate(&t, child, allocationSize);
+		TEST(Capability{ptr}.is_valid(), "Child allocation failed");
+
+		TEST_EQUAL(heap_claim(MALLOC_CAPABILITY, ptr),
+		           allocationSize,
+		           "Parent failed to claim child object");
+
+		TEST_EQUAL(
+		  recombine_quota(child, MALLOC_CAPABILITY), 0, "Recombine failed");
+
+		// Object is now owned by parent but parent already had a claim,
+		// which should result in parent owning it with an extra ref.
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr), 0, "Free 1 failed");
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr), 0, "Free 2 failed");
+
+		// Parent should only get back the "current" remaining quota of the
+		// child, not the "initial" split size, if there are active allocations.
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+
+		ptr = heap_allocate(&t, child, 1024);
+		TEST(Capability{ptr}.is_valid(), "Child allocation failed");
+
+		size_t childRemaining = heap_quota_remaining(child);
+		TEST(childRemaining < splitSize,
+		     "Quota for allocation was not deducted from child. Remaining: {}",
+		     childRemaining);
+		TEST_EQUAL(
+		  recombine_quota(child, MALLOC_CAPABILITY), 0, "Recombine failed");
+
+		size_t parentRemaining = heap_quota_remaining(MALLOC_CAPABILITY);
+		// ptr is still live and now owned by the parent, should count against
+		// quota
+		TEST(parentRemaining < initialQuota,
+		     "Parent quota change {} to {} did not reflect active child "
+		     "allocation",
+		     initialQuota,
+		     parentRemaining);
+
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr), 0, "Free failed");
+		TEST_EQUAL(heap_quota_remaining(MALLOC_CAPABILITY),
+		           initialQuota,
+		           "Full quota not recovered");
+
+		debug_log("Testing deeply nested sub quotas.");
+		// We should be able to arbitrarily nest sub quotas, and recombing
+		// should propagate ownership of allocations up to the top.
+		splitSize = allocationSize + (2 * sizeof(AllocatorCapabilityState));
+
+		quotas[0] = MALLOC_CAPABILITY;
+		ptrs[0]   = heap_allocate(&t, MALLOC_CAPABILITY, allocationSize);
+		TEST(Capability{ptrs[0]}.is_valid(), "Root allocation failed");
+
+		for (size_t i = 1; i < ArrSize; ++i)
+		{
+			quotas[i] =
+			  split_quota(&t, quotas[i - 1], (ArrSize - i) * splitSize);
+			TEST(Capability{quotas[i]}.is_valid_temporal(),
+			     "split failed at index {}",
+			     i);
+			ptrs[i] = heap_allocate(&t, quotas[i], allocationSize);
+			TEST(Capability{ptrs[i]}.is_valid_temporal(),
+			     "allocation failed at index {}",
+			     i);
+		}
+
+		// FIXME: volatile here as temporary fix for
+		// https://github.com/CHERIoT-Platform/llvm-project/issues/360
+		for (volatile size_t i = ArrSize - 1; i > 0; i = i - 1)
+		{
+			int result = recombine_quota(quotas[i], quotas[i - 1]);
+			TEST(result == 0,
+			     "Recombine failed at index {} with code {}",
+			     i,
+			     result);
+		}
+
+		for (size_t i = 0; i < ArrSize; ++i)
+		{
+			TEST(heap_free(MALLOC_CAPABILITY, ptrs[i]) == 0,
+			     "Free failed at index {}",
+			     i);
+		}
+
+		TEST_EQUAL(heap_quota_remaining(MALLOC_CAPABILITY),
+		           initialQuota,
+		           "Full quota not recovered");
+
+		debug_log("Testing quota free under dropped lock in allocation path.");
+
+		// Test transient allocation failure, quota freed while lock dropped
+		splitSize = allocationSize + (2 * sizeof(AllocatorCapabilityState));
+
+		child = split_quota(&t, MALLOC_CAPABILITY, splitSize);
+		TEST(Capability{child}.is_valid(),
+		     "Sub quota creation failed with error {}",
+		     reinterpret_cast<int>(child));
+
+		// Consume quota such that the next allocation will incur transient
+		// failure
+		ptr = heap_allocate(&t, child, allocationSize);
+		TEST(Capability{ptr}.is_valid(), "Initial child allocation failed");
+		TEST(static_cast<size_t>(heap_quota_remaining(child)) < allocationSize,
+		     "Child quota remaining should be less than allocationSize after "
+		     "first allocation.");
+
+		static cheriot::atomic<uint32_t> state = 0;
+
+		async([child]() {
+			// Wait until main thread is about to allocate.
+			state.wait(0);
+			// Sleep to ensure main thread is suspended on futex.
+			TEST(sleep(2) >= 0, "Failed to sleep");
+			// Recombine while the main thread has dropped the lock, which
+			// frees the underlying quota object. The free inside recombine
+			// notifies the futex the allocation is blocked on, which will
+			// wake the main thread.
+			TEST_EQUAL(recombine_quota(child, MALLOC_CAPABILITY),
+			           0,
+			           "recombine_quota failed in background thread");
+			// Flush quarantine to revoke the sub quota capability held on
+			// the main thread's stack before it can reacquire the lock.
+			TEST_SUCCESS(heap_quarantine_empty());
+			state = 2;
+			state.notify_one();
+		});
+
+		// Signal and immediately enter attempt allocation. Alloc size
+		// exceeds remaining child quota, so this call should drop the lock
+		// and block.
+		state = 1;
+		state.notify_one();
+		ErrorOr<void> result{heap_allocate(&t, child, allocationSize)};
+		TEST_EQUAL(result.as_error(),
+		           -EPERM,
+		           "Expected -EPERM when sub-quota freed during allocation");
+
+		// Wait for the background thread to finish before touching ptr.
+		state.wait(1);
+		TEST_EQUAL(heap_free(MALLOC_CAPABILITY, ptr),
+		           0,
+		           "Failed to free allocation transferred to parent");
+	}
 } // namespace
 
 /**
@@ -1541,6 +2001,8 @@ int test_allocator()
 	     quotaLeft);
 	test_claims();
 	test_permissions();
+	test_sub_quota_operations();
+	test_sub_quota_semantics();
 
 	TEST(heap_address_is_valid(&t) == false,
 	     "Stack object incorrectly reported as heap address");


### PR DESCRIPTION
MVP version of the sub quotas API, the design document for which can be seen at #669.

In particular, this implementation 1. Holds the allocator lock for the entire duration of a `recombine_quota`, and 2. cleaves the quota ID space in half naively, giving the top half to sub quotas, keeping the bottom for static quotas.

Addressing 1. should be done in tandem with `heap_free_all`, as they can rely on the same mechanism for dropping the lock mid-walk.

Addressing 2. can be done using #686 to compute the total number of static quotas and initializing a global in the allocator with this.