### PR TITLE
Add link-time check for negative heap size

### DIFF
--- a/sdk/firmware.rwdata.ldscript.in
+++ b/sdk/firmware.rwdata.ldscript.in
@@ -79,6 +79,8 @@ __export_mem_heap = @heap_start@;
 
 ASSERT(__export_mem_heap >= ., "Heap would overlap static data")
 
+ASSERT(__export_mem_heap < __export_mem_heap_end, "Heap has no available space")
+
 # This is sdk/core/allocator/alloc.h's MaxChunkSize + sizeof(MChunkHeader),
 # since right now the heap requires that we be able to represent the whole thing
 # in a single chunk.


### PR DESCRIPTION
Asserts that `__export_mem_heap`, whose position is dynamic, comes before `__export_mem_heap_end`, whose position is statically defined in the board definition.

Under normal conditions this will already trigger the heap_maximum_size check below, but provides a more appropriate error message.

For board definitions where instruction_end == heap_end, such as for Sail, this also catches the case where we have exceeded the instruction memory.

This does not check that the heap size is above the minimum needed by the allocator.