### PR TITLE
Add `volatile` qualifier in MMIO_CAPABILTY_WITH_PERMISSIONS macro

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -119,7 +119,7 @@
 	                                         permitLoadMutable,                \
 	                                         permitLoadGlobal)                 \
 		MMIO_CAPABILITY_WITH_PERMISSIONS_INNER(                                \
-		  type,                                                                \
+		  volatile type,                                                       \
 		  name,                                                                \
 		  permitLoad,                                                          \
 		  permitStore,                                                         \

--- a/tests/mmio-test.cc
+++ b/tests/mmio-test.cc
@@ -16,6 +16,11 @@ void check_permissions(Capability<volatile void> mmio, PermissionSet p)
 
 int test_mmio()
 {
+	// check that the returned pointer has the expected type. This serves a
+	// regression for https://github.com/CHERIoT-Platform/cheriot-rtos/pull/692
+	auto testType = MMIO_CAPABILITY(Uart, uart);
+	static_assert(std::is_same_v<decltype(testType), volatile Uart *>);
+
 #if !__has_attribute(cheriot_mmio)
 	// XXX No permissions; the compiler misinterprets this as all permissions!
 	// To mitigate this, we add a static assertion in the code this macro


### PR DESCRIPTION
As noted here: https://github.com/CHERIoT-Platform/cheriot-rtos/commit/2d7a16ba6972f86a22f90e9545d3b0860eae0e67#r183545095.