### PR TITLE
Add single <-> half precision float conversion builtins

### DIFF
--- a/sdk/lib/softfloat/softfloat.h
+++ b/sdk/lib/softfloat/softfloat.h
@@ -29,6 +29,10 @@ CHERIOT_DECLARE_STANDARD_LIBCALL(__negdf2, double, double)
 CHERIOT_DECLARE_STANDARD_LIBCALL(__extendsfdf2, double, float)
 CHERIOT_DECLARE_STANDARD_LIBCALL(__truncdfsf2, float, double)
 
+// Float <-> half conversion
+CHERIOT_DECLARE_STANDARD_LIBCALL(__truncsfhf2, uint16_t, float)
+CHERIOT_DECLARE_STANDARD_LIBCALL(__extendhfsf2, float, uint16_t)
+
 // Floating-point <-> integer conversion
 CHERIOT_DECLARE_STANDARD_LIBCALL(__fixsfsi, int, float)
 CHERIOT_DECLARE_STANDARD_LIBCALL(__fixdfsi, int, double)

--- a/sdk/lib/softfloat/xmake.lua
+++ b/sdk/lib/softfloat/xmake.lua
@@ -45,6 +45,13 @@ softfloat_library(3264, "convert")
 	add_files("../../third_party/compiler-rt/fixunsdfsi.c")
 	add_files("../../third_party/compiler-rt/floatunsidf.c")
 
+-- Conversions between 32-bit floats and 16-bit floats.
+-- These are not included as part of any other library, and there
+-- is no other support for 16-bit floats.
+softfloat_library(3216, "convert")
+    add_files("../../third_party/compiler-rt/extendhfsf2.c")
+    add_files("../../third_party/compiler-rt/truncsfhf2.c")
+
 softfloat_library(32, "convert")
 	add_files("../../third_party/compiler-rt/fixsfsi.c")
 	add_files("../../third_party/compiler-rt/fixsfdi.c")

--- a/sdk/third_party/compiler-rt/README.md
+++ b/sdk/third_party/compiler-rt/README.md
@@ -7,4 +7,4 @@ When updating, they should be overridden and the git hash in this file updated.
 
 Ideally we'd use a submodule for this, but unfortunately git doesn't let you have a submodule that points to a single sudirectory in a remote and so we'd have to have a 7.5 GiB LLVM clone to get well under 1 MiB of files.
 
-LLVM git revision: 389b7056ad3dd6631de3f44ebe21cf328e522543
+LLVM git revision: b9977ea5f8abca95f854b62ddd373b031b1dc933

--- a/sdk/third_party/compiler-rt/extendhfsf2.c
+++ b/sdk/third_party/compiler-rt/extendhfsf2.c
@@ -1,0 +1,29 @@
+//===-- lib/extendhfsf2.c - half -> single conversion -------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SRC_HALF
+#define DST_SINGLE
+#include "fp_extend_impl.inc"
+
+// Use a forwarding definition and noinline to implement a poor man's alias,
+// as there isn't a good cross-platform way of defining one.
+COMPILER_RT_ABI NOINLINE float __extendhfsf2(src_t a) {
+  return __extendXfYf2__(a);
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI float __gnu_h2f_ieee(src_t a) { return __extendhfsf2(a); }
+AEABI_RTABI float __aeabi_h2f(src_t a) { return __extendhfsf2(a); }
+#else
+COMPILER_RT_ALIAS(__extendhfsf2, __gnu_h2f_ieee)
+COMPILER_RT_ALIAS(__extendhfsf2, __aeabi_h2f)
+#endif
+#else
+COMPILER_RT_ABI float __gnu_h2f_ieee(src_t a) { return __extendhfsf2(a); }
+#endif

--- a/sdk/third_party/compiler-rt/fp_compare_impl.inc
+++ b/sdk/third_party/compiler-rt/fp_compare_impl.inc
@@ -12,7 +12,7 @@
 // functions. We need to ensure that the return value is sign-extended in the
 // same way as GCC expects (since otherwise GCC-generated __builtin_isinf
 // returns true for finite 128-bit floating-point numbers).
-#ifdef __aarch64__
+#if defined(__aarch64__) || defined(__arm64ec__)
 // AArch64 GCC overrides libgcc_cmp_return to use int instead of long.
 typedef int CMP_RESULT;
 #elif __SIZEOF_POINTER__ == 8 && __SIZEOF_LONG__ == 4 && !defined(__CHERI__)

--- a/sdk/third_party/compiler-rt/fp_lib.h
+++ b/sdk/third_party/compiler-rt/fp_lib.h
@@ -359,7 +359,7 @@ static __inline fp_t __compiler_rt_scalbn(fp_t x, int y) {
   return __compiler_rt_scalbnX(x, y);
 }
 static __inline fp_t __compiler_rt_fmax(fp_t x, fp_t y) {
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(__arm64ec__)
   // Use __builtin_fmax which turns into an fmaxnm instruction on AArch64.
   return __builtin_fmax(x, y);
 #else

--- a/sdk/third_party/compiler-rt/int_lib.h
+++ b/sdk/third_party/compiler-rt/int_lib.h
@@ -49,7 +49,7 @@
 #define SYMBOL_NAME(name) XSTR(__USER_LABEL_PREFIX__) #name
 
 #if defined(__ELF__) || defined(__MINGW32__) || defined(__wasm__) ||           \
-    defined(_AIX)    || defined(__CYGWIN__)
+    defined(_AIX) || defined(__CYGWIN__)
 #define COMPILER_RT_ALIAS(name, aliasname) \
   COMPILER_RT_ABI __typeof(name) aliasname __attribute__((__alias__(#name)));
 #elif defined(__APPLE__)
@@ -64,7 +64,7 @@
   COMPILER_RT_ALIAS_VISIBILITY(aliasname) \
   __asm__(SYMBOL_NAME(aliasname) " = " SYMBOL_NAME(name)); \
   COMPILER_RT_ABI __typeof(name) aliasname;
-#elif defined(_WIN32)
+#elif defined(_WIN32) || defined(__UEFI__)
 #define COMPILER_RT_ALIAS(name, aliasname)
 #else
 #error Unsupported target

--- a/sdk/third_party/compiler-rt/int_to_fp_impl.inc
+++ b/sdk/third_party/compiler-rt/int_to_fp_impl.inc
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Thsi file implements a generic conversion from an integer type to an
-// IEEE-754 floating point type, allowing a common implementation to be hsared
+// This file implements a generic conversion from an integer type to an
+// IEEE-754 floating point type, allowing a common implementation to be shared
 // without copy and paste.
 //
 //===----------------------------------------------------------------------===//
@@ -49,15 +49,15 @@ static __inline dst_t __floatXiYf__(src_t a) {
     a |= (a & 4) != 0; // Or P into R
     ++a;               // round - this step may add a significant bit
     a >>= 2;           // dump Q and R
-    // a is now rounded to dstMantDig or dstMantDig+1 bits
+    // `a` is now rounded to dstMantDig or dstMantDig+1 bits
     if (a & ((usrc_t)1 << dstMantDig)) {
       a >>= 1;
       ++e;
     }
-    // a is now rounded to dstMantDig bits
+    // `a` is now rounded to dstMantDig bits
   } else {
     a <<= (dstMantDig - sd);
-    // a is now rounded to dstMantDig bits
+    // `a` is now rounded to dstMantDig bits
   }
   const int dstBits = sizeof(dst_t) * CHAR_BIT;
   const dst_rep_t dstSignMask = DST_REP_C(1) << (dstBits - 1);

--- a/sdk/third_party/compiler-rt/int_types.h
+++ b/sdk/third_party/compiler-rt/int_types.h
@@ -223,7 +223,7 @@ typedef union {
 #define CRT_HAS_TF_MODE
 #endif
 
-#if __STDC_VERSION__ >= 199901L
+#if __STDC_VERSION__ >= 199901L && !defined(_MSC_VER)
 typedef float _Complex Fcomplex;
 typedef double _Complex Dcomplex;
 typedef long double _Complex Lcomplex;

--- a/sdk/third_party/compiler-rt/truncsfhf2.c
+++ b/sdk/third_party/compiler-rt/truncsfhf2.c
@@ -1,0 +1,29 @@
+//===-- lib/truncsfhf2.c - single -> half conversion --------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SRC_SINGLE
+#define DST_HALF
+#include "fp_trunc_impl.inc"
+
+// Use a forwarding definition and noinline to implement a poor man's alias,
+// as there isn't a good cross-platform way of defining one.
+COMPILER_RT_ABI NOINLINE dst_t __truncsfhf2(float a) {
+  return __truncXfYf2__(a);
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
+AEABI_RTABI dst_t __aeabi_f2h(float a) { return __truncsfhf2(a); }
+#else
+COMPILER_RT_ALIAS(__truncsfhf2, __gnu_f2h_ieee)
+COMPILER_RT_ALIAS(__truncsfhf2, __aeabi_f2h)
+#endif
+#else
+COMPILER_RT_ABI dst_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
+#endif


### PR DESCRIPTION
Adds a softfloat library `softfloat3216convert` containing only  `__truncsfhf2` and `__extendhfsf2`. These libcalls are expected by tests in the Rust compiler.

Since this is not particularly useful outside of storage it is not included in `softfloatall`. The expectation is that any math goes through the 32-bit float functions.

I updated the other files in `sdk/third_party/compiler-rt` per the README. There doesn't seem to be any meaningful changes.