### PR TITLE
Fix for bitpacked UART (incorrect placing of fields in one of the registers)

### DIFF
--- a/sdk/include/platform/sunburst/platform-uart.hh
+++ b/sdk/include/platform/sunburst/platform-uart.hh
@@ -105,16 +105,16 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 		BITPACK_MEMBER_ADD_ENUM_BOOL(Receive, AsIs, Reset, 0);
 		BITPACK_MEMBER_ADD_ENUM_BOOL(Transmit, AsIs, Reset, 1);
 
-		BITPACK_MEMBER_ADD_ENUM(TransmitWatermark, uint8_t, 2, 4) {
+		BITPACK_MEMBER_ADD_ENUM(ReceiveWatermark, uint8_t, 2, 4) {
 			Level1  = 0b000,
 			Level2  = 0b001,
 			Level4  = 0b010,
 			Level8  = 0b011,
 			Level16 = 0b100,
 			Level32 = 0b101,
-			Level64 = 0b110,
+			Level62 = 0b110,
 		};
-		BITPACK_MEMBER_ADD_ENUM(ReceiveWatermark, uint8_t, 5, 7) {
+		BITPACK_MEMBER_ADD_ENUM(TransmitWatermark, uint8_t, 5, 7) {
 			Level1  = 0b000,
 			Level2  = 0b001,
 			Level4  = 0b010,


### PR DESCRIPTION
PR #558 have added bitpacked `platform-uart.hh` implementation, however `TransmitWatermark` and `ReceiveWatermark` are located in wrong position according to [OpenTitan documentation](https://opentitan.org/book/hw/ip/uart/doc/registers.html#fifo_ctrl). In addition to that, for `ReceiveWatermark` the max value enum is `Level62` instead of `Level64`.

This PR fixes both issues.