### PR TITLE
Fixed multiwaiter_wait capability bound check

### DIFF
--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -705,7 +705,7 @@ __cheriot_minimum_stack(0xc0) int multiwaiter_wait(TimeoutArgument    timeout,
 		if (!check_pointer<PermissionSet{Permission::Load,
 		                                 Permission::Store,
 		                                 Permission::LoadStoreCapability}>(
-		      events, newEventsCount * sizeof(newEventsCount)))
+		      events, newEventsCount * sizeof(EventWaiterSource)))
 		{
 			Debug::log("Invalid new events pointer: {}", events);
 			return -EINVAL;


### PR DESCRIPTION
**Problem:**
`multiwaiter_wait` should check that the `events` capability covers the `EventWaiterSource` array. The old code used `sizeof(newEventsCount)`, which is equivalent to `sizeof(size_t)` instead of the actual element size.

**Solution:**
Changed the bounds check to use `sizeof(EventWaiterSource)`.

**Checks:**
1. Ran tests after the fix.
2. Ran clang-format and clang-tidy.