### PR TITLE
sdk/xmake: board search try file name w/o suffix

### DIFF
--- a/sdk/xmake/board-parsing.lua
+++ b/sdk/xmake/board-parsing.lua
@@ -7,7 +7,10 @@ local function board_file_for_name(boardfile, searchDir)
 	-- If this isn't a path, look in searchDir
 	if not os.isfile(boardfile) then
 		boarddir = searchDir
-		local fullBoardPath = path.join(boarddir, boardfile .. '.json')
+		local fullBoardPath = path.join(boarddir, boardfile)
+		if not os.isfile(fullBoardPath) then
+			fullBoardPath = path.join(boarddir, boardfile .. '.json')
+		end
 		if not os.isfile(fullBoardPath) then
 			fullBoardPath = path.join(boarddir, boardfile .. '.patch')
 		end


### PR DESCRIPTION
If the board file string doesn't name an on-disk file, try looking in the searchDir for a file (or path) of that name without additional suffix before also trying the .json then .patch suffixes.