### PR TITLE
Bitpacks: add required remove_reference_t in macro definitions

### DIFF
--- a/sdk/include/bitpack.hh
+++ b/sdk/include/bitpack.hh
@@ -1050,7 +1050,8 @@ struct BitpackDerived : B
  * There is no `BITPACK_MEMBER_TYPE(b, T)` analogue, because that's just
  * `b.member<T>()`.
  */
-#define BITPACK_MEMBER_DECLTYPE(b, T) (b).template member<decltype(b)::T>()
+#define BITPACK_MEMBER_DECLTYPE(b, T)                                          \
+	(b).template member<std::remove_reference_t<decltype(b)>::T>()
 
 /**
  * Like BITPACK_MEMBER_DECLTYPE, but with additional an "typename" keyword so we
@@ -1058,7 +1059,7 @@ struct BitpackDerived : B
  * more generally, involves a template argument).
  */
 #define BITPACK_MEMBER_DEPENDENT(b, T)                                         \
-	(b).template member<typename decltype(b)::T>()
+	(b).template member<typename std::remove_reference_t<decltype(b)>::T>()
 
 /// @}
 
@@ -1234,14 +1235,16 @@ struct BitpackDerived : B
  * that qualified value's type and said value.
  */
 #define BITPACK_OPERATE_VALUE_DECLTYPE(b, operator, value)                     \
-	BITPACK_OPERATE_VALUE(b, operator, decltype(b)::value)
+	BITPACK_OPERATE_VALUE(                                                     \
+	  b, operator, std::remove_reference_t<decltype(b)>::value)
 
 /**
  * BITPACK_OPERATE_VALUE with dependent qualification for the type of the
  * bitpack.
  */
 #define BITPACK_OPERATE_VALUE_DEPENDENT(b, operator, value)                    \
-	BITPACK_OPERATE_VALUE(b, operator, typename decltype(b)::value)
+	BITPACK_OPERATE_VALUE(                                                     \
+	  b, operator, typename std::remove_reference_t<decltype(b)>::value)
 
 /// A specialization of BITPACK_OPERATE_VALUE using `.with` as the operator
 #define BITPACK_WITH_VALUE(b, value) BITPACK_OPERATE_VALUE(b, .with, value)
@@ -1361,7 +1364,8 @@ struct BitpackDerived : B
 	}() > 1)
 
 /// Map function for BITPACK_MAP_DECLTYPE
-#define BITPACK_MAP_DECLTYPE_HELPER(x, b) decltype(b)::x
+#define BITPACK_MAP_DECLTYPE_HELPER(x, b)                                      \
+	std::remove_reference_t<decltype(b)>::x
 
 /**
  * Given bitpack `b`, qualify each additional argument with `decltype(b)`.  That
@@ -1377,7 +1381,8 @@ struct BitpackDerived : B
 	CHERIOT_MAP_LIST_UD(BITPACK_MAP_DECLTYPE_HELPER, b, __VA_ARGS__)
 
 /// Map function for BITPACK_MAP_DEPENDENT
-#define BITPACK_MAP_DEPENDENT_HELPER(x, b) typename decltype(b)::x
+#define BITPACK_MAP_DEPENDENT_HELPER(x, b)                                     \
+	typename std::remove_reference_t<decltype(b)>::x
 
 /**
  * Given bitpack `b`, qualify each additional argument with `typename

--- a/tests/bitpacks-test.cc
+++ b/tests/bitpacks-test.cc
@@ -235,6 +235,21 @@ static_assert(BITPACK_MEMBER_DECLTYPE(F1.control, Scalar) == 0x7F);
 static_assert(F1.control.raw() == 0x7F32);
 static_assert(F1.more.raw() == 0x1312);
 
+// test that macros work on arrays of bitpacks: sometimes this is complicated
+// by the need to remove the implicit reference created by decltype on array
+// members
+constexpr static Foo::Control BitpackArray[2] = {C0, C1};
+static_assert(BITPACK_MEMBER_DECLTYPE(BitpackArray[1], Scalar) == 7);
+static_assert(BITPACK_MEMBER_DEPENDENT(BitpackArray[1], Scalar) == 7);
+constexpr static auto C1array = []() {
+	return BITPACK_WITHS_DECLTYPE(BitpackArray[0], Scalar{7}, Drive::Up);
+}();
+static_assert(C1 == C1array);
+constexpr static bool ArrayOperationValue = []() {
+	return BITPACK_OPERATE_VALUE_DECLTYPE(BitpackArray[1], ==, Scalar{7});
+}();
+static_assert(ArrayOperationValue);
+
 __noinline static void test_volatile(volatile Foo *vfp)
 {
 	static_assert(std::is_same_v<volatile Foo::More &, decltype((vfp->more))>);


### PR DESCRIPTION
This is required when operating on a member of an array because
decltype adds ref to the type and the compiler refuses to allow it to
be used as a namespace. There may be more places where this is
required.
