### PR TITLE
Fix UART Control incorrect fields order

### DIFF
--- a/sdk/include/platform/sunburst/platform-uart.hh
+++ b/sdk/include/platform/sunburst/platform-uart.hh
@@ -66,15 +66,20 @@ struct OpenTitanUart : private utils::NoCopyNoMove
 		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(Transmit, 0);
 		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(Receive, 1);
 		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(NoiseFilter, 2);
-		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(SystemLoopback, 3);
-		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(LineLoopback, 4);
-		BITPACK_MEMBER_ADD_ENUM(Parity, uint8_t, 5, 6) {
+		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(SystemLoopback, 4);
+		BITPACK_MEMBER_ADD_ENUM_BOOL_DISABLED_ENABLED(LineLoopback, 5);
+		BITPACK_MEMBER_ADD_ENUM(Parity, uint8_t, 6, 7) {
 			None = 0b00,
 			Even = 0b01,
 			Odd  = 0b11,
 		};
 
-		BITPACK_MEMBER_ADD_NUMERIC(BreakLevel, uint8_t, 8, 9);
+		BITPACK_MEMBER_ADD_ENUM(BreakLevel, uint8_t, 8, 9) {
+			Level2  = 0b00,
+			Level4  = 0b01,
+			Level8  = 0b10,
+			Level16 = 0b11,
+		};
 		BITPACK_MEMBER_ADD_NUMERIC(Nco, uint16_t, 16, 31);
 	} control;
 


### PR DESCRIPTION
Several fields in UART Control register - specifically, `SystemLoopback`, `LineLoopback` and `Parity` - have been placed incorrectly; specifically, it omits reserved bit 3. As a result, this ends in loopback test fail and inproper configuration of non-default parity. 