### PR TITLE
Don't make shared objects `volatile` by default

### DIFF
--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -225,7 +225,7 @@
 			        permitStore,                                               \
 			        permitLoadStoreCapabilities,                               \
 			        permitLoadMutable,                                         \
-			        permitLoadGlobal)))) volatile extern char cValue;          \
+			        permitLoadGlobal)))) extern char cValue;                   \
 			(type *)&cValue;                                                   \
 			_Pragma("GCC diagnostic pop")                                      \
 			/* NOLINTEND(bugprone-macro-parentheses) */                        \


### PR DESCRIPTION
The `SHARED_OBJECT_WITH_PERMISSIONS_INNER` macro generates `volatile`-qualified values, but it shouldn't. 