### PR TITLE
Add support for clocks as described in docs/Clocks.md.

### DIFF
--- a/docs/Clocks.md
+++ b/docs/Clocks.md
@@ -83,7 +83,7 @@ struct ExampleClockSource
 	 * this time source is that this is a good time.  Larger values indicate
 	 * more confidence.
 	 */
-    int get_time(uint64_t &outRealTime, uint64_t &outMonotonicTime, int &outPriority);
+    int get_time(TimeoutArgument timeout, uint64_t &outRealTime, uint64_t &outMonotonicTime, int &outPriority);
 
 	/**
 	 * Set the current wall-clock time.  This return 0 on succcess, some

--- a/sdk/include/platform/concepts/wall_clock_source.hh
+++ b/sdk/include/platform/concepts/wall_clock_source.hh
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <concepts>
+#include <time.h>
+#include <timeout.h>
+
+/**
+ * Concept for wall-clock time sources (and sinks, if they support persisting
+ * time).
+ */
+template<typename T>
+concept IsWallClockSource =
+  requires(T v, TimeoutArgument t, clock_t c, int i) {
+	  /// Clock sources must expose whether they support setting the time.
+	  { T::SupportsTimeSetting } -> std::same_as<const bool &>;
+	  /**
+	   * Clock sources must expose whether they are cheap enough to call
+	   * every time a user asks for the clock to be updated or only after
+	   * there is some reasonable possibility of clock drift.
+	   */
+	  { T::IsCheap } -> std::same_as<const bool &>;
+
+	  /**
+	   * Clock sources must provide a mechanism to get a matching pair of
+	   * monotonic and wall-clock time and a priority.  This returns 0 on
+	   * success.
+	   */
+	  { v.get_time(t, c, c, i) } -> std::same_as<int>;
+  } &&
+  ((T::SupportsTimeSetting == true) &&
+     requires(T v) {
+	     {
+		     v.set_time(std::declval<TimeoutArgument>, std::declval<clock_t &>)
+	     } -> std::same_as<int>;
+     } ||
+   requires { !T::SupportsTimeSetting; });

--- a/sdk/include/sys/time.h
+++ b/sdk/include/sys/time.h
@@ -1,0 +1,48 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+#pragma once
+/**
+ * \file
+ * POSIX time definitions.  This is *not* a complete implementation of the POSIX
+ * spec.  The following are not implemented in CHERIoT RTOS:
+ *
+ *  -  `FD_CLR()`, `FD_ISSET()`, `FD_SET(), `FD_ZERO()`, `FD_SETSIZE`, and
+ * `fd_set`, used for `select`.
+ *  - `select` is not implemented because we do not have the POSIX file
+ * descriptor abstraction, use the APIs in `multiwaiter.h` to wait for multiple
+ * event sources.
+ *  - `utimes`, which depends on a filesystem.
+ *  - `getitimer` and `setitimer`, which are deprecated in POSIX.
+ */
+
+#include <cdefs.h>
+#include <stdint.h>
+
+// The names in this file come from C or POSIX and so do not correspond to our
+// naming scheme.  This header is expected to be included in C, so should also
+// not provide warnings about void in function parameter lists.
+// NOLINTBEGIN(readability-identifier-naming,modernize-redundant-void-arg)
+
+/// Type for holding seconds
+typedef int64_t time_t;
+/// Type for holding microseconds up to one second, which requires 20 bits.
+typedef uint32_t suseconds_t;
+
+/**
+ * Type used for time values as seconds and microseconds.
+ */
+struct timeval
+{
+	/// Number of seconds.
+	time_t tv_sec;
+	/// Number of microseconds (must be less than 1,000,000)
+	suseconds_t tv_usec;
+};
+
+/**
+ * Get the current wall-clock time.  The time-zone parameter is unused.
+ */
+__cheriot_libcall int gettimeofday(struct timeval *__restrict tp,
+                                   void *__restrict tzp);
+
+// NOLINTEND(readability-identifier-naming,modernize-redundant-void-arg)

--- a/sdk/include/time.h
+++ b/sdk/include/time.h
@@ -1,5 +1,136 @@
 // Copyright Microsoft and CHERIoT Contributors.
 // SPDX-License-Identifier: MIT
+#pragma once
 
-// libc++ headers expect this file to exist, but don't require any definitions
-// from it and so we can provide an empty version.
+/**
+ * \file .
+ *
+ * Standard clock support.
+ */
+
+#include <platform-time.h>
+#include <stdint.h>
+#include <sys/time.h>
+#include <thread.h>
+
+// The names in this file come from C or POSIX and so do not correspond to our
+// naming scheme.  This header is expected to be included in C, so should also
+// not provide warnings about void in function parameter lists.
+// NOLINTBEGIN(readability-identifier-naming,modernize-redundant-void-arg)
+
+/// ID for a clock.  Only monotonic and 'realtime' (wall clock) are supported.
+typedef enum __clockid_t
+{
+	/**
+	 * The monotonic clock. This is zero at system start and increments at a
+	 * fixed rate.
+	 */
+	CLOCK_MONOTONIC,
+	/**
+	 * The wall-clock time.
+	 *
+	 * This clock's value is meaningful only if `clock_update_wall_clock` has
+	 * been called at least once and there is at least one working clock source
+	 * in the system.
+	 */
+	CLOCK_REALTIME,
+	/**
+	 * CPU time consumed by the current thread, since boot time.  This clock is
+	 * equivalent to `CLOCK_MONOTONIC` if the scheduler is not compiled with
+	 * support for accounting.  Add `--scheduler-accounting=y` to your build
+	 * configuration line to enable this.
+	 */
+	CLOCK_THREAD_CPUTIME_ID,
+	/**
+	 * CPU time consumed by the current 'process'.  This value is defined by
+	 * POSIX, but CHERIoT RTOS does not have a direct equivalent of a process
+	 * and so this value is equivalent to `CLOCK_THREAD_CPUTIME_ID`, with all of
+	 * the attendant caveats.
+	 */
+	CLOCK_PROCESS_CPUTIME_ID = CLOCK_THREAD_CPUTIME_ID,
+} clockid_t;
+
+/**
+ * The number of ticks on the monotonic clock per second.
+ */
+#define CLOCKS_PER_SEC ((clock_t)CPU_TIMER_HZ)
+
+/**
+ * Flag to indicate that a timespec should be treated as an absolute, rather
+ * than relative, time.
+ */
+#define TIMER_ABSTIME 1
+
+/**
+ * Type for holding time.  The `CLOCKS_PER_SEC` macro defines the value in this
+ * type that corresponds to one second.  This rate is SoC-specific.
+ */
+typedef uint64_t clock_t;
+
+/**
+ * A time value with up to nanosecond precision.
+ */
+struct timespec
+{
+	/// Seconds
+	time_t tv_sec;
+	/**
+	 * Nanoseconds
+	 *
+	 * Note that POSIX and pre-C23 versions of C specify that this is `long`,
+	 * but they require that the values be between 0 and 999,999,999
+	 * (inclusive).  C23 allows this to be any type capable of representing
+	 * this range and so we use `uint32_t`.
+	 */
+	uint32_t tv_nsec;
+};
+
+__BEGIN_DECLS
+
+/**
+ * Returns the amount of CPU time (in units defined by `CLOCKS_PER_SEC`) that
+ * are accounted to the current thread (POSIX specifies 'process' here, but
+ * CHERIoT RTOS does not have an directly analogous abstraction).
+ *
+ * Note: If scheduler accounting is not enabled, this API will return the
+ * total elapsed uptime instead.  Add `--scheduler-accounting=y` to your build
+ * configuration line to enable this.
+ */
+static inline clock_t clock(void)
+{
+#if SCHEDULER_ACCOUNTING == true
+	return thread_elapsed_cycles_current();
+#else
+	return platform_monotonic_time_read();
+#endif
+}
+
+/**
+ * Retrieve the time from the specified clock as a `timespec`.
+ *
+ * If `clockID` is `CLOCK_REALTIME`, the returned value is meaningful only if
+ * `clock_update_wall_clock` has been called at least once and there is at least
+ * one working clock source in the system.
+ */
+__cheriot_libcall int clock_gettime(clockid_t        clockID,
+                                    struct timespec *outTime);
+
+/**
+ * Update the wall-clock time from available time sources.
+ */
+__cheriot_compartment("wall_clock") int clock_update_wall_clock(
+  TimeoutArgument timeout);
+
+/**
+ * POSIX-compatible time() implementation.  Returns the time in seconds since
+ * the UNIX epoch.
+ *
+ * This value is meaningful only if `clock_update_wall_clock` has been called at
+ * least once and there is at least one working clock source in the system.
+ *
+ */
+__cheriot_libcall time_t time(time_t *tloc);
+
+__END_DECLS
+
+// NOLINTEND(readability-identifier-naming,modernize-redundant-void-arg)

--- a/sdk/lib/README.md
+++ b/sdk/lib/README.md
@@ -8,6 +8,7 @@ This collection currently includes:
 
  - [atomic](atomic/) provides atomic support functions.
  - [compartment_helpers](compartment_helpers/) contains helpers for checking / ensuring that pointers are valid.
+ - [clock](clock/) provides support for wall-clock time.
  - [crt](crt/) provides C runtime functions that the compiler may emit.
  - [cxxrt](cxxrt/) provides a minimal C++ runtime (no exceptions or RTTI support).
  - [debug](debug/) contains functions to support the debug logging APIs.

--- a/sdk/lib/clock/README.md
+++ b/sdk/lib/clock/README.md
@@ -1,0 +1,50 @@
+Clock support
+=============
+
+This directory contains two components, the `clock_helpers` library and the `wall_clock` compartment.
+These work in tandem.
+The `wall_clock` compartment manages clock sources and exposes a shared-memory object that allows mapping from the monotonic clock (which is expected to be readable from any compartment by reading an MMIO region or CSR) to a wall-clock time.
+The `clock_helpers` library provides POSIX-compatible accessors for reading clocks.
+
+The design for this is in [`docs/Clocks.md`](../../../docs/Clocks.md).
+
+Adding a clock source
+---------------------
+
+To add a clock source, you must implement the clock-source concept and expose it to this compartment.
+The concept is in the [platform/concepts/wall_clock_source.hh](../../include/platform/concepts/wall_clock_source.hh) header.
+Implementations may be entirely inline in the header (for example, if the clock is a hardware device with a simple interface) or may call other compartments (for example, if the clock source is NTP or similar).
+
+The `wall_clock` compartment will perform the entire update sequence with a lock held, so clock implementations do not need to handle reentrant invocation.
+They should gracefully recover if they trap and not leave themselves in an unrecoverable state.
+
+If your implementation is called `MyWallClockSource` then you may find it useful to add a line such as this to validate compliance with the concept:
+
+```c++
+static_assert(IsWallClockSource<MyWallClockSource>,
+              "The SNTP wall-clock source must implement the required concept");
+```
+
+You will then need to add the following in the build logic for your target:
+
+```lua
+  after_load(function(target)
+      import("core.project.project")
+      local wall_clock = project.target("wall_clock")
+      if (wall_clock) then
+          print("Adding dependency on wall-clock compartment");
+          target:add("deps", "wall_clock")
+          wall_clock:add("includedirs", path.join(target:scriptdir(), "{relative path to where your header is in your target's directory}"))
+          wall_clock:add("cheriot.clock_source_includes", "{name of your header}")
+          wall_clock:add("cheriot.clock_source_types", "{name of the type for your clock source}")
+      else
+          raise("Did not find wall-clock compartment")
+      end
+  end)
+```
+
+This looks up the wall-clock compartment and *adds* values three property arrays:
+
+ - `includedirs` defines the include directories where this compartment will look for headers.
+ - `cheriot.clock_source_includes` defines the include files that the wall-clock compartment will include.
+ - `cheriot.clock_source_types` defines the list of types that will be used for defining a read-time clock.

--- a/sdk/lib/clock/clock-helpers.cc
+++ b/sdk/lib/clock/clock-helpers.cc
@@ -1,0 +1,114 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "wall_clock.hh"
+#include <compartment-macros.h>
+#include <debug.hh>
+#include <sys/time.h>
+#include <tick_macros.h>
+#include <time.h>
+
+using Debug = ConditionalDebug<false, "Clock helper">;
+
+namespace
+{
+	/**
+	 * Internal helper that fetches the current time from the shared-memory
+	 * object.
+	 */
+	clock_t wall_clock_time_get()
+	{
+		auto &synchronisedTime = *SHARED_OBJECT_WITH_PERMISSIONS(
+		  SynchronisedTime, wall_clock_time, true, false, false, false, false);
+		clock_t  wallClockTime;
+		clock_t  monotonicTime;
+		uint32_t epoch;
+		do
+		{
+			epoch = synchronisedTime.updatingEpoch.load();
+			// If the low bit is set then the time is being updated.  Wait for
+			// the update to finish.
+			if (epoch & 0x1)
+			{
+				Debug::log("Waiting for published time to update");
+				// Wait for the update to finish, include a timeout in case the
+				// update doesn't have enough stack or trusted stack to notify
+				// the futex.
+				Timeout t{MS_TO_TICKS(10)};
+				synchronisedTime.updatingEpoch.wait(&t, epoch);
+				continue;
+			}
+			wallClockTime = synchronisedTime.wallClockTime;
+			monotonicTime = synchronisedTime.monotonicTime;
+		} while (epoch != synchronisedTime.updatingEpoch.load());
+		// Fetch the monotonic time to calculate the time elapsed since the
+		// snapshot was published.
+		uint64_t now = platform_monotonic_time_read();
+		// Elapsed time in cycles
+		uint64_t elapsed = now - monotonicTime;
+		Debug::log(
+		  "Elapsed cycles {} (elapsed seconds: {}) (now: {}, timestamp: {})",
+		  static_cast<int64_t>(elapsed),
+		  static_cast<int>(elapsed / CPU_TIMER_HZ),
+		  static_cast<int64_t>(now),
+		  static_cast<int64_t>(monotonicTime));
+		return wallClockTime + elapsed;
+	}
+} // namespace
+
+int gettimeofday(struct timeval *tp, void *)
+{
+	clock_t now        = wall_clock_time_get();
+	tp->tv_sec         = now / CPU_TIMER_HZ;
+	clock_t subseconds = now % CPU_TIMER_HZ;
+	// Avoid integer rounding errors by *first* multiplying and then dividing.
+	// This is equivalent to subseconds /= (CPU_TIMER_HZ / 1'000'000).
+	subseconds *= 1'000'000;
+	subseconds /= CPU_TIMER_HZ;
+	tp->tv_usec = subseconds;
+	return 0;
+}
+
+int clock_gettime(clockid_t clockID, struct timespec *tp)
+{
+	clock_t now = 0;
+	switch (clockID)
+	{
+		case CLOCK_THREAD_CPUTIME_ID:
+			// Fall back to monotonic time if scheduler accounting is disabled.
+#if SCHEDULER_ACCOUNTING == true
+			now = thread_elapsed_cycles_current();
+			break;
+#else
+			[[fallthrough]];
+#endif
+		case CLOCK_MONOTONIC:
+			now = platform_monotonic_time_read();
+			break;
+		case CLOCK_REALTIME:
+			now = wall_clock_time_get();
+			break;
+		default:
+			return -1;
+	}
+	tp->tv_sec         = now / CPU_TIMER_HZ;
+	clock_t subseconds = now % CPU_TIMER_HZ;
+	// Avoid integer rounding errors by *first* multiplying and then dividing.
+	// This is equivalent to subseconds /= (CPU_TIMER_HZ / 1'000'000'000).  Note
+	// that tv_usec is a 32-bit value (nanoseconds in
+	subseconds *= 1'000'000'000;
+	subseconds /= CPU_TIMER_HZ;
+	tp->tv_nsec = static_cast<long>(subseconds);
+	return 0;
+}
+
+time_t time(time_t *tloc)
+{
+	clock_t now        = wall_clock_time_get();
+	time_t  nowSeconds = now / CPU_TIMER_HZ;
+	if (tloc != NULL)
+	{
+		*tloc = nowSeconds;
+	}
+	return nowSeconds;
+}

--- a/sdk/lib/clock/rtc_sources.hh.in
+++ b/sdk/lib/clock/rtc_sources.hh.in
@@ -1,0 +1,27 @@
+#include <tuple>
+#include <platform/concepts/wall_clock_source.hh>
+
+@include_implementations@
+
+/**
+ * Placeholder for systems with no wall clock.
+ */
+struct NoWallClockSource
+{
+	/// This doesn't set the time
+	static constexpr bool SupportsTimeSetting = false;
+	/// This does noting, it is cheap.
+	static constexpr bool IsCheap = true;
+	/// Return a zero time.
+	__always_inline int get_time(TimeoutArgument, clock_t &outRealTime, clock_t &outMonotonicTime, int &outPriority)
+	{
+		outRealTime = 0;
+		outMonotonicTime = 0;
+		outPriority = std::numeric_limits<int>::min();
+		return 0;
+	}
+};
+
+static_assert(IsWallClockSource<NoWallClockSource>, "Placeholder is not a valid wall clock soure");
+
+using ClockSources = std::tuple<@clock_sources@ NoWallClockSource>;

--- a/sdk/lib/clock/wall_clock.cc
+++ b/sdk/lib/clock/wall_clock.cc
@@ -1,0 +1,185 @@
+#include <debug.hh>
+#include <limits>
+#include <locks.hh>
+#include <platform-time.h>
+#include <sys/time.h>
+#include <time.h>
+#include <timeout.h>
+#include <unwind.h>
+
+// Appease clang-tidy and LSP by providing a stub implementation if we don't
+// have a build configuration that provides this file yet.
+#if __has_include("rtc_sources.hh")
+#	include "rtc_sources.hh"
+#else
+#	include <tuple>
+#	include <platform/concepts/wall_clock_source.hh>
+
+struct NoWallClockSource
+{
+	static constexpr bool SupportsTimeSetting = false;
+	static constexpr bool IsCheap             = true;
+	int                   get_time(TimeoutArgument,
+	                               clock_t &outRealTime,
+	                               clock_t &outMonotonicTime,
+	                               int     &outPriority);
+};
+static_assert(IsWallClockSource<NoWallClockSource>,
+              "Placeholder is not a valid wall clock soure");
+
+using ClockSources = std::tuple<NoWallClockSource>;
+#endif
+
+#include "wall_clock.hh"
+
+namespace
+{
+	/// Debugging for this component
+	using Debug = ConditionalDebug<false, "Wall clock">;
+
+	/**
+	 * Number of seconds to check expensive time sources.  Defaults to once per
+	 * minute.
+	 */
+	constexpr uint64_t TimeToCheckExpensiveSources = 60ULL * CPU_TIMER_HZ;
+
+	/**
+	 * A tuple of clock sources.
+	 */
+	ClockSources clockSources;
+
+	/**
+	 * Helper to visit each clock source in `clockSources` and invoke
+	 * `callback` on each.  The `callback` parameter should be a generic lambda
+	 * (taking the argument as an `auto`-type parameter) and will be
+	 * specialised to each concrete instance of the type.
+	 */
+	template<size_t I = 0>
+	void visit_clock_sources(auto &&callback)
+	{
+		callback(std::get<I>(clockSources), I);
+		if constexpr (I + 1 < std::tuple_size_v<ClockSources>)
+		{
+			visit_clock_sources<I + 1>(callback);
+		}
+	}
+
+} // namespace
+
+int clock_update_wall_clock(TimeoutArgument timeout)
+{
+	static FlagLock updatingLock;
+	auto           &synchronisedTime = *SHARED_OBJECT_WITH_PERMISSIONS(
+	  SynchronisedTime, wall_clock_time, true, true, false, false, false);
+	if (LockGuard g{updatingLock, timeout})
+	{
+		// Error handler to ensure that the lock is released if a clock source
+		// crashes.
+		CHERIOT_DURING
+
+		int     bestScore = std::numeric_limits<int>::min();
+		clock_t bestWallClock;
+		clock_t bestMonotonicClock;
+		clock_t lastSynchronisationTime;
+
+		// Get the current time.
+		uint32_t epoch;
+		do
+		{
+			epoch = synchronisedTime.updatingEpoch.load();
+			// If the low bit is set then the time is being updated.  Wait for
+			// the update to finish.
+			if (epoch & 0x1)
+			{
+				// Wait for the update to finish
+				synchronisedTime.updatingEpoch.wait(timeout, epoch);
+				continue;
+			}
+			lastSynchronisationTime = synchronisedTime.monotonicTime;
+		} while (epoch != synchronisedTime.updatingEpoch.load());
+
+		// If the time since the last expensive update is above the threshold,
+		// update from expensive sources as well as cheap ones.
+		clock_t timeSinceLastSynchronisation =
+		  platform_monotonic_time_read() - lastSynchronisationTime;
+		bool shouldUpdateExpensive =
+		  (lastSynchronisationTime == 0) ||
+		  (timeSinceLastSynchronisation >= TimeToCheckExpensiveSources);
+
+		bool anySucceeded = false;
+		int  bestSource   = -1;
+
+		// Check each source and find the one that gives the best score.
+		visit_clock_sources([&](auto &&source, int i) {
+			int     score;
+			clock_t monotonicTime;
+			clock_t wallclockTime;
+			if (source.IsCheap || shouldUpdateExpensive)
+			{
+				CHERIOT_DURING
+				if (source.get_time(
+				      timeout, wallclockTime, monotonicTime, score) != 0)
+				{
+					return;
+				}
+				if (score > bestScore)
+				{
+					bestMonotonicClock = monotonicTime;
+					bestWallClock      = wallclockTime;
+					bestScore          = score;
+					bestSource         = i;
+					Debug::log(
+					  "New best scores.  Wall clock: {}, monotonic: {}, "
+					  "current time: {}",
+					  bestWallClock,
+					  bestMonotonicClock,
+					  platform_monotonic_time_read());
+				}
+				CHERIOT_HANDLER
+				Debug::log("Source {} trapped", i);
+				CHERIOT_END_HANDLER
+			}
+			else
+			{
+				Debug::log("Skipping source {}", i);
+			}
+		});
+		Debug::log("Best source was {}", bestSource);
+
+		// If we found at least one usable source, update the others and
+		// publish the time.
+		if (bestScore != std::numeric_limits<int>::min())
+		{
+			visit_clock_sources([&](auto &&source, int i) {
+				if constexpr (source.SupportsTimeSetting)
+				{
+					if (bestSource != i)
+					{
+						CHERIOT_DURING
+						source.set_time(bestWallClock);
+						CHERIOT_HANDLER
+						CHERIOT_END_HANDLER
+					}
+				}
+			});
+			{
+				Debug::log("Updating time.  New wall-clock time is {} at "
+				           "monotonic time {}",
+				           static_cast<int64_t>(bestWallClock),
+				           static_cast<int64_t>(bestMonotonicClock));
+				synchronisedTime.updatingEpoch++;
+				synchronisedTime.monotonicTime = bestMonotonicClock;
+				synchronisedTime.wallClockTime = bestWallClock;
+				synchronisedTime.updatingEpoch++;
+				synchronisedTime.updatingEpoch.notify_all();
+			}
+			return 0;
+		}
+		CHERIOT_HANDLER
+		Debug::log("Clock compartment crashed updating");
+		CHERIOT_END_HANDLER
+		Debug::log("Returning failure");
+	}
+
+	return -ENOSYS;
+}

--- a/sdk/lib/clock/wall_clock.hh
+++ b/sdk/lib/clock/wall_clock.hh
@@ -1,0 +1,30 @@
+#pragma once
+/**
+ * \file
+ * The interface between the wall-clock time compartment and its supporting
+ * library.
+ */
+#include <atomic>
+#include <sys/time.h>
+#include <time.h>
+
+/**
+ * A snapshot in the past of the wall-clock time for a monotonic-clock time.
+ * This makes it possible to calculate the current time by computing the
+ * displacement from the previous monotonic time and adding that to the current
+ * wall-clock time.
+ */
+struct SynchronisedTime
+{
+	/// The value of the monotonic time when this was computed.
+	clock_t monotonicTime;
+	/// The value of the wall-clock time when this was computed.
+	clock_t wallClockTime;
+	/**
+	 * The epoch for synchronisation.  This is incremented once when the epoch
+	 * starts being incremented and again when it completes.  If the low bit is
+	 * 1 when reading, an update is in progress.  If the start and end values
+	 * differ, the read value is inconsistent and consumers should retry.
+	 */
+	std::atomic<uint32_t> updatingEpoch;
+};

--- a/sdk/lib/clock/xmake.lua
+++ b/sdk/lib/clock/xmake.lua
@@ -1,0 +1,66 @@
+-- Copyright Microsoft and CHERIoT Contributors.
+-- SPDX-License-Identifier: MIT
+
+library("clock_helpers")
+  set_default(false)
+  add_files("clock-helpers.cc")
+  on_load(function(target)
+    target:values_set("shared_objects", { wall_clock_time = 24 }, {expand = false})
+  end)
+
+-- Write contents to path if it would create or update the contents
+-- Copied from sdk/xmake.lua, because functions there aren't exported.
+local function maybe_writefile(xmake_io, xmake_try, path, contents)
+    xmake_try
+    { function()
+        -- Try reading the file and comparing
+        local old_contents = xmake_io.readfile(path)
+        if old_contents == contents then return end
+        xmake_io.writefile(path, contents)
+      end
+    , { catch = function()
+        -- If that threw an exception, just write the file
+        xmake_io.writefile(path, contents)
+      end
+    } }
+end
+
+
+compartment("wall_clock")
+  set_default(false)
+  add_files("wall_clock.cc")
+  add_deps("unwind_error_handler", "clock_helpers")
+  on_prepare(function(target)
+    local template = io.readfile(path.join(target:scriptdir(), "rtc_sources.hh.in"))
+    local includes = ""
+    for _,include in ipairs(target:get("cheriot.clock_source_includes")) do
+      includes = includes .. "#include <" .. include .. ">\n"
+    end
+    local types = ""
+    for _,typeName in ipairs(target:get("cheriot.clock_source_types")) do
+      types = types .. typeName .. ", "
+    end
+    local contents = template:gsub("@include_implementations@", includes)
+    contents = contents:gsub("@clock_sources@", types)
+    local outPath = path.join(target:targetdir(), "rtc_sources.hh");
+    try
+    {
+      function()
+        -- Try reading the file and comparing
+        local oldContents = io.readfile(outPath)
+        if oldContents == contents then return end
+        io.writefile(outPath, contents)
+      end
+    , { catch = function()
+          -- If that threw an exception, just write the file
+          io.writefile(outPath, contents)
+        end
+      }
+    }
+  end)
+  on_load(function(target)
+    target:values_set("shared_objects", { wall_clock_time = 24 }, {expand = false})
+    target:add('cxflags', format("-I%s", target:targetdir()), {force =
+    true})
+  end)
+

--- a/sdk/lib/xmake.lua
+++ b/sdk/lib/xmake.lua
@@ -10,6 +10,7 @@ option("print-doubles")
 
 includes(
 	"atomic",
+	"clock",
 	"compartment_helpers",
 	"crt",
 	"cxxrt",


### PR DESCRIPTION
This provides support for plugging in multiple clock sources. A parallel PR will refactor the existing SNTP support to use these interfaces.