### PR TITLE
locks: FlagLock lock() docs & Invariant

### DIFF
--- a/sdk/include/locks.hh
+++ b/sdk/include/locks.hh
@@ -39,31 +39,50 @@ __clang_ignored_warning_push("-Watomic-alignment");
  * requires mutual exclusion in the presence of mutual distrust should
  * consider an using a lock manager compartment with an API that returns a
  * single-use capability to unlock on any lock call.
+ *
+ * Flag locks are not recursive; if needed, use a `RecursiveMutex` instead.
  */
 template<bool IsPriorityInherited>
 class FlagLockGeneric
 {
 	FlagLockState state;
 
+	/**
+	 * Attempt to acquire the lock, blocking until a timeout specified by the
+	 * `timeout` parameter has expired.
+	 *
+	 * Returns an errno value.
+	 */
+	__always_inline int try_lock_internal(Timeout *timeout)
+	{
+		if constexpr (IsPriorityInherited)
+		{
+			return flaglock_priority_inheriting_trylock(timeout, &state);
+		}
+		else
+		{
+			return flaglock_trylock(timeout, &state);
+		}
+	}
+
 	public:
 	/**
 	 * Attempt to acquire the lock, blocking until a timeout specified by the
 	 * `timeout` parameter has expired.
+	 *
+	 * Returns `true` if and only if the lock transitioned from being unheld to
+	 * held by the current thread.
 	 */
 	__always_inline bool try_lock(Timeout *timeout)
 	{
-		if constexpr (IsPriorityInherited)
-		{
-			return flaglock_priority_inheriting_trylock(timeout, &state) == 0;
-		}
-		else
-		{
-			return flaglock_trylock(timeout, &state) == 0;
-		}
+		return try_lock_internal(timeout) == 0;
 	}
 
 	/**
 	 * Try to acquire the lock, do not block.
+	 *
+	 * Returns `true` if and only if the lock transitioned from being unheld to
+	 * held by the current thread.
 	 */
 	__always_inline bool try_lock()
 	{
@@ -73,11 +92,26 @@ class FlagLockGeneric
 
 	/**
 	 * Acquire the lock, potentially blocking forever.
+	 *
+	 * This function returns `void` despite that this is a bad idea.
+	 * Because the C++ standard library has `void`-returning `::lock()` methods,
+	 * templated callers would not check a return value,
+	 * making it unsafe to return in the event of failed lock acquisition.
+	 * Failures instead manifest as tripping a `Debug::Invariant`,
+	 * causing this function not to return (and yet not block forever).
+	 * Thus, it is not safe with locks that may be put into "destrucion mode"
+	 * (see `flaglock_upgrade_for_destruction`).
+	 * Attempting to recursively `lock` a held priority inheriting flag lock
+	 * (acquired by either `lock` or `try_lock`) will trip the same Invariant.
+	 * (Recall that flag locks explicitly do not support recursive acquisition;
+	 * the failure mode is, however, not one of blocking forever.)
+	 * In general, defensive code should prefer `try_lock`.
 	 */
 	__always_inline void lock()
 	{
 		Timeout t{UnlimitedTimeout};
-		try_lock(&t);
+		auto    res = try_lock_internal(&t);
+		LockDebug::Invariant(res == 0, "FlagLock lock() failed: {}", res);
 	}
 
 	/**
@@ -269,14 +303,28 @@ class LockGuard
 	bool isOwned;
 
 	public:
-	/// Constructor, acquires the lock.
+	/**
+	 * Constructor, acquires the lock with unbounded wait.
+	 *
+	 * The lock to be wrapped must not be held by the calling thread on entry.
+	 * Further, for this constructor to be safe to invoke,
+	 * the `Lock` type must have an unfailable `lock` member;
+	 * for example, this precludes the use of `FlagLock`-s
+	 * that may be placed in "destruction mode".
+	 *
+	 * In general, prefer the `LockGuard` constructor that takes a `Timeout`.
+	 */
 	[[nodiscard]] explicit LockGuard(Lock &lock)
 	  : wrappedLock(&lock), isOwned(true)
 	{
 		wrappedLock->lock();
 	}
 
-	/// Constructor, attempts to acquire the lock with a timeout.
+	/**
+	 * Constructor, attempts to acquire the lock with a timeout.
+	 *
+	 * The lock to be wrapped must not be held by the calling thread on entry.
+	 */
 	[[nodiscard]] explicit LockGuard(Lock &lock, Timeout *timeout)
 	    requires(TryLockable<Lock>)
 	  : wrappedLock(&lock), isOwned(false)
@@ -293,7 +341,14 @@ class LockGuard
 	}
 
 	/**
-	 * Explicitly lock the wrapped lock. Must be called with the lock unlocked.
+	 * Explicitly lock the wrapped lock.
+	 *
+	 * The wrapped lock must not be held by the calling thread on entry.
+	 * For this method to be safe to call,
+	 * the `Lock` type must have an unfailable `lock` member;
+	 * for example, this precludes the use of `FlagLock`-s
+	 * that may be placed in "destruction mode".
+	 * In general, prefer `try_lock`.
 	 */
 	void lock()
 	{
@@ -324,9 +379,11 @@ class LockGuard
 	}
 
 	/**
-	 * If the underlying lock type supports locking with a timeout, try to lock
-	 * it with the specified timeout. This must be called with the lock
-	 * unlocked.  Returns true if the lock has been acquired, false otherwise.
+	 * If the wrapped lock type supports locking with a timeout,
+	 * try to lock it with the specified timeout.
+	 *
+	 * The wrapped lock must not be held by the calling thread on entry.
+	 * Returns true if the lock has been acquired, false otherwise.
 	 */
 	bool try_lock(Timeout *timeout)
 	    requires(TryLockable<Lock>)


### PR DESCRIPTION
FlagLockGeneric<>::lock() invokes try_lock() (which wraps one of the lock library trylock() operations) with indefinite timeout and expects termination to imply success and has no way to indicate failure.

Unfortunately, these trylock()s can return after failure if the lock is PI and already held by the current thread (futex_wait(), and so std::atomic<>::wait, will fail), the lock has been "upgraded for destruction". or if the lock word has been corrupted.  Notably, the first case can happen if an attempt is made to recursively lock the FlagLock or the current thread was previously forcibly unwound out of a critical section with the lock held and is now attempting to reacquire it.

Document that lock() should not be used on locks that can be "upgraded for destruction" and add a Debug::Invariant that try_lock has indeed succeeded.