### PR TITLE
Complete the migration to TimeoutArgument.

### DIFF
--- a/examples/06.producer-consumer/consumer.cc
+++ b/examples/06.producer-consumer/consumer.cc
@@ -47,9 +47,9 @@ int __cheri_compartment("consumer") run()
 	                 "Compartment call to futex_wake failed");
 	Debug::log("Waiting for messages");
 	// Get a message from the queue and print it.  This blocks indefinitely.
-	int     value = 0;
-	Timeout t{UnlimitedTimeout};
-	while ((value != 199) && (queue_receive_sealed(&t, queue, &value) == 0))
+	int value = 0;
+	while ((value != 199) &&
+	       (queue_receive_sealed(TimeoutWaitForever, queue, &value) == 0))
 	{
 		Debug::log("Read {} from queue", value);
 	}

--- a/sdk/include/event.h
+++ b/sdk/include/event.h
@@ -15,8 +15,6 @@
  * abstraction on top of futexes directly.
  */
 
-#include "cdefs.h"
-#include "thread.h"
 #include <compartment-macros.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -32,7 +30,7 @@ struct EventGroup;
  * If the timeout expires then this returns `-ETIMEDOUT`, if memory cannot be
  * allocated it returns `-ENOMEM`.
  */
-int __cheri_libcall eventgroup_create(struct Timeout     *timeout,
+int __cheri_libcall eventgroup_create(TimeoutArgument     timeout,
                                       AllocatorCapability heapCapability,
                                       struct EventGroup **outGroup);
 
@@ -57,7 +55,7 @@ int __cheri_libcall eventgroup_create(struct Timeout     *timeout,
  * If `clearOnExit` is true and this returns successfully then the bits in
  * `bitsWanted` will be cleared in the event group before this returns.
  */
-int __cheri_libcall eventgroup_wait(Timeout           *timeout,
+int __cheri_libcall eventgroup_wait(TimeoutArgument    timeout,
                                     struct EventGroup *group,
                                     uint32_t          *outBits,
                                     uint32_t           bitsWanted,
@@ -75,7 +73,7 @@ int __cheri_libcall eventgroup_wait(Timeout           *timeout,
  * Independent of success or failure, `outBits` will be used to return the set
  * of currently set bits in this event group.
  */
-int __cheri_libcall eventgroup_set(Timeout           *timeout,
+int __cheri_libcall eventgroup_set(TimeoutArgument    timeout,
                                    struct EventGroup *group,
                                    uint32_t          *outBits,
                                    uint32_t           bitsToSet);
@@ -90,7 +88,7 @@ int __cheri_libcall eventgroup_set(Timeout           *timeout,
  * Independent of success or failure, `outBits` will be used to return the set
  * of currently set bits in this event group.
  */
-int __cheri_libcall eventgroup_clear(Timeout           *timeout,
+int __cheri_libcall eventgroup_clear(TimeoutArgument    timeout,
                                      struct EventGroup *group,
                                      uint32_t          *outBits,
                                      uint32_t           bitsToClear);

--- a/sdk/include/queue.h
+++ b/sdk/include/queue.h
@@ -113,7 +113,7 @@ ssize_t __cheri_libcall queue_allocation_size(size_t elementSize,
  * arguments are invalid (for example, if the requested number of elements
  * multiplied by the element size would overflow).
  */
-int __cheri_libcall queue_create(Timeout              *timeout,
+int __cheri_libcall queue_create(TimeoutArgument       timeout,
                                  AllocatorCapability   heapCapability,
                                  struct MessageQueue **outQueue,
                                  size_t                elementSize,
@@ -155,7 +155,7 @@ int __cheri_libcall queue_destroy(AllocatorCapability  heapCapability,
  * This expects to be called with a valid queue handle.  It does not validate
  * that this is correct.
  */
-int __cheri_libcall queue_send(Timeout             *timeout,
+int __cheri_libcall queue_send(TimeoutArgument      timeout,
                                struct MessageQueue *handle,
                                const void          *src);
 
@@ -170,7 +170,7 @@ int __cheri_libcall queue_send(Timeout             *timeout,
  * This expected to be called with a valid queue handle.  It does not validate
  * that this is correct.
  */
-int __cheri_libcall queue_send_multiple(Timeout             *timeout,
+int __cheri_libcall queue_send_multiple(TimeoutArgument      timeout,
                                         struct MessageQueue *handle,
                                         const void          *src,
                                         size_t               count);
@@ -184,7 +184,7 @@ int __cheri_libcall queue_send_multiple(Timeout             *timeout,
  * Returns 0 on success, `-ETIMEDOUT` if the timeout was exhausted, `-EINVAL` on
  * invalid arguments.
  */
-int __cheri_libcall queue_receive(Timeout             *timeout,
+int __cheri_libcall queue_receive(TimeoutArgument      timeout,
                                   struct MessageQueue *handle,
                                   void                *dst);
 
@@ -199,7 +199,7 @@ int __cheri_libcall queue_receive(Timeout             *timeout,
  * This expected to be called with a valid queue handle.  It does not validate
  * that this is correct.
  */
-int __cheri_libcall queue_receive_multiple(Timeout             *timeout,
+int __cheri_libcall queue_receive_multiple(TimeoutArgument      timeout,
                                            struct MessageQueue *handle,
                                            void                *dst,
                                            size_t               count);
@@ -225,7 +225,7 @@ int __cheri_libcall queue_items_remaining(struct MessageQueue *handle,
  * receiving.
  */
 int __cheri_compartment("message_queue")
-  queue_create_sealed(Timeout            *timeout,
+  queue_create_sealed(TimeoutArgument     timeout,
                       AllocatorCapability heapCapability,
                       CHERI_SEALED(struct MessageQueue *) * outQueue,
                       size_t elementSize,
@@ -237,7 +237,8 @@ int __cheri_compartment("message_queue")
  * Returns 0 on success, `-ETIMEDOUT` if this cannot be done in the available
  * timeout.
  */
-int __cheri_libcall queue_reset(Timeout *timeout, struct MessageQueue *queue);
+int __cheri_libcall queue_reset(TimeoutArgument      timeout,
+                                struct MessageQueue *queue);
 
 /**
  * Destroy a queue.  This requires a handle with `MessageQueuePermitDestroy`
@@ -247,7 +248,7 @@ int __cheri_libcall queue_reset(Timeout *timeout, struct MessageQueue *queue);
  * or lacks the relevant permissions.
  */
 int __cheri_compartment("message_queue")
-  queue_destroy_sealed(Timeout            *timeout,
+  queue_destroy_sealed(TimeoutArgument     timeout,
                        AllocatorCapability heapCapability,
                        CHERI_SEALED(struct MessageQueue *) queueHandle);
 
@@ -258,7 +259,7 @@ int __cheri_compartment("message_queue")
  * destroyed during the call.
  */
 int __cheri_compartment("message_queue")
-  queue_send_sealed(Timeout *timeout,
+  queue_send_sealed(TimeoutArgument timeout,
                     CHERI_SEALED(struct MessageQueue *) handle,
                     const void *src);
 
@@ -269,7 +270,7 @@ int __cheri_compartment("message_queue")
  * `-ECOMPARTMENTFAIL` if the queue is destroyed during the call.
  */
 int __cheri_compartment("message_queue")
-  queue_send_multiple_sealed(Timeout *timeout,
+  queue_send_multiple_sealed(TimeoutArgument timeout,
                              CHERI_SEALED(struct MessageQueue *) handle,
                              const void *src,
                              size_t      count);
@@ -281,7 +282,7 @@ int __cheri_compartment("message_queue")
  * queue is destroyed during the call.
  */
 int __cheri_compartment("message_queue")
-  queue_receive_sealed(Timeout *timeout,
+  queue_receive_sealed(TimeoutArgument timeout,
                        CHERI_SEALED(struct MessageQueue *) handle,
                        void *dst);
 
@@ -292,7 +293,7 @@ int __cheri_compartment("message_queue")
  * `-ECOMPARTMENTFAIL` if the queue is destroyed during the call.
  */
 int __cheri_compartment("message_queue")
-  queue_receive_multiple_sealed(Timeout *timeout,
+  queue_receive_multiple_sealed(TimeoutArgument timeout,
                                 CHERI_SEALED(struct MessageQueue *) handle,
                                 void  *dst,
                                 size_t count);
@@ -386,7 +387,7 @@ static inline CHERI_SEALED(struct MessageQueue *)
 static inline int __attribute__((
   deprecated("Restricted handles have been replaced by permissions on queue "
              "capabilities, controlled with queue_permissions_and")))
-queue_receive_handle_create_sealed(struct Timeout     *timeout,
+queue_receive_handle_create_sealed(TimeoutArgument     timeout,
                                    AllocatorCapability heapCapability,
                                    CHERI_SEALED(struct MessageQueue *) handle,
                                    CHERI_SEALED(struct MessageQueue *) *
@@ -407,7 +408,7 @@ queue_receive_handle_create_sealed(struct Timeout     *timeout,
 static inline int __attribute__((
   deprecated("Restricted handles have been replaced by permissions on queue "
              "capabilities, controlled with queue_permissions_and")))
-queue_send_handle_create_sealed(struct Timeout     *timeout,
+queue_send_handle_create_sealed(TimeoutArgument     timeout,
                                 AllocatorCapability heapCapability,
                                 CHERI_SEALED(struct MessageQueue *) handle,
                                 CHERI_SEALED(struct MessageQueue *) * outHandle)

--- a/sdk/include/timeout.hh
+++ b/sdk/include/timeout.hh
@@ -12,8 +12,7 @@
 template<auto Fn, typename... Args>
 __always_inline auto blocking_forever(Args... args)
 {
-	Timeout t{UnlimitedTimeout};
-	return Fn(&t, std::forward<Args>(args)...);
+	return Fn(TimeoutWaitForever, std::forward<Args>(args)...);
 }
 
 /**
@@ -22,6 +21,5 @@ __always_inline auto blocking_forever(Args... args)
 template<auto Fn, typename... Args>
 __always_inline auto non_blocking(Args... args)
 {
-	Timeout t{0};
-	return Fn(&t, std::forward<Args>(args)...);
+	return Fn(TimeoutNoWait, std::forward<Args>(args)...);
 }

--- a/sdk/lib/event_group/event_group.cc
+++ b/sdk/lib/event_group/event_group.cc
@@ -33,7 +33,7 @@ struct EventGroup
 	EventWaiter waiters[];
 };
 
-int eventgroup_create(Timeout            *timeout,
+int eventgroup_create(TimeoutArgument     timeout,
                       AllocatorCapability heapCapability,
                       EventGroup        **outGroup)
 {
@@ -54,12 +54,12 @@ int eventgroup_create(Timeout            *timeout,
 	return 0;
 }
 
-int eventgroup_wait(Timeout    *timeout,
-                    EventGroup *group,
-                    uint32_t   *outBits,
-                    uint32_t    bitsWanted,
-                    bool        waitForAll,
-                    bool        clearOnExit)
+int eventgroup_wait(TimeoutArgument timeout,
+                    EventGroup     *group,
+                    uint32_t       *outBits,
+                    uint32_t        bitsWanted,
+                    bool            waitForAll,
+                    bool            clearOnExit)
 {
 	// Bits wanted can be only a 24-bit value.
 	if (bitsWanted & 0xff000000)
@@ -112,10 +112,10 @@ int eventgroup_wait(Timeout    *timeout,
 	return -ETIMEDOUT;
 }
 
-int eventgroup_clear(Timeout    *timeout,
-                     EventGroup *group,
-                     uint32_t   *outBits,
-                     uint32_t    bitsToClear)
+int eventgroup_clear(TimeoutArgument timeout,
+                     EventGroup     *group,
+                     uint32_t       *outBits,
+                     uint32_t        bitsToClear)
 {
 	if (LockGuard g{group->lock, timeout})
 	{
@@ -129,10 +129,10 @@ int eventgroup_clear(Timeout    *timeout,
 	return -ETIMEDOUT;
 }
 
-int eventgroup_set(Timeout    *timeout,
-                   EventGroup *group,
-                   uint32_t   *outBits,
-                   uint32_t    bitsToSet)
+int eventgroup_set(TimeoutArgument timeout,
+                   EventGroup     *group,
+                   uint32_t       *outBits,
+                   uint32_t        bitsToSet)
 {
 	if (LockGuard g{group->lock, timeout})
 	{

--- a/sdk/lib/locks/semaphore.cc
+++ b/sdk/lib/locks/semaphore.cc
@@ -6,7 +6,7 @@ namespace
 	constexpr uint32_t WaitersBit = 1 << 31;
 } // namespace
 
-int semaphore_get(Timeout *timeout, CountingSemaphoreState *semaphore)
+int semaphore_get(TimeoutArgument timeout, CountingSemaphoreState *semaphore)
 {
 	do
 	{

--- a/sdk/lib/queue/queue.cc
+++ b/sdk/lib/queue/queue.cc
@@ -446,7 +446,7 @@ ssize_t queue_allocation_size(size_t elementSize, size_t elementCount)
 	return allocSize;
 }
 
-int queue_create(Timeout              *timeout,
+int queue_create(TimeoutArgument       timeout,
                  AllocatorCapability   heapCapability,
                  struct MessageQueue **outQueue,
                  size_t                elementSize,
@@ -469,7 +469,7 @@ int queue_create(Timeout              *timeout,
 	return 0;
 }
 
-int queue_send_multiple(Timeout             *timeout,
+int queue_send_multiple(TimeoutArgument      timeout,
                         struct MessageQueue *handle,
                         const void          *src,
                         size_t               count)
@@ -583,12 +583,14 @@ int queue_send_multiple(Timeout             *timeout,
 	return ret;
 }
 
-int queue_send(Timeout *timeout, struct MessageQueue *handle, const void *src)
+int queue_send(TimeoutArgument      timeout,
+               struct MessageQueue *handle,
+               const void          *src)
 {
 	return std::min(0, queue_send_multiple(timeout, handle, src, 1));
 }
 
-int queue_reset(Timeout *timeout, struct MessageQueue *queue)
+int queue_reset(TimeoutArgument timeout, struct MessageQueue *queue)
 {
 	HighBitFlagLock producerLock{queue->producer};
 	HighBitFlagLock consumerLock{queue->consumer};
@@ -604,7 +606,7 @@ int queue_reset(Timeout *timeout, struct MessageQueue *queue)
 	return -ETIMEDOUT;
 }
 
-int queue_receive_multiple(Timeout             *timeout,
+int queue_receive_multiple(TimeoutArgument      timeout,
                            struct MessageQueue *handle,
                            void                *dst,
                            size_t               count)
@@ -723,7 +725,9 @@ int queue_receive_multiple(Timeout             *timeout,
 	return ret;
 }
 
-int queue_receive(Timeout *timeout, struct MessageQueue *handle, void *dst)
+int queue_receive(TimeoutArgument      timeout,
+                  struct MessageQueue *handle,
+                  void                *dst)
 {
 	return std::min(0, queue_receive_multiple(timeout, handle, dst, 1));
 }

--- a/sdk/lib/queue/queue_compartment.cc
+++ b/sdk/lib/queue/queue_compartment.cc
@@ -55,7 +55,7 @@ namespace
 	}
 } // namespace
 
-int queue_create_sealed(Timeout            *timeout,
+int queue_create_sealed(TimeoutArgument     timeout,
                         AllocatorCapability heapCapability,
                         CHERI_SEALED(MessageQueue *) * outQueue,
                         size_t elementSize,
@@ -81,7 +81,7 @@ int queue_create_sealed(Timeout            *timeout,
 	return 0;
 }
 
-int queue_destroy_sealed(Timeout            *timeout,
+int queue_destroy_sealed(TimeoutArgument     timeout,
                          AllocatorCapability heapCapability,
                          CHERI_SEALED(MessageQueue *) queueHandle)
 {
@@ -100,11 +100,11 @@ int queue_destroy_sealed(Timeout            *timeout,
 	  });
 }
 
-int queue_send_sealed(Timeout *timeout,
+int queue_send_sealed(TimeoutArgument timeout,
                       CHERI_SEALED(MessageQueue *) handle,
                       const void *src)
 {
-	if (!check_timeout_pointer(timeout))
+	if (!timeout.is_valid())
 	{
 		return -EINVAL;
 	}
@@ -113,12 +113,12 @@ int queue_send_sealed(Timeout *timeout,
 	});
 }
 
-int queue_send_multiple_sealed(Timeout *timeout,
+int queue_send_multiple_sealed(TimeoutArgument timeout,
                                CHERI_SEALED(MessageQueue *) handle,
                                const void *src,
                                size_t      count)
 {
-	if (!check_timeout_pointer(timeout))
+	if (!timeout.is_valid())
 	{
 		return -EINVAL;
 	}
@@ -127,11 +127,11 @@ int queue_send_multiple_sealed(Timeout *timeout,
 	});
 }
 
-int queue_receive_sealed(Timeout *timeout,
+int queue_receive_sealed(TimeoutArgument timeout,
                          CHERI_SEALED(MessageQueue *) handle,
                          void *dst)
 {
-	if (!check_timeout_pointer(timeout))
+	if (!timeout.is_valid())
 	{
 		return -EINVAL;
 	}
@@ -141,12 +141,12 @@ int queue_receive_sealed(Timeout *timeout,
 	  });
 }
 
-int queue_receive_multiple_sealed(Timeout *timeout,
+int queue_receive_multiple_sealed(TimeoutArgument timeout,
                                   CHERI_SEALED(MessageQueue *) handle,
                                   void  *dst,
                                   size_t count)
 {
-	if (!check_timeout_pointer(timeout))
+	if (!timeout.is_valid())
 	{
 		return -EINVAL;
 	}


### PR DESCRIPTION
PR #708 moved to using either relative timeouts in ticks or absolute timeouts in cycles on some clock.  That PR intentionally did not move *all* APIs to using the new interface, so that we could be certain that callers were not broken.  Now that this is done, move everything to the newer structure.