### PR TITLE
Add cancellation-token APIs.

### DIFF
--- a/sdk/include/cancellation.h
+++ b/sdk/include/cancellation.h
@@ -1,0 +1,92 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <cdefs.h>
+#include <stdlib.h>
+#include <timeout.h>
+
+/**
+ * \file .
+ *
+ * Cancellation token APIs.
+ *
+ * Cancellation tokens are an abstraction that allows long-running tasks in
+ * other threads to be cooperatively cancelled.  A cancellation token is created
+ * from a *cancellation-token source*.  The holder of the cancellation-token
+ * source may signal cancellation.  Holders of the token can check whether it
+ * has been cancelled.
+ */
+
+/**
+ * State associated with a cancellation token.  The cancellation token and the
+ * cancellation-token source are both views of this object, but it is not used
+ */
+struct CancellationTokenState;
+
+/**
+ * The handle for a cancellation-token source.
+ */
+typedef struct CancellationTokenState
+  *__sealed_capability CancealltionTokenSource;
+
+/**
+ * The type for a cancellation token.  This can be queried, but cannot be
+ * signalled.
+ */
+typedef const struct CancellationTokenState *CancellationToken;
+
+/**
+ * Create a cancellation-token source, allocated from the caller's quota.
+ *
+ * This returns either a tagged capability for a cancellation token or an
+ * untagged value that is an error code that corresponds to a value that the
+ * allocator would return on failure.
+ */
+CancealltionTokenSource __cheriot_compartment("cancellation_token")
+  cancellation_token_source_create(TimeoutArgument     timeout,
+                                   AllocatorCapability allocator);
+
+/**
+ * Returns a pointer to the cancellation token for this cancellation-token
+ * source.  This is a read-only *unsealed* capability.
+ *
+ * Returns an untagged value if the cross-compartment call fails or if `source`
+ * is not a valid cancellation-token source.
+ */
+CancellationToken __cheriot_compartment("cancellation_token")
+  cancellation_token_get(CancealltionTokenSource source);
+
+/**
+ * Signal a cancellation token.  This ensures that the next call to
+ * `cancellation_token_check` will return 1.
+ */
+int __cheriot_compartment("cancellation_token")
+  cancellation_token_signal(CancealltionTokenSource tokenSource);
+
+/**
+ * Destroys a cancellation token.  The `allocator` parameter must be the same
+ * as that passed to `cancellation_token_source_create`.  Returns 0 on success,
+ * or `-EINVAL` if either of the arguments is not the correct type.
+ */
+int __cheriot_compartment("cancellation_token")
+  cancellation_token_source_destroy(CancealltionTokenSource tokenSource,
+                                    AllocatorCapability     allocator);
+
+/**
+ * Check whether the cancellation token has been signalled.  This will acquire
+ * an ephemeral claim over the token, so is safe to use even if the token has
+ * been deallocated.
+ *
+ * The ephemeral claim acquisition will potentially block for an unbounded
+ * amount of time.  If this is not acceptable, use
+ * `cancellation_token_check_unsafe`.
+ *
+ * Return values are:
+ *
+ * * 0: The cancellation token is still valid.
+ * * 1: The cancellation token has been signalled.
+ * * `-EINVAL`: The argument is not a cancellation token (this can happen if the
+ *   cancellation token has been deallocated).
+ */
+int __cheriot_libcall cancellation_token_check(CancellationToken token);

--- a/sdk/include/cheri-builtins.h
+++ b/sdk/include/cheri-builtins.h
@@ -24,7 +24,7 @@
 #	include <cdefs.h>
 #	include <stddef.h>
 
-static inline __always_inline ptraddr_t cheri_address_get(void *x)
+static inline __always_inline ptraddr_t cheri_address_get(auto *x)
 {
 	return __builtin_cheri_address_get(x);
 }
@@ -39,62 +39,62 @@ static inline __always_inline auto cheri_address_increment(auto *x, ptrdiff_t y)
 	return __builtin_cheri_address_increment(x, y);
 }
 
-static inline __always_inline ptraddr_t cheri_base_get(void *x)
+static inline __always_inline ptraddr_t cheri_base_get(auto x)
 {
 	return __builtin_cheri_base_get(x);
 }
 
-static inline __always_inline ptraddr_t cheri_top_get(void *x)
+static inline __always_inline ptraddr_t cheri_top_get(auto x)
 {
 	return __builtin_cheri_top_get(x);
 }
 
-static inline __always_inline ptraddr_t cheri_length_get(void *x)
+static inline __always_inline ptraddr_t cheri_length_get(auto x)
 {
 	return __builtin_cheri_length_get(x);
 }
 
-static inline __always_inline auto cheri_tag_clear(void *x)
+static inline __always_inline auto cheri_tag_clear(auto x)
 {
 	return __builtin_cheri_tag_clear(x);
 }
 
-static inline __always_inline auto cheri_tag_get(void *x)
+static inline __always_inline auto cheri_tag_get(auto x)
 {
 	return __builtin_cheri_tag_get(x);
 }
 
-static inline __always_inline bool cheri_is_valid(void *x)
+static inline __always_inline bool cheri_is_valid(auto x)
 {
 	return cheri_tag_get(x);
 }
 
-static inline __always_inline bool cheri_is_invalid(void *x)
+static inline __always_inline bool cheri_is_invalid(auto x)
 {
 	return !cheri_tag_get(x);
 }
 
-static inline __always_inline bool cheri_is_equal_exact(void *x, void *y)
+static inline __always_inline bool cheri_is_equal_exact(auto x, auto y)
 {
 	return __builtin_cheri_equal_exact(x, y);
 }
 
-static inline __always_inline bool cheri_is_subset(void *x, void *y)
+static inline __always_inline bool cheri_is_subset(auto x, auto y)
 {
 	return __builtin_cheri_subset_test(x, y);
 }
 
-static inline __always_inline auto cheri_permissions_get(void *x)
+static inline __always_inline auto cheri_permissions_get(auto x)
 {
 	return __builtin_cheri_perms_get(x);
 }
 
-static inline __always_inline auto cheri_permissions_and(void *x, unsigned y)
+static inline __always_inline auto cheri_permissions_and(auto x, unsigned y)
 {
 	return __builtin_cheri_perms_and(x, y);
 }
 
-static inline __always_inline auto cheri_type_get(void *x)
+static inline __always_inline auto cheri_type_get(auto x)
 {
 	return __builtin_cheri_type_get(x);
 }
@@ -119,7 +119,7 @@ static inline __always_inline auto cheri_bounds_set_exact(auto *a, size_t b)
 	return __builtin_cheri_bounds_set_exact(a, b);
 }
 
-static inline __always_inline auto cheri_subset_test(void *a, void *b)
+static inline __always_inline auto cheri_subset_test(auto a, auto b)
 {
 	return __builtin_cheri_subset_test(a, b);
 }

--- a/sdk/lib/README.md
+++ b/sdk/lib/README.md
@@ -7,6 +7,7 @@ Each directory can be included directly in xmake to add the entire library, some
 This collection currently includes:
 
  - [atomic](atomic/) provides atomic support functions.
+ - [cancellation_token](cancellation_token/) contains support for cancellation tokens.
  - [compartment_helpers](compartment_helpers/) contains helpers for checking / ensuring that pointers are valid.
  - [clock](clock/) provides support for wall-clock time.
  - [crt](crt/) provides C runtime functions that the compiler may emit.

--- a/sdk/lib/cancellation_token/README.md
+++ b/sdk/lib/cancellation_token/README.md
@@ -1,0 +1,13 @@
+Cancellation tokens
+===================
+
+Cancellation tokens are a primitive for building cooperative asynchronous termination.
+APIs that may run for a long time and require asynchronous cancellation take a cancellation token as an argument.
+Periodically, during their long operation, they check the cancellation state of the token and, if they have been instructed to do so, stop.
+Cancellation tokens are associated with a *cancellation-token source*, which can *signal* the token to indicate that they should stop.
+Each cancellation token supports arbitrary *fan out*: many asynchronous tasks can be signalled by a single cancellation token.
+
+The cancellation-token APIs are documented in [`cancellation.h`](../../include/cancellation.h).
+
+These are implemented in a compartment that handles the signalling end and a library that implements the fast paths.
+Adding the `cancellation_token` compartment as dependency also adds the fast-path library.

--- a/sdk/lib/cancellation_token/cancellation-fast-path.cc
+++ b/sdk/lib/cancellation_token/cancellation-fast-path.cc
@@ -1,0 +1,23 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "cancellation-private.h"
+#include <allocator.h>
+#include <cheri.hh>
+#include <debug.hh>
+#include <errno.h>
+#include <unwind.h>
+
+int __cheriot_libcall cancellation_token_check(CancellationToken token)
+{
+	if (CHERI::Capability{token}.is_valid())
+	{
+		CHERIOT_DURING
+		{
+			return token->token;
+		}
+		CHERIOT_HANDLER
+		CHERIOT_END_HANDLER
+	}
+	return -EINVAL;
+}

--- a/sdk/lib/cancellation_token/cancellation-private.h
+++ b/sdk/lib/cancellation_token/cancellation-private.h
@@ -1,0 +1,17 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+#include <atomic>
+#include <cancellation.h>
+
+/**
+ * Cancellation token state.
+ */
+struct CancellationTokenState
+{
+	/**
+	 * The flag indicating that the token has been signalled.
+	 */
+	std::atomic<bool> token;
+};

--- a/sdk/lib/cancellation_token/cancellation.cc
+++ b/sdk/lib/cancellation_token/cancellation.cc
@@ -1,0 +1,51 @@
+// Copyright SCI Semiconductor and CHERIoT Contributors.
+// SPDX-License-Identifier: MIT
+
+#include "cancellation-private.h"
+#include <cheri.hh>
+#include <errno.h>
+#include <token.h>
+
+using namespace CHERI;
+
+#define CANCELLATION_TOKEN_KEY STATIC_SEALING_TYPE(CancellationToken)
+
+CancealltionTokenSource
+cancellation_token_source_create(TimeoutArgument     timeout,
+                                 AllocatorCapability allocator)
+{
+	auto [unsealed, sealed] = token_allocate<CancellationTokenState>(
+	  timeout, allocator, CANCELLATION_TOKEN_KEY);
+	if (!cheri_is_valid(unsealed))
+	{
+		return reinterpret_cast<CancealltionTokenSource>(&unsealed);
+	}
+	return sealed;
+}
+
+CancellationToken cancellation_token_get(CancealltionTokenSource source)
+{
+	if (Capability unsealed = token_unseal(CANCELLATION_TOKEN_KEY, source))
+	{
+		unsealed.permissions() &=
+		  PermissionSet{Permission::Load, Permission::Global};
+		return unsealed;
+	}
+	return reinterpret_cast<CancellationToken>(static_cast<uintptr_t>(-EINVAL));
+}
+
+int cancellation_token_signal(CancealltionTokenSource source)
+{
+	if (Capability unsealed = token_unseal(CANCELLATION_TOKEN_KEY, source))
+	{
+		unsealed->token = true;
+		return 0;
+	}
+	return -EINVAL;
+}
+
+int cancellation_token_source_destroy(CancealltionTokenSource tokenSource,
+                                      AllocatorCapability     allocator)
+{
+	return token_obj_destroy(allocator, CANCELLATION_TOKEN_KEY, tokenSource);
+}

--- a/sdk/lib/cancellation_token/xmake.lua
+++ b/sdk/lib/cancellation_token/xmake.lua
@@ -1,0 +1,9 @@
+compartment("cancellation_token")
+  set_default(false)
+  add_deps("atomic4", "cancellation_token_fast_path")
+  add_files("cancellation.cc")
+
+library("cancellation_token_fast_path")
+  set_default(false)
+  add_deps("atomic4")
+  add_files("cancellation-fast-path.cc")

--- a/sdk/lib/xmake.lua
+++ b/sdk/lib/xmake.lua
@@ -12,6 +12,7 @@ includes(
 	"atomic",
 	"clock",
 	"compartment_helpers",
+	"cancellation_token",
 	"crt",
 	"cxxrt",
 	"debug",

--- a/tests/cancellation-test.cc
+++ b/tests/cancellation-test.cc
@@ -1,0 +1,42 @@
+#include <cancellation.h>
+#include <errno.h>
+#define TEST_NAME "Cancellation token"
+#include "tests.hh"
+#include <fail-simulator-on-error.h>
+
+int test_cancellation()
+{
+	TEST_EQUAL(cancellation_token_check(nullptr),
+	           -EINVAL,
+	           "Checking an invalid token failed to report an error");
+	Timeout t{1};
+	auto    source = cancellation_token_source_create(&t, MALLOC_CAPABILITY);
+	TEST(cheri_tag_get(source),
+	     "cancellation_token_source_create returned an untagged capability");
+	TEST(cheri_type_get(source) != 0,
+	     "cancellation_token_source_create returned an unsealed capability");
+	auto token = cancellation_token_get(source);
+	TEST(cheri_tag_get(token),
+	     "cancellation_token_get returned an untagged capability");
+	TEST_EQUAL(cheri_type_get(token),
+	           0,
+	           "cancellation_token_get returned a sealed capability");
+
+	TEST_EQUAL(cancellation_token_check(token),
+	           0,
+	           "Checking an unsignalled token should report unsignalled");
+
+	TEST_EQUAL(cancellation_token_signal(source), 0, "Signalling token failed");
+
+	TEST_EQUAL(cancellation_token_check(token),
+	           1,
+	           "Checking a signalled token should report signalled");
+
+	TEST_EQUAL(cancellation_token_source_destroy(source, MALLOC_CAPABILITY),
+	           0,
+	           "Failed to destroy cancellation-token source");
+	TEST_EQUAL(cancellation_token_check(token),
+	           -EINVAL,
+	           "Checking a deallocated token should report invalid");
+	return 0;
+}

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -214,6 +214,9 @@ test("rust", { name = "Rust", not_most = true })
 
 test("bitpacks")
 
+test("cancellation")
+  add_deps("cancellation_token")
+
 includes(path.join(sdkdir, "lib"))
 
 rule("cheriot.tests")


### PR DESCRIPTION
These are modelled on their .NET equivalent, with mostly the same properties.  They provide a mechanism for coordinating cancellation, where one token can be shared with an arbitrary number of long-running tasks and they can all be notified that they're cancelled.

Also includes a commit that fixes some issues with another header that this exposed.