### PR TITLE
Provide prototypes for runtime libcalls in header files.

### DIFF
--- a/scripts/run_clang_tidy_format.exempt_headers
+++ b/scripts/run_clang_tidy_format.exempt_headers
@@ -20,3 +20,4 @@ microvium
 FreeRTOS-Compat
 sunburst/v0\.2
 float\.h
+arith64\.h

--- a/sdk/lib/atomic/atomic.hh
+++ b/sdk/lib/atomic/atomic.hh
@@ -20,8 +20,9 @@
  * single load for most cases of this, rather than needing a cross-library
  * call, so eventually this will go away.
  */
+#define DECLARE_ATOMIC_LOAD(size, type)                                        \
+	DECLARE_ATOMIC_LIBCALL(__atomic_load_##size, type, const type *, int);
 #define DEFINE_ATOMIC_LOAD(size, type)                                         \
-	DECLARE_ATOMIC_LIBCALL(__atomic_load_##size, type, const type *, int);     \
 	type __atomic_load_##size(const type *ptr, int)                            \
 	{                                                                          \
 		static_assert(sizeof(type) == size, "Invalid type for size");          \
@@ -36,8 +37,9 @@
  * single store for most cases of this, rather than needing a cross-library
  * call, so eventually this will go away.
  */
+#define DECLARE_ATOMIC_STORE(size, type)                                       \
+	DECLARE_ATOMIC_LIBCALL(__atomic_store_##size, void, type *, type, int);
 #define DEFINE_ATOMIC_STORE(size, type)                                        \
-	DECLARE_ATOMIC_LIBCALL(__atomic_store_##size, void, type *, type, int);    \
 	void __atomic_store_##size(type *ptr, type value, int)                     \
 	{                                                                          \
 		static_assert(sizeof(type) == size, "Invalid type for size");          \
@@ -50,9 +52,10 @@
  * name is the name of the operation and `op` is the C++ operator that
  * implements it.
  */
-#define DEFINE_ATOMIC_FETCH_OP(size, type, name, op)                           \
+#define DECLARE_ATOMIC_FETCH_OP(size, type, name, op)                          \
 	DECLARE_ATOMIC_LIBCALL(                                                    \
-	  __atomic_fetch_##name##_##size, type, type *, type, int);                \
+	  __atomic_fetch_##name##_##size, type, type *, type, int);
+#define DEFINE_ATOMIC_FETCH_OP(size, type, name, op)                           \
 	type __atomic_fetch_##name##_##size(type *ptr, type value, int)            \
 	{                                                                          \
 		static_assert(sizeof(type) == size, "Invalid type for size");          \
@@ -65,9 +68,9 @@
  * Macro that defines a library function to implement an atomic
  * fetch-and-nand for the specified size, using the specified type.
  */
+#define DECLARE_ATOMIC_FETCH_NAND(size, type)                                  \
+	DECLARE_ATOMIC_LIBCALL(__atomic_fetch_nand_##size, type, type *, type, int);
 #define DEFINE_ATOMIC_FETCH_NAND(size, type)                                   \
-	DECLARE_ATOMIC_LIBCALL(                                                    \
-	  __atomic_fetch_nand_##size, type, type *, type, int);                    \
 	type __atomic_fetch_nand_##size(type *ptr, type value, int)                \
 	{                                                                          \
 		static_assert(sizeof(type) == size, "Invalid type for size");          \
@@ -75,6 +78,17 @@
 		*ptr     = ~(tmp & value);                                             \
 		return tmp;                                                            \
 	}
+
+/**
+ * Helper macro that declares all of the cases of atomic operations.
+ */
+#define DECLARE_ATOMIC_FETCH_OPS(size, type)                                   \
+	DECLARE_ATOMIC_FETCH_OP(size, type, add, +)                                \
+	DECLARE_ATOMIC_FETCH_OP(size, type, sub, -)                                \
+	DECLARE_ATOMIC_FETCH_OP(size, type, and, &)                                \
+	DECLARE_ATOMIC_FETCH_OP(size, type, or, |)                                 \
+	DECLARE_ATOMIC_FETCH_OP(size, type, xor, ^)                                \
+	DECLARE_ATOMIC_FETCH_NAND(size, type)
 
 /**
  * Helper macro that defines all of the cases of atomic operations.
@@ -91,8 +105,9 @@
  * Macro that defines a library function to implement an atomic exchange for the
  * specified size, using the specified type.
  */
+#define DECLARE_ATOMIC_EXCHANGE(size, type)                                    \
+	DECLARE_ATOMIC_LIBCALL(__atomic_exchange_##size, type, type *, type, int);
 #define DEFINE_ATOMIC_EXCHANGE(size, type)                                     \
-	DECLARE_ATOMIC_LIBCALL(__atomic_exchange_##size, type, type *, type, int); \
 	type __atomic_exchange_##size(type *ptr, type value, int)                  \
 	{                                                                          \
 		static_assert(sizeof(type) == size, "Invalid type for size");          \
@@ -105,9 +120,10 @@
  * Macro that defines a library function to implement an atomic compare and
  * exchange for the specified size, using the specified type.
  */
-#define DEFINE_ATOMIC_COMPARE_EXCHANGE(size, type)                             \
+#define DECLARE_ATOMIC_COMPARE_EXCHANGE(size, type)                            \
 	DECLARE_ATOMIC_LIBCALL(                                                    \
-	  __atomic_compare_exchange_##size, int, type *, type *, type, int, int);  \
+	  __atomic_compare_exchange_##size, int, type *, type *, type, int, int);
+#define DEFINE_ATOMIC_COMPARE_EXCHANGE(size, type)                             \
 	int __atomic_compare_exchange_##size(                                      \
 	  type *ptr, type *expected, type desired, int, int)                       \
 	{                                                                          \
@@ -120,9 +136,33 @@
 		*expected = *ptr;                                                      \
 		return 0;                                                              \
 	}
+
+#define DECLARE_ALL_ATOMIC_OPS(size, type)                                     \
+	DECLARE_ATOMIC_LOAD(size, type)                                            \
+	DECLARE_ATOMIC_STORE(size, type)                                           \
+	DECLARE_ATOMIC_EXCHANGE(size, type)                                        \
+	DECLARE_ATOMIC_COMPARE_EXCHANGE(size, type)                                \
+	DECLARE_ATOMIC_FETCH_OPS(size, type)
+
 #define DEFINE_ALL_ATOMIC_OPS(size, type)                                      \
 	DEFINE_ATOMIC_LOAD(size, type)                                             \
 	DEFINE_ATOMIC_STORE(size, type)                                            \
 	DEFINE_ATOMIC_EXCHANGE(size, type)                                         \
 	DEFINE_ATOMIC_COMPARE_EXCHANGE(size, type)                                 \
 	DEFINE_ATOMIC_FETCH_OPS(size, type)
+
+DECLARE_ALL_ATOMIC_OPS(1, uint8_t)
+DECLARE_ALL_ATOMIC_OPS(2, uint16_t)
+DECLARE_ALL_ATOMIC_OPS(4, uint32_t)
+DECLARE_ALL_ATOMIC_OPS(8, uint64_t)
+
+DECLARE_ATOMIC_LIBCALL(__atomic_compare_exchange_cap,
+                       int,
+                       void **,
+                       void **,
+                       void *,
+                       int,
+                       int);
+DECLARE_ATOMIC_LIBCALL(__atomic_load_cap, void *, void *const *, int)
+DECLARE_ATOMIC_LIBCALL(__atomic_store_cap, void, void **, void *, int)
+DECLARE_ATOMIC_LIBCALL(__atomic_exchange_cap, void *, void **, void *, int)

--- a/sdk/lib/atomic/atomiccap.cc
+++ b/sdk/lib/atomic/atomiccap.cc
@@ -7,17 +7,6 @@
  * operations on pointers.
  */
 
-DECLARE_ATOMIC_LIBCALL(__atomic_compare_exchange_cap,
-                       int,
-                       void **,
-                       void **,
-                       void *,
-                       int,
-                       int);
-DECLARE_ATOMIC_LIBCALL(__atomic_load_cap, void *, void *const *, int)
-DECLARE_ATOMIC_LIBCALL(__atomic_store_cap, void, void **, void *, int)
-DECLARE_ATOMIC_LIBCALL(__atomic_exchange_cap, void *, void **, void *, int)
-
 int __atomic_compare_exchange_cap(void **ptr,
                                   void **expected,
                                   void  *desired,

--- a/sdk/lib/crt/arith64.c
+++ b/sdk/lib/crt/arith64.c
@@ -29,41 +29,11 @@
 // - Provide real implementations for __clzsi2() / __clzdi2() / __popcount* only when the RISCV Zbb extension is not present
 // - Use __builtin_clzg rather than calling __clzdi2 from other functions
 // - Replace clz*/ctz*/popcount* implementations with calls to clang builtins: they have slightly smaller code size without B, or will use B instructions if enabled and present
+// - Extracted declarations to arith64.h
 //
 // This file is *not* formatted, to make it easier to track changes from upstream (if there are any).
 
-#include "cdefs.h"
-#include <stdint.h>
-#include <compartment-macros.h>
-
-#define arith64_u64 uint64_t
-#define arith64_s64 int64_t
-#define arith64_u32 uint32_t
-#define arith64_s32 int32_t
-
-arith64_s64 __cheri_libcall __ashldi3(arith64_s64 a, int b) __asm__("__ashldi3");
-arith64_s64 __cheri_libcall __absvdi2(arith64_s64 a) __asm__("__absvdi2");
-arith64_s64 __cheri_libcall __ashldi3(arith64_s64 a, int b) __asm__("__ashldi3");
-arith64_s64 __cheri_libcall __ashrdi3(arith64_s64 a, int b) __asm__("__ashrdi3");
-
-#if !defined(__riscv_zbb)
-// These should use dedicated instructions when B extension is enabled
-int __cheri_libcall __clzsi2(arith64_u32 a) __asm__("__clzsi2");
-int __cheri_libcall __clzdi2(arith64_u64 a) __asm__("__clzdi2");
-int __cheri_libcall __ctzsi2(arith64_u32 a) __asm__("__ctzsi2");
-int __cheri_libcall __ctzdi2(arith64_u64 a) __asm__("__ctzdi2");
-int __cheri_libcall __popcountsi2(arith64_u32 a) __asm__("__popcountsi2");
-int __cheri_libcall __popcountdi2(arith64_u64 a) __asm__("__popcountdi2");
-#endif
-
-arith64_u64 __cheri_libcall __divmoddi4(arith64_u64 a, arith64_u64 b, arith64_u64 *c) __asm__("__divmoddi4");
-arith64_s64 __cheri_libcall __divdi3(arith64_s64 a, arith64_s64 b) __asm__("__divdi3");
-int __cheri_libcall __ffsdi2(arith64_u64 a) __asm__("__ffsdi2");
-arith64_u64 __cheri_libcall __lshrdi3(arith64_u64 a, int b) __asm__("__lshrdi3");
-arith64_s64 __cheri_libcall __moddi3(arith64_s64 a, arith64_s64 b) __asm__("__moddi3");
-arith64_u64 __cheri_libcall __udivdi3(arith64_u64 a, arith64_u64 b) __asm__("__udivdi3");
-arith64_u64 __cheri_libcall __umoddi3(arith64_u64 a, arith64_u64 b) __asm__("__umoddi3");
-arith64_s64 __cheri_libcall __multi3(arith64_s64 a, arith64_s64 b) __asm__("__multi3");
+#include "arith64.h"
 
 typedef union
 {

--- a/sdk/lib/crt/arith64.h
+++ b/sdk/lib/crt/arith64.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Unlicense
+// See arith64.c
+
+#include "cdefs.h"
+#include <compartment-macros.h>
+#include <stdint.h>
+
+#define arith64_u64 uint64_t
+#define arith64_s64 int64_t
+#define arith64_u32 uint32_t
+#define arith64_s32 int32_t
+
+arith64_s64 __cheri_libcall __ashldi3(arith64_s64 a,
+                                      int         b) __asm__("__ashldi3");
+arith64_s64 __cheri_libcall __absvdi2(arith64_s64 a) __asm__("__absvdi2");
+arith64_s64 __cheri_libcall __ashldi3(arith64_s64 a,
+                                      int         b) __asm__("__ashldi3");
+arith64_s64 __cheri_libcall __ashrdi3(arith64_s64 a,
+                                      int         b) __asm__("__ashrdi3");
+
+#if !defined(__riscv_zbb)
+// These should use dedicated instructions when B extension is enabled
+int __cheri_libcall __clzsi2(arith64_u32 a) __asm__("__clzsi2");
+int __cheri_libcall __clzdi2(arith64_u64 a) __asm__("__clzdi2");
+int __cheri_libcall __ctzsi2(arith64_u32 a) __asm__("__ctzsi2");
+int __cheri_libcall __ctzdi2(arith64_u64 a) __asm__("__ctzdi2");
+int __cheri_libcall __popcountsi2(arith64_u32 a) __asm__("__popcountsi2");
+int __cheri_libcall __popcountdi2(arith64_u64 a) __asm__("__popcountdi2");
+#endif
+
+arith64_u64 __cheri_libcall __divmoddi4(arith64_u64  a,
+                                        arith64_u64  b,
+                                        arith64_u64 *c) __asm__("__divmoddi4");
+arith64_s64 __cheri_libcall __divdi3(arith64_s64 a,
+                                     arith64_s64 b) __asm__("__divdi3");
+int __cheri_libcall         __ffsdi2(arith64_u64 a) __asm__("__ffsdi2");
+arith64_u64 __cheri_libcall __lshrdi3(arith64_u64 a,
+                                      int         b) __asm__("__lshrdi3");
+arith64_s64 __cheri_libcall __moddi3(arith64_s64 a,
+                                     arith64_s64 b) __asm__("__moddi3");
+arith64_u64 __cheri_libcall __udivdi3(arith64_u64 a,
+                                      arith64_u64 b) __asm__("__udivdi3");
+arith64_u64 __cheri_libcall __umoddi3(arith64_u64 a,
+                                      arith64_u64 b) __asm__("__umoddi3");
+arith64_s64 __cheri_libcall __multi3(arith64_s64 a,
+                                     arith64_s64 b) __asm__("__multi3");

--- a/sdk/lib/cxxrt/guard.cc
+++ b/sdk/lib/cxxrt/guard.cc
@@ -1,6 +1,7 @@
 // Copyright Microsoft and CHERIoT Contributors.
 // SPDX-License-Identifier: MIT
 
+#include "guard.h"
 #include <atomic>
 #include <cdefs.h>
 #include <debug.hh>
@@ -8,19 +9,6 @@
 #include <stdint.h>
 
 using Debug = ConditionalDebug<DEBUG_CXXRT, "cxxrt">;
-
-/**
- * The helper functions need to expose an unmangled name because the compiler
- * inserts calls to them.  Declare them using the asm label extension.
- */
-#define DECLARE_LIBCALL(name, ret, ...)                                        \
-	__cheri_libcall ret name(__VA_ARGS__) asm(#name);
-
-// NOLINTBEGIN(readability-identifier-naming)
-DECLARE_LIBCALL(__cxa_guard_acquire, int, uint64_t *)
-DECLARE_LIBCALL(__cxa_guard_release, void, uint64_t *)
-DECLARE_LIBCALL(__cxa_atexit, int, void (*)(void *), void *, void *)
-// NOLINTEND(readability-identifier-naming)
 
 namespace
 {

--- a/sdk/lib/cxxrt/guard.h
+++ b/sdk/lib/cxxrt/guard.h
@@ -1,0 +1,18 @@
+// Copyright Microsoft and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#include <cdefs.h>
+#include <stdint.h>
+
+/**
+ * The helper functions need to expose an unmangled name because the compiler
+ * inserts calls to them.  Declare them using the asm label extension.
+ */
+#define DECLARE_LIBCALL(name, ret, ...)                                        \
+	__cheri_libcall ret name(__VA_ARGS__) asm(#name);
+
+// NOLINTBEGIN(readability-identifier-naming)
+DECLARE_LIBCALL(__cxa_guard_acquire, int, uint64_t *)
+DECLARE_LIBCALL(__cxa_guard_release, void, uint64_t *)
+DECLARE_LIBCALL(__cxa_atexit, int, void (*)(void *), void *, void *)
+// NOLINTEND(readability-identifier-naming)


### PR DESCRIPTION
We want to have the toolchain emit warnings for functions annotated as libcalls that do not have a separate prototype provided in a header. This causes issues for CRT libcalls provided by the RTOS, where no header declaration is normally present. The simple fix is to add internal-only headers to provide such declarations and silence the warning.
