### PR TITLE
Explicitly drop .note.cheriot.compartment-name sections in the final ELF.

### DIFF
--- a/sdk/firmware.ldscript.in
+++ b/sdk/firmware.ldscript.in
@@ -15,4 +15,8 @@ SECTIONS
 {
 	# The build system generates sections and assigns them within its PHDRs.
 	@ldscript_top_sections@
+
+	/DISCARD/ : {
+    	*(.note.cheriot.compartment-name)
+	}
 }


### PR DESCRIPTION
These notes are per-compartment, so propagating them into the final ELF doesn't result in anything meaningful. This change is backwards compatible even if the compiler is not emitting .note.cheriot.compartment-name sections.
