### PR TITLE
Fix allocator initialization arithmetics

### DIFF
--- a/sdk/core/allocator/alloc.h
+++ b/sdk/core/allocator/alloc.h
@@ -1061,13 +1061,10 @@ class MState
 	}
 
 	/**
-	 * @brief Called when adding the first memory chunk to this MState.
-	 * At the moment we only support one contiguous MChunk for each MState.
+	 * Called when adding the first memory chunk to this MState. At the
+	 * moment we only support one contiguous MChunk for each MState.
 	 *
-	 * @param p The chunk used to initialise the MState. It must have the
-	 * previous-in-use bit set and the next chunk's in-use bit set to prevent
-	 * free() from coalescing below and above, unless you really know what you
-	 * are doing.
+	 * Takes the base address and size of the first chunk to be added.
 	 */
 	void mspace_firstchunk_add(void *base, size_t size)
 	{

--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -81,23 +81,7 @@ namespace
 			return nullptr;
 		}
 
-		size_t msize = pad_request(sizeof(MState));
-		/*
-		 * Each memory space has the MState structure at the beginning, followed
-		 * by at least enough space for a smallest chunk, followed by a fake
-		 * malloc header at the very end.
-		 *
-		 * The memory used to initialise a memory space must have enough bytes,
-		 * but not too big that overflows what the compressed header can
-		 * support.
-		 */
-		if (tsize < msize + MinChunkSize + sizeof(MChunkHeader) ||
-		    tsize > MaxChunkSize)
-		{
-			return nullptr;
-		}
-
-		Capability m{tbase.cast<MState>()};
+		size_t msize = (sizeof(MState) + MallocAlignMask) & ~MallocAlignMask;
 
 		size_t hazardQuarantineSize =
 		  Capability{SHARED_OBJECT_WITH_PERMISSIONS(void *,
@@ -109,9 +93,34 @@ namespace
 		                                            false)}
 		    .length();
 
+		/*
+		 * Each memory space has the MState structure at the beginning,
+		 * followed by the hazard quarantine, then at least enough
+		 * space for a smallest chunk, and a fake malloc header at the
+		 * very end.
+		 *
+		 * The memory used to initialise a memory space must have enough bytes,
+		 * but not too big that overflows what the compressed header can
+		 * support.
+		 */
+		if (tsize < (msize + hazardQuarantineSize + MinChunkSize +
+		             sizeof(MChunkHeader)) ||
+		    tsize > MaxChunkSize)
+		{
+			return nullptr;
+		}
+
+		Capability m{tbase.cast<MState>()};
+
 		m.bounds()            = sizeof(*m);
 		m->heapStart          = tbase;
 		m->heapStart.bounds() = tsize;
+		/*
+		 * The address of the start of the heap must be 8-byte aligned,
+		 * but we do not need to pad here: we already did when
+		 * calculating msize, and the size of the hazard quarantine is
+		 * a multiple of 8 (number of threads * 8 * 2).
+		 */
 		m->heapStart.address() += msize + hazardQuarantineSize;
 		m->init_bins();
 


### PR DESCRIPTION
This fixes/improves a few things on the allocator initialization path:

- Don't add the size of `MChunkHeader` to the size of `MState` when calculating msize. This space is wasted, I suspect that the mistake comes either from re-using `pad_request` (which adds the `MChunkHeader` size), or from incorrectly assuming that `MinChunkSize` does not include `MChunkHeader`.

- The check for the minimal heap size does not include the hazard quarantine. This would let us initialize a heap that's too small.

- The documentation of `mspace_firstchunk_add` is outdated. I removed the `@brief` tags, it doesn't seem to be a standard practice (anymore) throughout the RTOS. Please let me know if you want it back.

- Add a comment to explain why we don't need to pad again after the hazard quarantine.

(This deserves a really good look by another pair of eyes to make sure I didn't break it more than it was!)