### PR TITLE
benchmarks: enable clang-format and clang-tidy

### DIFF
--- a/benchmarks/compartment-call/callee.cc
+++ b/benchmarks/compartment-call/callee.cc
@@ -15,7 +15,7 @@ int callee_stack_using_return_metric(size_t stackUse)
 	return METRIC();
 }
 
-int callee_dereference(int *p)
+int callee_dereference(const int *p)
 {
 	return *p;
 }

--- a/benchmarks/compartment-call/callee.h
+++ b/benchmarks/compartment-call/callee.h
@@ -11,9 +11,9 @@ int __cheri_compartment("callee") callee_check_pointer_return_metric(void *);
 int __cheri_compartment("callee") callee_ephemeral_claim_return_metric(void *);
 int __cheri_compartment("callee") callee_claim_release_return_metric(void *);
 
-int __cheri_compartment("callee") callee_dereference(int *);
+int __cheri_compartment("callee") callee_dereference(const int *);
 
-int __cheri_compartment("callee_ueh") callee_ueh_dereference(int *);
-int __cheri_compartment("callee_seh") callee_seh_dereference(int *);
+int __cheri_compartment("callee_ueh") callee_ueh_dereference(const int *);
+int __cheri_compartment("callee_seh") callee_seh_dereference(const int *);
 
 int __cheri_libcall lib_noop_return_metric();

--- a/benchmarks/compartment-call/callee_seh.cc
+++ b/benchmarks/compartment-call/callee_seh.cc
@@ -3,7 +3,7 @@
 #include <errno.h>
 #include <unwind.h>
 
-int callee_seh_dereference(int *p)
+int callee_seh_dereference(const int *p)
 {
 	CHERIOT_DURING
 	{

--- a/benchmarks/compartment-call/callee_ueh.cc
+++ b/benchmarks/compartment-call/callee_ueh.cc
@@ -8,7 +8,7 @@ compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 	return ForceUnwind;
 }
 
-int callee_ueh_dereference(int *p)
+int callee_ueh_dereference(const int *p)
 {
 	return *p;
 }

--- a/benchmarks/compartment-call/caller.cc
+++ b/benchmarks/compartment-call/caller.cc
@@ -10,7 +10,7 @@
 
 using Debug = ConditionalDebug<DEBUG_CALLER, "Compartment call benchmark">;
 
-DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(MALLOC_CAP_TWO, 1024);
+DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(mallocCapTwo, 1024);
 
 __noinline int local_noop_return_metric()
 {
@@ -187,8 +187,7 @@ int __cheri_compartment("caller") run()
 		  [](int) { return local_check_pointer_return_metric(&nextResult); });
 
 		Timeout t{UnlimitedTimeout};
-		void   *alloc =
-		  heap_allocate(&t, STATIC_SEALED_VALUE(MALLOC_CAP_TWO), 10);
+		void *alloc = heap_allocate(&t, STATIC_SEALED_VALUE(mallocCapTwo), 10);
 
 		printf("#heap_claim_ephemeral\n");
 		benchWithMiddle(

--- a/benchmarks/interrupt-latency-ext/interrupt_bench.cc
+++ b/benchmarks/interrupt-latency-ext/interrupt_bench.cc
@@ -30,7 +30,7 @@ struct Source
 
 	auto futex()
 	{
-		return static_cast<uint32_t*>(nullptr);
+		return static_cast<uint32_t *>(nullptr);
 	}
 
 	void init()

--- a/benchmarks/interrupt-latency/interrupt_bench.cc
+++ b/benchmarks/interrupt-latency/interrupt_bench.cc
@@ -47,15 +47,15 @@ int __cheri_compartment("interrupt_bench") entry_high_priority()
 		}
 
 		int    end       = CHERI::with_interrupts_disabled([&]() {
-            uint32_t bits = 0;
-            Debug::log("Thread {} releasing ticket lock", threadID);
-            g.unlock();
-            Debug::log("Thread {} waiting on event", threadID);
-            event.wait(0);
-            int time = rdcycle();
-            Debug::Invariant(event == 1, "Futex woke spuriously");
-            return time;
-		         });
+			uint32_t bits = 0;
+			Debug::log("Thread {} releasing ticket lock", threadID);
+			g.unlock();
+			Debug::log("Thread {} waiting on event", threadID);
+			event.wait(0);
+			int time = rdcycle();
+			Debug::Invariant(event == 1, "Futex woke spuriously");
+			return time;
+		});
 		size_t stackSize = get_stack_size();
 		printf(__XSTRING(BOARD) "\t%d\t%d\n", stackSize, end - start);
 	}

--- a/benchmarks/timing.h
+++ b/benchmarks/timing.h
@@ -1,4 +1,3 @@
-#include "cdefs.h"
 #include <cheri.hh>
 #include <platform-rdcycle.h>
 

--- a/benchmarks/timing.h
+++ b/benchmarks/timing.h
@@ -46,18 +46,21 @@ namespace
 
 	void use_stack(size_t s)
 	{
-		volatile uint8_t stack_array[s];
-		stack_array[0] = 1;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+		volatile uint8_t stackArray[s];
+#pragma clang diagnostic pop
+		stackArray[0] = 1;
 	}
 
 	void check_stack_zeroed()
 	{
 		register void **cspRegister asm("csp");
 		asm("" : "=C"(cspRegister));
-		CHERI::Capability stack{cspRegister};
-		CHERI::Capability<void*> stackP{stack};
+		CHERI::Capability         stack{cspRegister};
+		CHERI::Capability<void *> stackP{stack};
 		stackP.address() = stack.base();
-		while(stackP.address() < stack.address())
+		while (stackP.address() < stack.address())
 		{
 			CHERI::Capability<void> value{*stackP};
 			if (value != NULL)

--- a/benchmarks/timing.h
+++ b/benchmarks/timing.h
@@ -1,3 +1,4 @@
+#include "cdefs.h"
 #include <cheri.hh>
 #include <platform-rdcycle.h>
 
@@ -46,10 +47,9 @@ namespace
 
 	void use_stack(size_t s)
 	{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+		__clang_ignored_warning_push("-Wvla-cxx-extension");
 		volatile uint8_t stackArray[s];
-#pragma clang diagnostic pop
+		__clang_ignored_warning_pop();
 		stackArray[0] = 1;
 	}
 

--- a/scripts/generate_compile_commands.sh
+++ b/scripts/generate_compile_commands.sh
@@ -12,7 +12,7 @@ find_sdk $1
 echo "Using SDK=$SDK"
 
 # Generate compile_commands.json for all of the extra tests and examples.
-for dir in tests.extra/*/ ex*/[[:digit:]]* ; do
+for dir in tests.extra/*/ ex*/[[:digit:]]* benchmarks/*/; do
     echo Generating compile_commands.json for $dir
     (cd $dir && xmake f --sdk="${SDK}" && xmake project -k compile_commands)
 done

--- a/scripts/run_clang_tidy_format.sh
+++ b/scripts/run_clang_tidy_format.sh
@@ -26,7 +26,7 @@ if which nproc ; then
 else
 	PARALLEL_JOBS=$(sysctl -n kern.smp.cpus)
 fi
-DIRECTORIES="sdk tests examples tests.extra"
+DIRECTORIES="sdk tests examples tests.extra benchmarks"
 # Standard headers should be included once we move to a clang-tidy that
 # supports NOLINTBEGIN to disable specific checks over a whole file.
 # In particular, modernize-redundant-void-arg should be disabled in any header


### PR DESCRIPTION
Added `benchmarks/*` to `generate_compile_commands.sh` and `run_clang_tidy_format.sh` so benchmark files are included in the clang-format and clang-tidy checks.
Fixed the resulting style issues in the benchmark files and confirmed that the benchmark files pass the checks.