### PR TITLE
queue_compartment.cc: removed unused helper has_permissions

### DIFF
--- a/sdk/lib/queue/queue_compartment.cc
+++ b/sdk/lib/queue/queue_compartment.cc
@@ -18,21 +18,6 @@ namespace
 		return STATIC_SEALING_TYPE(MessageQueueHandle);
 	}
 
-	template<MessageQueuePermission... Permissions>
-	__always_inline bool has_permissions(CHERI_SEALED(MessageQueue *) handle)
-	{
-		static const constinit int PermissionsMask = []() {
-			std::tuple permissions    = std::make_tuple(Permissions...);
-			int        permissionMask = 0;
-			std::for_each(permissions, [&](MessageQueuePermission permission) {
-				permissionMask |= permission;
-			});
-			return permissionMask;
-		};
-		return ((queue_permissions(handle) & PermissionsMask) ==
-		        PermissionsMask);
-	}
-
 	/**
 	 * Unseal a queue handle if it has all the given permissions.  Returns the
 	 * unsealed handle or null if the handle is invalid or lacks the relevant


### PR DESCRIPTION
Removed the unused `has_permissions` helper from `queue_compartment.cc`.
Permission checking is handled by `unseal(CHERI_SEALED(MessageQueue *) handle, int permissions)` now, so this removes dead code without changing behavior.
Testing:
- Ran the test suite successfully after the removal.