### PR TITLE
Add fallback #define's for debug macros in benchmarks.

### DIFF
--- a/benchmarks/allocation/alloc.cc
+++ b/benchmarks/allocation/alloc.cc
@@ -4,6 +4,10 @@
 #include <debug.hh>
 #include <locks.hh>
 
+#ifndef DEBUG_ALLOCBENCH
+#	define DEBUG_ALLOCBENCH false
+#endif
+
 using Debug = ConditionalDebug<DEBUG_ALLOCBENCH, "Allocator benchmark">;
 
 void run(size_t allocSize, size_t allocations, size_t inHeap)

--- a/benchmarks/compartment-call/caller.cc
+++ b/benchmarks/compartment-call/caller.cc
@@ -8,6 +8,10 @@
 #include <token.h>
 #include <vector>
 
+#ifndef DEBUG_CALLER
+#	define DEBUG_CALLER false
+#endif
+
 using Debug = ConditionalDebug<DEBUG_CALLER, "Compartment call benchmark">;
 
 DECLARE_AND_DEFINE_ALLOCATOR_CAPABILITY(mallocCapTwo, 1024);

--- a/benchmarks/interrupt-latency/interrupt_bench.cc
+++ b/benchmarks/interrupt-latency/interrupt_bench.cc
@@ -6,6 +6,11 @@
 #include <simulator.h>
 #include <thread.h>
 #include <timeout.h>
+
+#ifndef DEBUG_INTERRUPT_BENCH
+#	define DEBUG_INTERRUPT_BENCH false
+#endif
+
 #if DEBUG_INTERRUPT_BENCH
 #	include <fail-simulator-on-error.h>
 #endif


### PR DESCRIPTION
These are needed to prevent clang-tidy from erroring out if the debug macros are not explicitly specified in the invocation. I opted to default these to debug-disabled, as that seems like the sensible choice for a benchmark, as opposed to a regression test.
