### PR TITLE
More xmake board goo, again

### DIFF
--- a/docs/BoardDescriptions.md
+++ b/docs/BoardDescriptions.md
@@ -109,8 +109,8 @@ Conditional compilation
 The `defines` property specifies any pre-defined macros that should be set when building for this board.
 The `driver_includes` property contains an array (in priority order) of include directories that should be added for this target.
 Each of the paths in `driver_includes` is, by default, relative to the location of the board file (which allows the board file and drivers to be distributed together).
-Optionally, it may include the string `$(sdk)`, which will be replaced by the full path of the SDK directory.
-For example, `"$(sdk)/include/platform/generic-riscv"` will expand to the generic RISC-V directory in the SDK.
+Optionally, it may include the string `${sdk}`, which will be replaced by the full path of the SDK directory.
+For example, `"${sdk}/include/platform/generic-riscv"` will expand to the generic RISC-V directory in the SDK.
 
 The driver headers use `#include_next` to include more generic files and so it is important to list the directories containing your overrides first.
 
@@ -126,3 +126,45 @@ This will be run from the build directory and will be passed the absolute path o
 The build system will look for the simulator in the SDK directory and, failing that, in the path.
 Exact paths can be provided by using `${sdk}` or `${board}` in the name of the simulator.
 These will be expanded to the full path of the SDK or the directory containing the board description file, respectively.
+
+Specifying A Build's Target Board
+---------------------------------
+
+Pass a path to the board file as the argument to the `xmake config` `--board` option.
+
+Due to limitations of `xmake`,
+- Each build directory should be used with exactly one board
+  (note that `xmake` supports out-of-tree builds quite well; see its `--project` option).
+- Changes to the board file may not be seen by incremental builds;
+  perform clean builds whenever changing board definitions.
+
+Board Patch Files and Mixins
+============================
+
+In addition to taking whole board descriptions in a single file,
+the CHERIoT-RTOS `xmake` build system understands incremental definition of boards
+by having a stack of _patches_ atop a base definition.
+Such board patch files have names that end in `.patch`
+and contain JSON dictionaries with two keys:
+
+- "patch", which is an array of [JSON Patch](https://jsonpatch.com) "add", "remove", and "replace" operations.
+
+- "base", which names a board file or another board patch file to which the above operations apply.
+  If the base is not an absolute path, the build system looks to find the base file next to the patch file.
+  The build system will look, in order, for a file named exactly as given, named with a `.json` suffix, or named with a `.patch` suffix.
+
+If using an incremental board definition,
+a path to its top-most patch should be given as the argument to the `xmake config` `--board` option.
+
+Multiple patches may also be "mixed in" to a board definition, incremental or not, at `xmake config` time,
+by passing a comma-separated list of file paths to the `--board-mixins` option.
+These mixins are just JSON arrays of JSON Patch "add", "remove", and "replace" operations,
+which are all applied, in order, to the (patched) board definition computed above.
+
+Board patch base file names and board mixin names are subject to the following expansions:
+- `${sdk}` will be replaced with an absolute path to the RTOS SDK directory
+- `${sdkboards}` will be replaced with an absolute path to the RTOS SDK's boards/ directory
+- `${project}` will be replaced with an absolute path to the project being built
+- `${board}` will be replaced with an absolute path to the board file
+
+The first three of these are also applicable to the argument given to the `--board` option.

--- a/sdk/xmake/board-parsing.lua
+++ b/sdk/xmake/board-parsing.lua
@@ -144,7 +144,7 @@ end
 -- Helper to load a board file.  This must be passed the json object provided
 -- by import("core.base.json") because import does not work in helper
 -- functions at the top level.
-local function load_board_file_inner(boardDir, boardFile)
+local function load_board_file_inner(boardDir, boardFile, boardPathSubstitutes)
 	if path.extension(boardFile) == ".json" then
 		return json.loadfile(boardFile)
 	end
@@ -155,11 +155,14 @@ local function load_board_file_inner(boardDir, boardFile)
 	if not patch.base then
 		raise("Board file " .. boardFile .. " does not specify a base")
 	end
-	local baseDir, baseFile = board_file_for_name(patch.base, boardDir)
+
+	substitutedBase = patch.base:gsub("${(%w)}", boardPathSubstitutes)
+
+	local baseDir, baseFile = board_file_for_name(substitutedBase, boardDir)
 	if not baseDir then
 		raise("unable to find base board file " .. patch.base .. " with search dir " .. boardDir .. ".  Try specifying a full path")
 	end
-	local base = load_board_file_inner(baseDir, baseFile)
+	local base = load_board_file_inner(baseDir, baseFile, boardPathSubstitutes)
 
 	patch_board(base, patch.patch)
 
@@ -168,14 +171,17 @@ end
 
 -- Load a board (patch) file (recursively) and then apply the configuration's
 -- mixins as well.
-local function load_board_file(boardDir, boardFile, mixinString)
-	local base = load_board_file_inner(boardDir, boardFile)
+local function load_board_file(boardDir, boardFile, mixinString, boardPathSubstitutes)
+	local base = load_board_file_inner(boardDir, boardFile, boardPathSubstitutes)
 
 	if not mixinString or mixinString == "" then
 		return base
 	end
 
 	for mixinName in mixinString:gmatch("([^,]*),?") do
+
+		mixinName = mixinName:gsub("${(%w)}", boardPathSubstitutes)
+
 		-- Initially, look next to the board file
 		local mixinDir, mixinFile = board_file_for_name(mixinName, boardDir)
 		if not mixinDir then
@@ -230,7 +236,10 @@ function main(boardPathSubstitutes, boardName, boardMixins)
 	if not boarddir then
 		raise("unable to find board file " .. boardName .. ".  Try specifying a full path")
 	end
-	local board = load_board_file(boarddir, boardfile, boardMixins)
+
+	boardPathSubstitutes.board = boarddir
+
+	local board = load_board_file(boarddir, boardfile, boardMixins, boardPathSubstitutes)
 
 	local jsonpath = {"devices"}
 	for name, extent in table.orderpairs(board.devices) do
@@ -257,8 +266,6 @@ function main(boardPathSubstitutes, boardName, boardMixins)
 	-- loader component asserts that this value matches what the rest of
 	-- the system sees.
 	board.trusted_spill_size = board.stack_high_water_mark and 192 or 176
-
-	boardPathSubstitutes.board = boarddir
 
 	return {
 		info = board,


### PR DESCRIPTION
One semantic change (to make patch `base` and mixin names also subject to path substitutions) and some documentation about the whole mess.