### PR TITLE
Strengthen static_asserts on MMIO capability permissions.

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -91,8 +91,7 @@
 	  cValue)                                                                  \
 		({                                                                     \
 			/* NOLINTBEGIN(bugprone-macro-parentheses) */                      \
-			_Static_assert(permitLoad || permitStore ||                        \
-			                 permitLoadStoreCapabilities || permitLoadMutable, \
+			_Static_assert(permitLoad || permitStore,                          \
 			               "Importing an MMIO capability with no permissions " \
 			               "is not allowed.");                                 \
 			_Pragma("GCC diagnostic push")                                     \
@@ -213,8 +212,7 @@
 		({                                                                     \
 			/* NOLINTBEGIN(bugprone-macro-parentheses) */                      \
 			_Static_assert(                                                    \
-			  permitLoad || permitStore || permitLoadStoreCapabilities ||      \
-			    permitLoadMutable,                                             \
+			  permitLoad || permitStore,                                       \
 			  "Importing a shared object capability with no permissions "      \
 			  "is not allowed.");                                              \
 			_Pragma("GCC diagnostic push")                                     \


### PR DESCRIPTION
During review of #692 I noticed that these static asserts do not make
sense: permitLoadStoreCapability is not permitted without either
permitLoad or PermitStore and permitLoadMutable is not permitted with
permitLoad and permitLoadStoreCapability. The previous assertions
would therefore pass incorrectly if one of the subordinate permissions
was requested without the required prerequisites. permitLoad or
permitStore is the minimum sensible set of permissions for an
MMIO_CAPABILITY so just check for this. We could extend the assertion
to check the dependencies of subordinate permissions but the compiler
checks this anyway.
