### PR TITLE
Remove memcpy from the loader.

### DIFF
--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -349,7 +349,7 @@ namespace
 	{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc99-designator"
-		constexpr SealingType Sentries[] = {
+		static constexpr const SealingType Sentries[] = {
 		  [static_cast<int>(InterruptStatus::Enabled)]   = SentryEnabling,
 		  [static_cast<int>(InterruptStatus::Disabled)]  = SentryDisabling,
 		  [static_cast<int>(InterruptStatus::Inherited)] = SentryInheriting};
@@ -1512,21 +1512,3 @@ extern "C" void loader_entry_point(SchedulerEntryInfo &ret,
 	ret.schedPCC = schedPCC;
 	ret.schedCGP = schedCGP;
 }
-
-/**
- * a dumb implementation, assuming no overlap and no capabilities
- */
-// NOLINTBEGIN(clang-analyzer-cheri.CapabilityCopy)
-void *memcpy(void *dst, const void *src, size_t n)
-{
-	char       *dst0 = static_cast<char *>(dst);
-	const char *src0 = static_cast<const char *>(src);
-
-	for (size_t i = 0; i < n; ++i)
-	{
-		dst0[i] = src0[i];
-	}
-
-	return dst0;
-}
-// NOLINTEND(clang-analyzer-cheri.CapabilityCopy)

--- a/sdk/core/loader/debug.hh
+++ b/sdk/core/loader/debug.hh
@@ -147,7 +147,7 @@ namespace
 				s = 0 - s;
 			}
 			std::array<char, 10> buf;
-			const char           Digits[] = "0123456789";
+			static const char    Digits[] = "0123456789";
 			for (int i = static_cast<int>(buf.size() - 1); i >= 0; i--)
 			{
 				buf.at(static_cast<size_t>(i)) = Digits[s % 10];
@@ -175,7 +175,7 @@ namespace
 		__attribute__((noinline)) void append_hex_word(uint32_t s)
 		{
 			std::array<char, 8> buf;
-			const char          Hexdigits[] = "0123456789abcdef";
+			static const char   Hexdigits[] = "0123456789abcdef";
 			// Length of string including null terminator
 			static_assert(sizeof(Hexdigits) == 0x11);
 			for (long i = static_cast<long>(buf.size() - 1); i >= 0; i--)


### PR DESCRIPTION
To date, every use of memcpy in the loader has been a bug.  There was one left (actually two after inlining) and it was a bug.  And then, in debug builds, there were two more instances of the same bug.

Fix the bug (in all three places) and now we don't need it.