### PR TITLE
sonata: fix PcIntModeBits definition in SonataGpioBase

### DIFF
--- a/sdk/include/platform/sunburst/platform-gpio.hh
+++ b/sdk/include/platform/sunburst/platform-gpio.hh
@@ -69,8 +69,10 @@ struct SonataGpioBase : private utils::NoCopyNoMove
 	{
 		/// Pin-change interrupt mode.
 		/// See PcIntMode enums.
-		PcIntModeSelect = PcIntModeBits << 0,
-		/// Select between the raw (0) and debounced input (1).
+		PcIntModeSelect =
+		  PcIntModeBits
+		  << 0, // NOLINT(clang-diagnostic-flag-enum)
+		        /// Select between the raw (0) and debounced input (1).
 		PcIntInputSelect = 1U << 3,
 		/// Enable the pin-change interrupt instance-wide.
 		PcIntEnable = 1U << 31,

--- a/sdk/include/platform/sunburst/platform-gpio.hh
+++ b/sdk/include/platform/sunburst/platform-gpio.hh
@@ -63,7 +63,7 @@ struct SonataGpioBase : private utils::NoCopyNoMove
 		LowLevel    = 3,
 	};
 
-	static constexpr uint32_t PcIntModeBits = 2;
+	static constexpr uint32_t PcIntModeBits = 0b11;
 	/// Status Register Fields
 	enum [[clang::flag_enum]] : uint32_t
 	{


### PR DESCRIPTION
This PR fixes an incorrect definition of the pin-change interrupt mode bitmask.