### PR TITLE
Initial work on generalising timeouts.

### DIFF
--- a/examples/06.producer-consumer/xmake.lua
+++ b/examples/06.producer-consumer/xmake.lua
@@ -20,6 +20,9 @@ firmware("producer-consumer")
     -- Both compartments need memcpy and the message queue compartment.
     add_deps("freestanding", "message_queue", "debug")
     add_deps("producer", "consumer")
+    -- Note that the stacks here are larger than they need to be in a release
+    -- build, but if scheduler debugging is enabled then the log messages use
+    -- quite a lot of stack and so we run out.
     on_load(function(target)
         target:values_set("threads", {
             {
@@ -33,7 +36,7 @@ firmware("producer-consumer")
                 compartment = "consumer",
                 priority = 1,
                 entry_point = "run",
-                stack_size = 0x400,
+                stack_size = 0x500,
                 trusted_stack_frames = 3
             }
         }, {expand = false})

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -165,18 +165,6 @@ namespace
 	cheriot::atomic<int32_t> freeFutex = -1;
 
 	/**
-	 * Helper that returns true if the timeout value permits sleeping.
-	 *
-	 * This assumes that the pointer was checked with `check_pointer` earlier
-	 * but defends against the case where the timeout object was freed by
-	 * another thread while the thread using it slept.
-	 */
-	bool may_block(Timeout *timeout)
-	{
-		return timeout->may_block();
-	}
-
-	/**
 	 * Helper to reacquire the lock after sleeping.  This adds any time passed
 	 * as `elapsed` to the timeout and then tries to reacquire the lock,
 	 * blocking for no longer than the remaining time on this timeout.
@@ -184,11 +172,11 @@ namespace
 	 * Returns `true` if the lock has been successfully reacquired, `false`
 	 * otherwise.
 	 */
-	bool reacquire_lock(Timeout                   *timeout,
+	bool reacquire_lock(TimeoutArgument            timeout,
 	                    LockGuard<decltype(lock)> &g,
 	                    Ticks                      elapsed = 0)
 	{
-		timeout->elapse(elapsed);
+		timeout.elapse(elapsed);
 		return g.try_lock(timeout);
 	}
 
@@ -203,7 +191,7 @@ namespace
 	 *
 	 */
 	template<typename T = Revocation::Revoker>
-	bool wait_for_background_revoker(Timeout                   *timeout,
+	bool wait_for_background_revoker(TimeoutArgument            timeout,
 	                                 uint32_t                   epoch,
 	                                 LockGuard<decltype(lock)> &g,
 	                                 T                         &r = revoker)
@@ -229,7 +217,7 @@ namespace
 	 *
 	 */
 	template<typename T = Revocation::Revoker>
-	bool wait_for_background_revoker(Timeout                   *timeout,
+	bool wait_for_background_revoker(TimeoutArgument            timeout,
 	                                 uint32_t                   epoch,
 	                                 LockGuard<decltype(lock)> &g,
 	                                 T                         &r = revoker)
@@ -284,7 +272,7 @@ namespace
 	ErrorOr<void> malloc_internal(size_t                           bytes,
 	                              LockGuard<decltype(lock)>      &&g,
 	                              PrivateAllocatorCapabilityState *capability,
-	                              Timeout                         *timeout,
+	                              TimeoutArgument                  timeout,
 	                              bool     isSealedAllocation = false,
 	                              uint32_t flags              = AllocateWaitAny)
 	{
@@ -322,7 +310,7 @@ namespace
 					return -EAGAIN;
 				}
 
-				if (!may_block(timeout))
+				if (!timeout.may_block())
 				{
 					return -ETIMEDOUT;
 				}
@@ -387,12 +375,16 @@ namespace
 				// If there are things on the hazard list, wake after one tick
 				// and see if they have gone away.  Otherwise, wait until we
 				// have some newly freed objects.
-				Timeout t{gm->hazard_quarantine_is_empty() ? timeout->remaining
-				                                           : 1};
+				Timeout         oneTick(1);
+				TimeoutArgument t = &oneTick;
+				if (gm->hazard_quarantine_is_empty())
+				{
+					t = timeout;
+				}
 				// Drop the lock while yielding
 				g.unlock();
-				freeFutex.wait(&t, expected);
-				timeout->elapse(t.elapsed);
+				freeFutex.wait(t, expected);
+				timeout.elapse_from(oneTick);
 				Debug::log("Woke from futex wake");
 				if (!reacquire_lock(timeout, g))
 				{
@@ -401,7 +393,7 @@ namespace
 				}
 				continue;
 			}
-		} while (may_block(timeout));
+		} while (timeout.may_block());
 		// Exhausted the timeout period while retrying the allocation.
 		return -ETIMEDOUT;
 	}
@@ -905,10 +897,12 @@ namespace
 
 } // namespace
 
-__cheriot_minimum_stack(0xa0) ssize_t
+__cheriot_minimum_stack(0xb0) ssize_t
   heap_quota_remaining(AllocatorCapability heapCapability)
 {
-	STACK_CHECK(0xa0);
+	// Note: This can likely be reduced if CHERIoT-Platform/llvm-project#398 is
+	// fixed or has a work around.
+	STACK_CHECK(0xb0);
 	LockGuard g{lock};
 	// Querying quota is always allowed
 	auto *cap = malloc_capability_unseal(heapCapability, AllocatorPermitNone);
@@ -919,11 +913,11 @@ __cheriot_minimum_stack(0xa0) ssize_t
 	return cap->quota;
 }
 
-__cheriot_minimum_stack(0xe0) int heap_quarantine_flush(Timeout *timeout)
+__cheriot_minimum_stack(0xe0) int heap_quarantine_flush(TimeoutArgument timeout)
 {
 	STACK_CHECK(0xe0);
 
-	if (!check_timeout_pointer(timeout))
+	if (!timeout.is_valid())
 	{
 		return -EINVAL;
 	}
@@ -968,13 +962,13 @@ __cheriot_minimum_stack(0xe0) int heap_quarantine_flush(Timeout *timeout)
 }
 
 __cheriot_minimum_stack(0x220) void *heap_allocate(
-  Timeout            *timeout,
+  TimeoutArgument     timeout,
   AllocatorCapability heapCapability,
   size_t              bytes,
   uint32_t            flags)
 {
 	STACK_CHECK(0x220);
-	if (!check_timeout_pointer(timeout))
+	if (!timeout.is_valid())
 	{
 		return reinterpret_cast<void *>(-EINVAL);
 	}
@@ -1116,14 +1110,14 @@ __cheriot_minimum_stack(0x1a0) ssize_t
 }
 
 __cheriot_minimum_stack(0x230) void *heap_allocate_array(
-  Timeout            *timeout,
+  TimeoutArgument     timeout,
   AllocatorCapability heapCapability,
   size_t              nElements,
   size_t              elemSize,
   uint32_t            flags)
 {
 	STACK_CHECK(0x230);
-	if (!check_timeout_pointer(timeout))
+	if (!timeout.is_valid())
 	{
 		return reinterpret_cast<void *>(-EINVAL);
 	}
@@ -1169,13 +1163,13 @@ namespace
 	 * all of the permissions in `permissions`.
 	 */
 	std::pair<SealedTokenHandle, TokenHandle<false>>
-	  __noinline allocate_sealed_unsealed(Timeout            *timeout,
+	  __noinline allocate_sealed_unsealed(TimeoutArgument     timeout,
 	                                      AllocatorCapability heapCapability,
 	                                      SealingKey          key,
 	                                      size_t              requestedSize,
 	                                      PermissionSet       permissions)
 	{
-		if (!check_timeout_pointer(timeout))
+		if (!timeout.is_valid())
 		{
 			return {nullptr, nullptr};
 		}
@@ -1304,14 +1298,14 @@ TokenKey token_key_new()
 }
 
 __cheriot_minimum_stack(0x290) CHERI_SEALED(void *)
-  token_sealed_unsealed_alloc(Timeout            *timeout,
+  token_sealed_unsealed_alloc(TimeoutArgument     timeout,
                               AllocatorCapability heapCapability,
                               TokenKey            key,
                               size_t              sz,
                               void              **unsealed)
 {
 	STACK_CHECK(0x290);
-	if (!check_timeout_pointer(timeout))
+	if (!timeout.is_valid())
 	{
 		return nullptr;
 	}
@@ -1339,7 +1333,7 @@ __cheriot_minimum_stack(0x290) CHERI_SEALED(void *)
 }
 
 __cheriot_minimum_stack(0x260) CHERI_SEALED(void *)
-  token_sealed_alloc(Timeout            *timeout,
+  token_sealed_alloc(TimeoutArgument     timeout,
                      AllocatorCapability heapCapability,
                      TokenKey            rawKey,
                      size_t              sz)

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -475,12 +475,15 @@ SystickReturn __cheri_compartment("scheduler") thread_systemtick_get()
 	return ret;
 }
 
-__cheriot_minimum_stack(0x90) int __cheri_compartment("scheduler")
-  thread_sleep(Timeout *timeout, uint32_t flags)
+__cheriot_minimum_stack(0xa0) int __cheri_compartment("scheduler")
+  thread_sleep(TimeoutArgument timeout, uint32_t flags)
 {
-	STACK_CHECK(0x90);
-	if (!check_timeout_pointer(timeout))
+	// Note: This can likely be reduced if CHERIoT-Platform/llvm-project#398 is
+	// fixed or has a work around.
+	STACK_CHECK(0xa0);
+	if (!timeout.is_valid())
 	{
+		Debug::log("Invalid timeout: {}", timeout);
 		return -EINVAL;
 	}
 	// Debug::log("Thread {} sleeping for {} ticks",
@@ -490,14 +493,16 @@ __cheriot_minimum_stack(0x90) int __cheri_compartment("scheduler")
 	return 0;
 }
 
-__cheriot_minimum_stack(0xb0) int futex_timed_wait(
-  Timeout                 *timeout,
+__cheriot_minimum_stack(0xd0) int futex_timed_wait(
+  TimeoutArgument          timeout,
   const volatile uint32_t *address,
   uint32_t                 expected,
   uint32_t                 flags)
 {
-	STACK_CHECK(0xb0);
-	if (!check_timeout_pointer(timeout) ||
+	// Note: This can likely be reduced if CHERIoT-Platform/llvm-project#398 is
+	// fixed or has a work around.
+	STACK_CHECK(0xd0);
+	if (!timeout.is_valid() ||
 	    !check_pointer<PermissionSet{Permission::Load}>(address))
 	{
 		Debug::log("futex_timed_wait: invalid timeout or address");
@@ -515,7 +520,7 @@ __cheriot_minimum_stack(0xb0) int futex_timed_wait(
 	Debug::log("Thread {} waiting on futex {} for {} ticks",
 	           currentThread->id_get(),
 	           key,
-	           timeout->remaining);
+	           timeout);
 	bool isPriorityInheriting              = flags & FutexPriorityInheritance;
 	currentThread->futexWaitAddress        = key;
 	currentThread->futexPriorityInheriting = isPriorityInheriting;
@@ -651,7 +656,7 @@ __cheriot_minimum_stack(0xd0) int futex_wake(const volatile uint32_t *address,
 #if SCHEDULER_MULTIWAITER != false
 
 __cheriot_minimum_stack(0x60) int multiwaiter_create(
-  Timeout            *timeout,
+  TimeoutArgument     timeout,
   AllocatorCapability heapCapability,
   MultiWaiter        *ret,
   size_t              maxItems)
@@ -683,7 +688,7 @@ __cheriot_minimum_stack(0x90) int multiwaiter_delete(
 	return deallocate<MultiWaiterInternal>(heapCapability, mw);
 }
 
-__cheriot_minimum_stack(0xc0) int multiwaiter_wait(Timeout           *timeout,
+__cheriot_minimum_stack(0xc0) int multiwaiter_wait(TimeoutArgument    timeout,
                                                    MultiWaiter        waiter,
                                                    EventWaiterSource *events,
                                                    size_t newEventsCount)
@@ -705,7 +710,7 @@ __cheriot_minimum_stack(0xc0) int multiwaiter_wait(Timeout           *timeout,
 			Debug::log("Invalid new events pointer: {}", events);
 			return -EINVAL;
 		}
-		if (!check_timeout_pointer(timeout))
+		if (!timeout.is_valid())
 		{
 			return -EINVAL;
 		}
@@ -720,8 +725,8 @@ __cheriot_minimum_stack(0xc0) int multiwaiter_wait(Timeout           *timeout,
 				Debug::log("Adding events returned error");
 				return -EINVAL;
 			case MultiWaiterInternal::EventOperationResult::Sleep:
-				Debug::log("Sleeping for {} ticks", timeout->remaining);
-				if (timeout->may_block())
+				Debug::log("Sleeping for {} ticks", timeout);
+				if (timeout.may_block())
 				{
 					mw.wait(timeout);
 					// If we yielded then it's possible for either of the

--- a/sdk/core/scheduler/multiwait.h
+++ b/sdk/core/scheduler/multiwait.h
@@ -180,7 +180,7 @@ class MultiWaiterInternal : public Handle</*IsDynamic*/ true>
 	 * The result is a *sealed* multiwaiter handle.
 	 */
 	static CHERI_SEALED(MultiWaiterInternal *)
-	  create(Timeout            *timeout,
+	  create(TimeoutArgument     timeout,
 	         AllocatorCapability heapCapability,
 	         size_t              length,
 	         int                &error)
@@ -317,7 +317,7 @@ class MultiWaiterInternal : public Handle</*IsDynamic*/ true>
 	 * Wait on this multi-waiter object until either the timeout expires or
 	 * one or more events have fired.
 	 */
-	void wait(Timeout *timeout)
+	void wait(TimeoutArgument timeout)
 	{
 		Thread *currentThread      = Thread::current_get();
 		currentThread->multiWaiter = this;

--- a/sdk/core/scheduler/thread.h
+++ b/sdk/core/scheduler/thread.h
@@ -158,28 +158,22 @@ namespace
 		 *
 		 * Returns true on timeout, false otherwise.
 		 */
-		bool suspend(Timeout     *t,
-		             ThreadImpl **newSleepQueue,
-		             bool         yieldUnconditionally = false,
-		             bool         yieldNotSleep        = false)
+		bool suspend(TimeoutArgument t,
+		             ThreadImpl    **newSleepQueue,
+		             bool            yieldUnconditionally = false,
+		             bool            yieldNotSleep        = false)
 		{
-			if (t->remaining != 0)
+			bool mayBlock = t.may_block();
+			if (mayBlock)
 			{
-				suspend(t->remaining, newSleepQueue, yieldNotSleep);
+				suspend_internal(t, newSleepQueue, yieldNotSleep);
 			}
-			if ((t->remaining != 0) || yieldUnconditionally)
+			if (yieldUnconditionally || mayBlock)
 			{
 				auto elapsed = yield_timed();
-				if (CHERI::Capability{t}.is_valid())
-				{
-					t->elapse(elapsed);
-					if (t->remaining > 0)
-					{
-						return false;
-					}
-				}
+				t.elapse(elapsed);
 			}
-			return true;
+			return !t.may_block();
 		}
 
 		/**
@@ -216,8 +210,6 @@ namespace
 		 */
 		void ready(WakeReason reason)
 		{
-			int64_t ticksLeft;
-
 			// We must be suspended.
 			Debug::Assert(state == ThreadState::Suspended,
 			              "Waking thread that is in state {}, not suspended",
@@ -278,32 +270,6 @@ namespace
 				visitor(thread);
 				thread = next;
 			}
-		}
-
-		/**
-		 * Suspend this thread. Take it off the ready list. If it is suspended
-		 * waiting on a resource, add it to the list of that resource. No
-		 * matter what, it has to be added to the timer list.
-		 */
-		void suspend(uint32_t     waitTicks,
-		             ThreadImpl **newSleepQueue,
-		             bool         yieldNotSleep = false)
-		{
-			isYielding = yieldNotSleep;
-			Debug::Assert(state == ThreadState::Ready,
-			              "Suspending thread that is in state {}, not ready",
-			              static_cast<ThreadState>(state));
-			list_remove(&priorityList[priority]);
-			state = ThreadState::Suspended;
-			priority_map_remove();
-			if (newSleepQueue != nullptr)
-			{
-				list_insert(newSleepQueue);
-				sleepQueue = newSleepQueue;
-			}
-			expiryTime = expiry_time_for_timeout(waitTicks);
-
-			timer_list_insert(&waitingList);
 		}
 
 		/**
@@ -624,6 +590,41 @@ namespace
 		CHERI_SEALED(TrustedStack *) tStackPtr;
 
 		private:
+		/**
+		 * Suspend this thread. Take it off the ready list. If it is suspended
+		 * waiting on a resource, add it to the list of that resource. No
+		 * matter what, it has to be added to the timer list.
+		 */
+		void suspend_internal(TimeoutArgument timeout,
+		                      ThreadImpl    **newSleepQueue,
+		                      bool            yieldNotSleep = false)
+		{
+			isYielding = yieldNotSleep;
+			Debug::Assert(state == ThreadState::Ready,
+			              "Suspending thread that is in state {}, not ready",
+			              static_cast<ThreadState>(state));
+			list_remove(&priorityList[priority]);
+			state = ThreadState::Suspended;
+			priority_map_remove();
+			if (newSleepQueue != nullptr)
+			{
+				list_insert(newSleepQueue);
+				sleepQueue = newSleepQueue;
+			}
+			if (timeout.is_relative())
+			{
+				expiryTime =
+				  expiry_time_for_timeout(timeout.relativeTimeout->remaining);
+			}
+			else
+			{
+				expiryTime = timeout.absoluteTimeout;
+			}
+			Debug::log("Sleeping until {}", expiryTime);
+
+			timer_list_insert(&waitingList);
+		}
+
 		/**
 		 * Helper to remove a thread from the priority map and update the
 		 * highest priority, if it was the last runnable thread at that

--- a/sdk/include/allocator.h
+++ b/sdk/include/allocator.h
@@ -11,7 +11,6 @@
 #include <cdefs.h>
 #include <riscvreg.h>
 #include <stddef.h>
-#include <stdint.h>
 #include <timeout.h>
 #include <token.h>
 
@@ -113,14 +112,14 @@ ssize_t __cheri_compartment("allocator")
  * This function is provided by the `compartment_helpers` library, which must be
  * linked for it to be available.
  */
-int __cheri_libcall heap_claim_ephemeral(Timeout         *timeout,
+int __cheri_libcall heap_claim_ephemeral(TimeoutArgument  timeout,
                                          const void      *ptr,
                                          const void *ptr2 __if_cxx(= nullptr));
 
 __attribute__((deprecated("heap_claim_fast was a bad name.  This function has "
                           "been renamed heap_claim_ephemeral")))
 __always_inline static int
-heap_claim_fast(Timeout         *timeout,
+heap_claim_fast(TimeoutArgument  timeout,
                 const void      *ptr,
                 const void *ptr2 __if_cxx(= nullptr))
 {
@@ -181,7 +180,7 @@ ssize_t __cheri_compartment("allocator")
  * not valid.
  */
 __attribute__((overloadable)) int __cheri_compartment("allocator")
-  heap_quarantine_flush(Timeout *timeout);
+  heap_quarantine_flush(TimeoutArgument timeout);
 
 /**
  * Run `heap_quarantine_flush` with unlimited timeout.
@@ -191,8 +190,7 @@ __attribute__((overloadable)) int __cheri_compartment("allocator")
  */
 static int heap_quarantine_empty()
 {
-	Timeout t = {0, UnlimitedTimeout};
-	return heap_quarantine_flush(&t);
+	return heap_quarantine_flush(TimeoutWaitForever);
 }
 
 /**

--- a/sdk/include/c++-config/atomic
+++ b/sdk/include/c++-config/atomic
@@ -257,10 +257,10 @@ __clang_ignored_warning_push("-Watomic-alignment") namespace std
 			}
 
 			__always_inline int
-			wait(Timeout       *timeout,
-			     T              old,
-			     memory_order   order = memory_order::seq_cst,
-			     FutexWaitFlags flags = FutexNone) const noexcept
+			wait(TimeoutArgument timeout,
+			     T               old,
+			     memory_order    order = memory_order::seq_cst,
+			     FutexWaitFlags  flags = FutexNone) const noexcept
 			    requires(sizeof(T) == sizeof(uint32_t))
 			{
 				// FIXME: The (1<<5) here should be
@@ -274,8 +274,9 @@ __clang_ignored_warning_push("-Watomic-alignment") namespace std
 				  flags);
 			}
 
-			__always_inline int
-			wait(Timeout *timeout, T old, FutexWaitFlags flags) const noexcept
+			__always_inline int wait(TimeoutArgument timeout,
+			                         T               old,
+			                         FutexWaitFlags  flags) const noexcept
 			    requires(sizeof(T) == sizeof(uint32_t))
 			{
 				return wait(timeout, old, memory_order::seq_cst, flags);

--- a/sdk/include/cheri.h
+++ b/sdk/include/cheri.h
@@ -382,10 +382,3 @@ bool __cheri_libcall check_pointer(const volatile void *ptr,
                                    size_t               space,
                                    uint32_t             rawPermissions,
                                    bool                 checkStackNeeded);
-
-/**
- * Check that the argument is a valid pointer to a `Timeout` structure.  This
- * must have read/write permissions, be unsealed, and must not be a heap
- * address.
- */
-bool __cheri_libcall check_timeout_pointer(const struct Timeout *timeout);

--- a/sdk/include/debug.hh
+++ b/sdk/include/debug.hh
@@ -9,6 +9,7 @@
 #include <platform-uart.hh>
 #include <string.h>
 #include <switcher.h>
+#include <timeout.h>
 
 #include <string_view>
 #include <type_traits>
@@ -385,6 +386,42 @@ struct DebugFormatArgumentAdaptor<T>
 		return {static_cast<uintptr_t>(value),
 		        reinterpret_cast<uintptr_t>(&debug_enum_helper<T>)};
 #endif
+	}
+};
+
+/**
+ * Helper for printing timeouts.
+ */
+template<>
+struct DebugFormatArgumentAdaptor<TimeoutArgument>
+{
+	__always_inline static DebugFormatArgument construct(TimeoutArgument value)
+	{
+		uintptr_t v;
+		static_assert(sizeof(v) == sizeof(value));
+		memcpy(&v, &value, sizeof(v));
+		return {v, reinterpret_cast<uintptr_t>(&print)};
+	}
+
+	private:
+	static void print(uintptr_t value, DebugWriter &writer)
+	{
+		TimeoutArgument t(0ULL);
+		static_assert(sizeof(t) == sizeof(value));
+		memcpy(&t, &value, sizeof(t));
+		if (t.is_relative())
+		{
+			writer.write("{ elapsed: ");
+			writer.write(t.relativeTimeout->elapsed);
+			writer.write(", remaining: ");
+			writer.write(t.relativeTimeout->remaining);
+			writer.write(" }");
+		}
+		else
+		{
+			writer.write(t.absoluteTimeout);
+			writer.write(" cycles");
+		}
 	}
 };
 

--- a/sdk/include/futex.h
+++ b/sdk/include/futex.h
@@ -42,7 +42,7 @@ enum [[clang::flag_enum]] FutexWaitFlags
  *  - `-ETIMEDOUT` if the timeout expires.
  */
 [[cheriot::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
-  futex_timed_wait(Timeout                 *ticks,
+  futex_timed_wait(TimeoutArgument          timeout,
                    const volatile uint32_t *address,
                    uint32_t                 expected,
                    uint32_t flags           __if_cxx(= FutexNone));
@@ -59,8 +59,7 @@ enum [[clang::flag_enum]] FutexWaitFlags
 __always_inline static int futex_wait(const volatile uint32_t *address,
                                       uint32_t                 expected)
 {
-	Timeout t = {0, UnlimitedTimeout};
-	return futex_timed_wait(&t, address, expected, FutexNone);
+	return futex_timed_wait(TimeoutWaitForever, address, expected, FutexNone);
 }
 
 /**

--- a/sdk/include/locks.h
+++ b/sdk/include/locks.h
@@ -142,7 +142,7 @@ __BEGIN_DECLS
  * Returns 0 on success, -ETIMEDOUT if the timeout expired, -EINVAL if the
  * arguments are invalid, or -ENOENT if the lock is set in destruction mode.
  */
-int __cheri_libcall flaglock_trylock(Timeout              *timeout,
+int __cheri_libcall flaglock_trylock(TimeoutArgument       timeout,
                                      struct FlagLockState *lock);
 
 /**
@@ -164,7 +164,7 @@ int __cheri_libcall flaglock_trylock(Timeout              *timeout,
  * ensure that the object remains live until after the call.
  */
 int __cheri_libcall
-flaglock_priority_inheriting_trylock(Timeout              *timeout,
+flaglock_priority_inheriting_trylock(TimeoutArgument       timeout,
                                      struct FlagLockState *lock);
 
 /**
@@ -248,7 +248,7 @@ flaglock_priority_inheriting_get_owner_thread_id(struct FlagLockState *lock)
  * arguments are invalid.  Can also return -EOVERFLOW if the lock depth would
  * overflow the depth counter.
  */
-int __cheri_libcall recursivemutex_trylock(Timeout                    *timeout,
+int __cheri_libcall recursivemutex_trylock(TimeoutArgument             timeout,
                                            struct RecursiveMutexState *lock);
 
 /**
@@ -277,7 +277,7 @@ void __cheri_libcall ticketlock_unlock(struct TicketLockState *lock);
  * success, -ETIMEDOUT if the timeout expired.  Can also return -EINVAL if the
  * arguments are invalid.
  */
-int __cheri_libcall semaphore_get(Timeout                       *timeout,
+int __cheri_libcall semaphore_get(TimeoutArgument                timeout,
                                   struct CountingSemaphoreState *semaphore);
 /**
  * Semaphore put operation.  Returns 0 on success, -EINVAL if this would push
@@ -296,7 +296,7 @@ int __cheri_libcall semaphore_put(struct CountingSemaphoreState *semaphore);
  *
  * Other errors may be propagated from `futex_timed_wait` if they fail.
  */
-int __cheriot_libcall barrier_timed_wait(Timeout             *timeout,
+int __cheriot_libcall barrier_timed_wait(TimeoutArgument      timeout,
                                          struct BarrierState *barrier);
 
 /**
@@ -346,10 +346,10 @@ condition_variable_notify(struct ConditionVariableState *conditionVariable,
  * thread calling `condition_variable_wait` will sleep forever.
  */
 int __cheriot_libcall
-condition_variable_wait(Timeout                       *t,
+condition_variable_wait(TimeoutArgument                t,
                         struct ConditionVariableState *conditionVariable,
                         void                          *mutex,
-                        int (*mutexLock)(Timeout *, void *),
+                        int (*mutexLock)(TimeoutArgument, void *),
                         int (*mutexUnlock)(void *));
 
 __always_inline static inline int run_once(struct OnceState *state,

--- a/sdk/include/locks.hh
+++ b/sdk/include/locks.hh
@@ -53,7 +53,7 @@ class FlagLockGeneric
 	 *
 	 * Returns an errno value.
 	 */
-	__always_inline int try_lock_internal(Timeout *timeout)
+	__always_inline int try_lock_internal(TimeoutArgument timeout)
 	{
 		if constexpr (IsPriorityInherited)
 		{
@@ -73,7 +73,7 @@ class FlagLockGeneric
 	 * Returns `true` if and only if the lock transitioned from being unheld to
 	 * held by the current thread.
 	 */
-	__always_inline bool try_lock(Timeout *timeout)
+	__always_inline bool try_lock(TimeoutArgument timeout)
 	{
 		return try_lock_internal(timeout) == 0;
 	}
@@ -162,7 +162,7 @@ class RecursiveMutex
 	 * Attempt to acquire the lock, blocking until a timeout specified by the
 	 * `timeout` parameter has expired.
 	 */
-	__always_inline bool try_lock(Timeout *timeout)
+	__always_inline bool try_lock(TimeoutArgument timeout)
 	{
 		return recursivemutex_trylock(timeout, &state) == 0;
 	}
@@ -247,7 +247,7 @@ class NoLock
 	/**
 	 * Attempt to acquire the lock with a timeout.  Always succeeds.
 	 */
-	bool try_lock(Timeout *timeout)
+	bool try_lock(TimeoutArgument timeout)
 	{
 		return true;
 	}
@@ -281,7 +281,7 @@ concept Lockable = requires(T l) {
 };
 
 template<typename T>
-concept TryLockable = Lockable<T> && requires(T l, Timeout *t) {
+concept TryLockable = Lockable<T> && requires(T l, TimeoutArgument t) {
 	{ l.try_lock(t) } -> std::same_as<bool>;
 };
 
@@ -325,7 +325,7 @@ class LockGuard
 	 *
 	 * The lock to be wrapped must not be held by the calling thread on entry.
 	 */
-	[[nodiscard]] explicit LockGuard(Lock &lock, Timeout *timeout)
+	[[nodiscard]] explicit LockGuard(Lock &lock, TimeoutArgument timeout)
 	    requires(TryLockable<Lock>)
 	  : wrappedLock(&lock), isOwned(false)
 	{
@@ -385,7 +385,7 @@ class LockGuard
 	 * The wrapped lock must not be held by the calling thread on entry.
 	 * Returns true if the lock has been acquired, false otherwise.
 	 */
-	bool try_lock(Timeout *timeout)
+	bool try_lock(TimeoutArgument timeout)
 	    requires(TryLockable<Lock>)
 	{
 		LockDebug::Assert(!isOwned, "Trying to lock an already-locked lock");
@@ -427,7 +427,7 @@ class LockGuard
 	/**
 	 * Drop and reacquire the lock around a yield
 	 */
-	int yield(Timeout *t, uint32_t ticks = 1)
+	int yield(TimeoutArgument t, uint32_t ticks = 1)
 	{
 		unlock();
 
@@ -437,7 +437,7 @@ class LockGuard
 			return sleepRes;
 		}
 
-		t->elapse(smallSleep.elapsed);
+		t.elapse_from(smallSleep);
 
 		return try_lock(t);
 	}
@@ -478,9 +478,9 @@ class ConditionVariable
 	 * failed due to a timeout.
 	 */
 	template<TryLockable Mutex>
-	int wait(Timeout *t, Mutex &mutex)
+	int wait(TimeoutArgument t, Mutex &mutex)
 	{
-		auto lock = [](Timeout *t, void *m) {
+		auto lock = [](TimeoutArgument t, void *m) {
 			return static_cast<Mutex *>(m)->try_lock(t) ? 0 : -ETIMEDOUT;
 		};
 		auto unlock = [](void *m) {
@@ -499,10 +499,10 @@ class ConditionVariable
 	 * fail in the same ways as the normal overload.
 	 */
 	template<Lockable Mutex>
-	int wait(Timeout *t, Mutex &mutex)
+	int wait(TimeoutArgument t, Mutex &mutex)
 	    requires(!TryLockable<Mutex>)
 	{
-		auto lock = [](Timeout *t, void *m) {
+		auto lock = [](TimeoutArgument t, void *m) {
 			static_cast<Mutex *>(m)->lock();
 			return 0;
 		};

--- a/sdk/include/multiwaiter.h
+++ b/sdk/include/multiwaiter.h
@@ -72,7 +72,7 @@ typedef CHERI_SEALED(struct MultiWaiterInternal *) MultiWaiter;
  * most `maxItems` event sources.
  */
 [[cheriot::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
-  multiwaiter_create(Timeout            *timeout,
+  multiwaiter_create(TimeoutArgument     timeout,
                      AllocatorCapability heapCapability,
                      MultiWaiter        *ret,
                      size_t              maxItems);
@@ -96,7 +96,7 @@ typedef CHERI_SEALED(struct MultiWaiterInternal *) MultiWaiter;
  *    returns `-ETIMEDOUT`.
  */
 [[cheriot::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
-  multiwaiter_wait(Timeout                  *timeout,
+  multiwaiter_wait(TimeoutArgument           timeout,
                    MultiWaiter               waiter,
                    struct EventWaiterSource *events,
                    size_t                    newEventsCount);

--- a/sdk/include/platform/generic-riscv/platform-time.h
+++ b/sdk/include/platform/generic-riscv/platform-time.h
@@ -1,0 +1,71 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include <cdefs.h>
+#include <stdint.h>
+
+/**
+ * @file `platform-time.h` defines the interface for the timer that is used to
+ * implement a monotonic clock.  This is the generic implementation that
+ * assumes that the time value is exposed via a CSR.  If your board exposes
+ * this via an MMIO region then it must provide a different implementation.
+ */
+
+/**
+ * `CHERIOT_PLATFORM_TIME_HIGH` is a macro that can be defined by platform
+ * headers that include this via `#include_next`.  This defines the name for
+ * the CSR that provides the top 32 bits of a 64-bit counter.
+ */
+#ifndef CHERIOT_PLATFORM_TIME_HIGH
+#	define CHERIOT_PLATFORM_TIME_HIGH mcycleh
+#endif
+
+/**
+ * `CHERIOT_PLATFORM_TIME_LOW` is a macro that can be defined by platform
+ * headers that include this via `#include_next`.  This defines the name for
+ * the CSR that provides the top 32 bits of a 64-bit counter.
+ */
+#ifndef CHERIOT_PLATFORM_TIME_LOW
+#	define CHERIOT_PLATFORM_TIME_LOW mcycle
+#endif
+
+/**
+ * Platform-specific hook for reading the current monotonic time.  This should
+ * be implemented to return the time that increments with the rate defined by
+ * the `CPU_TIMER_HZ` macro and must be the same timer used by the scheduler.
+ */
+__if_c(static) inline uint64_t platform_monotonic_time_read()
+{
+	uint32_t mtimehBefore;
+	uint32_t mtime;
+	uint32_t mtimehAfter;
+	/* Read the two 32-bit time CSRs.  Read the high value first, and then check
+	 * whether it has changed.  This can happen in two situations:
+	 *
+	 * If we are reading near the point where the low value overflows.  This
+	 * would cause the read of high then low to appear almost 2^32 ticks in the
+	 * past.
+	 *
+	 * If we are preempted in the middle of the read, it's possible that the
+	 * value of the high counter may be incremented (possibly by more than one)
+	 * and the value of the low would change an arbitrary amount.
+	 *
+	 * Note that, if not called with interrupts disabled, it's still possible
+	 * that we are preempted immediately *after* this returns, so the time read
+	 * here may be an arbitrary time in the past, but it is guaranteed to be a
+	 * point between when this function is entered and when it returns.
+	 */
+	do
+	{
+		__asm__ volatile("csrr %0, " __XSTRING(CHERIOT_PLATFORM_TIME_HIGH)
+		                 : "=r"(mtimehBefore));
+		__asm__ volatile("csrr %0, " __XSTRING(CHERIOT_PLATFORM_TIME_LOW)
+		                 : "=r"(mtime));
+		__asm__ volatile("csrr %0, " __XSTRING(CHERIOT_PLATFORM_TIME_HIGH)
+		                 : "=r"(mtimehAfter));
+	} while (mtimehBefore != mtimehAfter);
+	// This header is included from C and C++, don't do C++-specific lints in
+	// it. NOLINTNEXTLINE(google-readability-casting)
+	return ((uint64_t)(mtimehAfter) << 32) + mtime;
+}

--- a/sdk/include/platform/ibex/platform-hardware_revoker.hh
+++ b/sdk/include/platform/ibex/platform-hardware_revoker.hh
@@ -186,7 +186,7 @@ namespace Ibex
 		/**
 		 * Block until the revocation epoch specified by `epoch` has completed.
 		 */
-		bool wait_for_completion(Timeout *timeout, uint32_t epoch)
+		bool wait_for_completion(TimeoutArgument timeout, uint32_t epoch)
 		{
 			uint32_t interruptValue;
 			do

--- a/sdk/include/stdlib.h
+++ b/sdk/include/stdlib.h
@@ -188,7 +188,7 @@ enum [[clang::flag_enum]] AllocateWaitFlags
  * Memory returned from this interface is guaranteed to be zeroed.
  */
 void *__cheri_compartment("allocator")
-  heap_allocate(Timeout            *timeout,
+  heap_allocate(TimeoutArgument     timeout,
                 AllocatorCapability heapCapability,
                 size_t              size,
                 uint32_t flags      __if_cxx(= AllocateWaitAny));
@@ -215,7 +215,7 @@ void *__cheri_compartment("allocator")
  * Memory returned from this interface is guaranteed to be zeroed.
  */
 void *__cheri_compartment("allocator")
-  heap_allocate_array(Timeout            *timeout,
+  heap_allocate_array(TimeoutArgument     timeout,
                       AllocatorCapability heapCapability,
                       size_t              nmemb,
                       size_t              size,
@@ -297,7 +297,7 @@ static inline void *calloc(size_t nmemb, size_t size)
 {
 	Timeout t   = {0, MALLOC_WAIT_TICKS};
 	void   *ptr = heap_allocate_array(
-      &t, MALLOC_CAPABILITY, nmemb, size, AllocateWaitRevocationNeeded);
+	  &t, MALLOC_CAPABILITY, nmemb, size, AllocateWaitRevocationNeeded);
 	if (!__builtin_cheri_tag_get(ptr))
 	{
 		ptr = NULL;

--- a/sdk/include/thread.h
+++ b/sdk/include/thread.h
@@ -65,7 +65,7 @@ enum ThreadSleepFlags : uint32_t
  * `ThreadSleepNoEarlyWake` as the flags argument to prevent early wakeups.
  */
 [[cheriot::interrupt_state(disabled)]] int __cheri_compartment("scheduler")
-  thread_sleep(struct Timeout *timeout, uint32_t flags __if_cxx(= 0));
+  thread_sleep(TimeoutArgument timeout, uint32_t flags __if_cxx(= 0));
 
 /**
  * Return the thread ID of the current running thread.

--- a/sdk/include/timeout.h
+++ b/sdk/include/timeout.h
@@ -9,6 +9,8 @@
  */
 
 #include <cdefs.h>
+#include <cheri-builtins.h>
+#include <platform-time.h>
 #include <stdint.h>
 
 /**
@@ -16,8 +18,21 @@
  */
 typedef uint32_t Ticks;
 
-/// Value indicating an unbounded timeout.
+/// Value indicating an unbounded timeout for use with `Timeout`.
 static __if_cxx(constexpr) const Ticks UnlimitedTimeout = UINT32_MAX;
+
+/**
+ * Type used for absolute timeouts.  These are times against the
+ * platform-specific uptime timer.
+ */
+typedef uint64_t AbsoluteMonotonicTimeout;
+
+/// Timeout value for unlimited blocking.
+static __if_cxx(constexpr) const AbsoluteMonotonicTimeout TimeoutWaitForever =
+  0xffff'ffff'ffff'ffff;
+
+/// Timeout value for not blocking.
+static __if_cxx(constexpr) const AbsoluteMonotonicTimeout TimeoutNoWait = 0;
 
 /**
  * Structure representing a timeout.  This is intended to allow a single
@@ -86,3 +101,163 @@ typedef struct Timeout
 	}
 #endif
 } Timeout;
+
+/**
+ * A union to hold timeouts that are passed down to end up in the scheduler.
+ * These are one of two things:
+ *
+ *  - An absolute timeout, measured in cycles of some platform-specific timer
+ *    (such as the `mtime` register) that increments at predictable rate.
+ *  - A relative timeout counted in elapsed scheduler ticks.
+ *
+ * This is a tagged union, with the CHERI tag bit used to differentiate between
+ * the two cases.
+ */
+typedef union __if_c(__attribute__((transparent_union))) __TimeoutArgument
+{
+	/**
+	 * An absolute timeout.
+	 */
+	AbsoluteMonotonicTimeout absoluteTimeout;
+	/**
+	 * A relative timeout.
+	 */
+	Timeout *relativeTimeout;
+
+#ifdef __cplusplus
+	/// Permit implicit construction from absolute timeouts.
+	__TimeoutArgument(AbsoluteMonotonicTimeout absoluteTimeout)
+	  : absoluteTimeout(absoluteTimeout)
+	{
+	}
+	/// Permit implicit construction from relative timeouts.
+	__TimeoutArgument(Timeout *relativeTimeout)
+	  : relativeTimeout(relativeTimeout)
+	{
+	}
+
+	/**
+	 * Returns true if this is a relative timeout, false otherwise.
+	 */
+	bool is_relative()
+	{
+		return cheri_is_valid(relativeTimeout);
+	}
+
+	/**
+	 * Returns true if this is a valid timeout, false otherwise.
+	 */
+	bool is_valid();
+
+	/**
+	 * Returns true if the timeout is in the future (and therefore may still
+	 * block), false otherwise.
+	 */
+	bool may_block();
+
+	/**
+	 * If this is a relative timeout, elapse the specified number of ticks.
+	 * Otherwise, do nothing.
+	 */
+	void elapse(Ticks ticks);
+
+	/**
+	 * Take any ticks that have been counted towards `source` and apply it to
+	 * `destination`.  If `destination` is not a tick-counting relative timeout,
+	 * do nothing.
+	 *
+	 * This is intended for short-yielding operations, where a compartment
+	 * wishes to yield for a small amount of time (typically one tick) and then
+	 * retry some operation, rather than waiting for the whole time that the
+	 * caller has allowed them to wait.  The caller-provided timeout may be
+	 * relative or absolute, but the timeout for the short sleep is local to the
+	 * compartment doing the short sleep and so is always a `Timeout`.
+	 */
+	void elapse_from(Timeout &source)
+	{
+		elapse(source.elapsed);
+	}
+#endif
+} TimeoutArgument;
+
+_Static_assert(sizeof(TimeoutArgument) == sizeof(void *),
+               "Timeout arguments should be passable in a single register");
+
+/**
+ * Check that the argument is a valid pointer to a `Timeout` structure.  This
+ * must have read/write permissions, be unsealed, and must not be a heap
+ * address.
+ *
+ * This function is not recommended for new code.  The more general
+ * `timeout_is_valid` call checks that this is a valid timeout argument.
+ */
+bool __cheri_libcall check_timeout_pointer(const struct Timeout *timeout);
+
+/**
+ * Helper to determine whether a timeout's `relativeTimeout` alternative is the
+ * active one.
+ */
+__if_c(static) inline bool timeout_is_relative(TimeoutArgument timeout)
+{
+	return cheri_is_valid(timeout.relativeTimeout);
+}
+
+/**
+ * Returns true if this is a valid `TimeoutArgument`: either an untagged value
+ * or a valid pointer to a `Timeout`.
+ */
+bool __cheriot_libcall timeout_is_valid(TimeoutArgument timeout);
+
+/**
+ * Returns true if the timeout is in the past (for relative timeouts, if there
+ * is no remaining time), false otherwise.
+ */
+bool __cheriot_libcall timeout_has_expired(TimeoutArgument timeout);
+
+/**
+ * Returns true if the timeout is in the future (and therefore may still
+ * block), false otherwise.
+ */
+__if_c(static) inline bool timeout_may_block(TimeoutArgument timeout)
+{
+	return !timeout_has_expired(timeout);
+}
+
+/**
+ * If this is a relative timeout, elapse the specified number of ticks.
+ * Otherwise, do nothing.
+ */
+void __cheriot_libcall timeout_elapse(TimeoutArgument timeout, Ticks ticks);
+
+/**
+ * Take any ticks that have been counted towards `source` and apply it to
+ * `destination`.  If `destination` is not a tick-counting relative timeout, do
+ * nothing.
+ *
+ * This is intended for short-yielding operations, where a compartment wishes
+ * to yield for a small amount of time (typically one tick) and then retry some
+ * operation, rather than waiting for the whole time that the caller has
+ * allowed them to wait.  The caller-provided timeout may be relative or
+ * absolute, but the timeout for the short sleep is local to the compartment
+ * doing the short sleep and so is always a `Timeout`.
+ */
+__if_c(static) inline void timeout_elapse_from(TimeoutArgument destination,
+                                               Timeout        *source)
+{
+	timeout_elapse(destination, source->elapsed);
+}
+
+#ifdef __cplusplus
+inline bool TimeoutArgument::is_valid()
+{
+	return timeout_is_valid(*this);
+}
+inline bool TimeoutArgument::may_block()
+{
+	return timeout_may_block(*this);
+}
+inline void TimeoutArgument::elapse(Ticks ticks)
+{
+	return timeout_elapse(*this, ticks);
+}
+#endif

--- a/sdk/include/token.h
+++ b/sdk/include/token.h
@@ -52,7 +52,7 @@ TokenKey __cheri_compartment("allocator") token_key_new(void);
  */
 CHERI_SEALED(void *)
 __cheri_compartment("allocator")
-  token_sealed_unsealed_alloc(Timeout            *timeout,
+  token_sealed_unsealed_alloc(TimeoutArgument     timeout,
                               AllocatorCapability heapCapability,
                               TokenKey            key,
                               size_t              sz,
@@ -66,7 +66,7 @@ __cheri_compartment("allocator")
  */
 CHERI_SEALED(void *)
 __cheri_compartment("allocator")
-  token_sealed_alloc(Timeout            *timeout,
+  token_sealed_alloc(TimeoutArgument     timeout,
                      AllocatorCapability heapCapability,
                      TokenKey,
                      size_t);
@@ -237,7 +237,7 @@ class Sealed
  */
 template<typename T>
 __always_inline std::pair<T *, Sealed<T>>
-token_allocate(Timeout            *timeout,
+token_allocate(TimeoutArgument     timeout,
                AllocatorCapability heapCapability,
                TokenKey            key)
 {

--- a/sdk/lib/compartment_helpers/claim_fast.cc
+++ b/sdk/lib/compartment_helpers/claim_fast.cc
@@ -7,7 +7,9 @@
 #include <futex.h>
 #include <switcher.h>
 
-int heap_claim_ephemeral(Timeout *timeout, const void *ptr, const void *ptr2)
+int heap_claim_ephemeral(TimeoutArgument timeout,
+                         const void     *ptr,
+                         const void     *ptr2)
 {
 	void   **hazards = switcher_thread_hazard_slots();
 	auto    *epochCounter{const_cast<cheriot::atomic<uint32_t> *>(
@@ -40,7 +42,7 @@ int heap_claim_ephemeral(Timeout *timeout, const void *ptr, const void *ptr2)
 	{
 		while (epoch & 1)
 		{
-			if (timeout->may_block())
+			if (timeout.may_block())
 			{
 				Timeout t{1};
 				(void)futex_timed_wait(
@@ -48,7 +50,7 @@ int heap_claim_ephemeral(Timeout *timeout, const void *ptr, const void *ptr2)
 				  reinterpret_cast<uint32_t *>(epochCounter),
 				  epoch,
 				  FutexPriorityInheritance);
-				timeout->elapse(t.elapsed);
+				timeout.elapse_from(t);
 			}
 			else
 			{

--- a/sdk/lib/compartment_helpers/timeout.cc
+++ b/sdk/lib/compartment_helpers/timeout.cc
@@ -1,0 +1,25 @@
+#include <debug.hh>
+#include <timeout.h>
+
+bool timeout_is_valid(TimeoutArgument timeout)
+{
+	return !timeout.is_relative() ||
+	       check_timeout_pointer(timeout.relativeTimeout);
+}
+
+bool timeout_has_expired(TimeoutArgument timeout)
+{
+	if (timeout_is_relative(timeout))
+	{
+		return timeout.relativeTimeout->remaining == 0;
+	}
+	return timeout.absoluteTimeout < platform_monotonic_time_read();
+}
+
+void timeout_elapse(TimeoutArgument timeout, Ticks ticks)
+{
+	if (timeout_is_relative(timeout))
+	{
+		timeout.relativeTimeout->elapse(ticks);
+	}
+}

--- a/sdk/lib/compartment_helpers/xmake.lua
+++ b/sdk/lib/compartment_helpers/xmake.lua
@@ -1,3 +1,3 @@
 library("compartment_helpers")
   set_default(false)
-  add_files("claim_fast.cc", "check_pointer.cc")
+  add_files("claim_fast.cc", "check_pointer.cc", "timeout.cc")

--- a/sdk/lib/locks/barrier.cc
+++ b/sdk/lib/locks/barrier.cc
@@ -2,7 +2,7 @@
 #include <errno.h>
 #include <locks.h>
 
-int barrier_timed_wait(Timeout *timeout, struct BarrierState *barrier)
+int barrier_timed_wait(TimeoutArgument timeout, struct BarrierState *barrier)
 {
 	auto remaining = --barrier->remaining;
 	Debug::Assert(remaining < std::numeric_limits<int32_t>::max(),

--- a/sdk/lib/locks/condition_variable.cc
+++ b/sdk/lib/locks/condition_variable.cc
@@ -10,10 +10,10 @@ int condition_variable_notify(ConditionVariableState *conditionVariable,
 	  waiters);
 }
 
-int condition_variable_wait(Timeout                *timeout,
+int condition_variable_wait(TimeoutArgument         timeout,
                             ConditionVariableState *conditionVariable,
                             void                   *mutex,
-                            int (*mutexLock)(Timeout *, void *),
+                            int (*mutexLock)(TimeoutArgument, void *),
                             int (*mutexUnlock)(void *))
 {
 	auto counter = conditionVariable->sequenceCounter.load();

--- a/sdk/lib/locks/locks.cc
+++ b/sdk/lib/locks/locks.cc
@@ -33,8 +33,9 @@ namespace
 		 * Attempt to acquire the lock, blocking until a timeout specified by
 		 * the `timeout` parameter has expired.
 		 */
-		int
-		try_lock(Timeout *timeout, uint32_t threadID, bool isPriorityInherited)
+		int try_lock(TimeoutArgument timeout,
+		             uint32_t        threadID,
+		             bool            isPriorityInherited)
 		{
 			while (true)
 			{
@@ -57,7 +58,7 @@ namespace
 					return -ENOENT;
 				}
 
-				if (!timeout->may_block())
+				if (!timeout.may_block())
 				{
 					return -ETIMEDOUT;
 				}
@@ -233,7 +234,7 @@ namespace
 
 } // namespace
 
-int __cheri_libcall flaglock_trylock(Timeout *t, FlagLockState *lock)
+int __cheri_libcall flaglock_trylock(TimeoutArgument t, FlagLockState *lock)
 {
 	// The thread ID is only used for debugging, or priority inheriting
 	// (which is not relevant here). To avoid a useless call to
@@ -246,8 +247,8 @@ int __cheri_libcall flaglock_trylock(Timeout *t, FlagLockState *lock)
 
 	return static_cast<InternalFlagLock *>(lock)->try_lock(t, threadID, false);
 }
-int __cheri_libcall flaglock_priority_inheriting_trylock(Timeout       *t,
-                                                         FlagLockState *lock)
+int __cheri_libcall flaglock_priority_inheriting_trylock(TimeoutArgument t,
+                                                         FlagLockState  *lock)
 {
 	return static_cast<InternalFlagLock *>(lock)->try_lock(
 	  t, thread_id_get(), true);
@@ -272,7 +273,7 @@ void __cheri_libcall ticketlock_unlock(TicketLockState *lock)
 	static_cast<InternalTicketLock *>(lock)->unlock();
 }
 
-int recursivemutex_trylock(Timeout *timeout, RecursiveMutexState *mutex)
+int recursivemutex_trylock(TimeoutArgument timeout, RecursiveMutexState *mutex)
 {
 	auto              threadID = thread_id_get();
 	InternalFlagLock *internalLock =

--- a/sdk/lib/queue/queue.cc
+++ b/sdk/lib/queue/queue.cc
@@ -292,7 +292,7 @@ namespace
 		/**
 		 * Try to acquire the lock.  Returns true on success, false on failure.
 		 */
-		bool try_lock(Timeout *t)
+		bool try_lock(TimeoutArgument t)
 		{
 			uint32_t value;
 			do

--- a/tests/allocator-test.cc
+++ b/tests/allocator-test.cc
@@ -527,11 +527,6 @@ namespace
 		           -EPERM,
 		           "Non-blocking heap allocation did not fail on null "
 		           "heap capability");
-		TEST_EQUAL(
-		  ErrorOr{heap_allocate(nullptr, MALLOC_CAPABILITY, 64)}.as_error(),
-		  -EINVAL,
-		  "Non-blocking heap allocation did not fail on null "
-		  "timeout");
 		// Wake up the thread that will free memory
 		freeStart = 1;
 		debug_log("Notifying deallocation thread to start with futex {}",
@@ -1557,10 +1552,16 @@ int test_allocator()
 	    .as_error(),
 	  -EINVAL,
 	  "Allocating array with size overflow succeeded");
-	TEST_EQUAL(ErrorOr{heap_allocate_array(nullptr, MALLOC_CAPABILITY, 64, 2)}
-	             .as_error(),
-	           -EINVAL,
-	           "Allocating array with null timeout succeeded");
+	Timeout *invalidTimeout = static_cast<Timeout *>(
+	  heap_allocate(TimeoutNoWait, MALLOC_CAPABILITY, sizeof(Timeout)));
+	TimeoutArgument testArg = invalidTimeout;
+	TEST(!testArg.is_valid(), "{} should not be valid!", testArg);
+	TEST_EQUAL(
+	  ErrorOr{heap_allocate_array(invalidTimeout, MALLOC_CAPABILITY, 64, 2)}
+	    .as_error(),
+	  -EINVAL,
+	  "Allocating array with invalid timeout succeeded");
+	heap_free(MALLOC_CAPABILITY, invalidTimeout);
 	TEST_EQUAL(ErrorOr{heap_allocate_array(&t, nullptr, 64, 2)}.as_error(),
 	           -EPERM,
 	           "Allocating array with null quota succeeded");

--- a/tests/futex-test.cc
+++ b/tests/futex-test.cc
@@ -26,6 +26,19 @@ int test_futex()
 	static uint32_t futex;
 	int             ret;
 	int             sleeps;
+
+	// Test sleeping for a short amount of time.
+	AbsoluteMonotonicTimeout absoluteTimeout = platform_monotonic_time_read();
+	// Sleep for a couple of thousand cycles
+	absoluteTimeout += 2000;
+	ret                 = thread_sleep(absoluteTimeout, ThreadSleepNoEarlyWake);
+	auto afterTimestamp = platform_monotonic_time_read();
+	TEST_EQUAL(ret, 0, "Thread sleep for an absolute timeout failed");
+	TEST(afterTimestamp >= absoluteTimeout,
+	     "Timeout until {} finished at {}, before expected",
+	     absoluteTimeout,
+	     afterTimestamp);
+
 	// Make sure that waking a futex with no sleepers doesn't crash!
 	ret = futex_wake(&futex, 1);
 	TEST(ret == 0, "Waking a futex with no sleepers should return 0");


### PR DESCRIPTION
This extends the core (scheduler, locking, allocator) APIs to support either an absolute timeout relative to the platform's monotonic clock in addition to the FreeRTOS-inspired relative-tick-based waiting.

This is designed to be compatible with old APIs.  Deliberately, this PR *doesn't* update *all* of the APIs, so that we have callers that are still taking `Timeout*` and forward it.

Fixes #703