### PR TITLE
xmake board parsing: add boardBase path, tweak mixin resolution

### DIFF
--- a/docs/BoardDescriptions.md
+++ b/docs/BoardDescriptions.md
@@ -160,6 +160,7 @@ Multiple patches may also be "mixed in" to a board definition, incremental or no
 by passing a comma-separated list of file paths to the `--board-mixins` option.
 These mixins are just JSON arrays of JSON Patch "add", "remove", and "replace" operations,
 which are all applied, in order, to the (patched) board definition computed above.
+Mixins specified by relative paths are looked for in the project root, next to the file given to the `--board` option, and in the SDK's `boards/` directory, in that order.
 
 Board patch base file names, board mixin names, and paths within board files are subject to the following expansions:
 - `${sdk}` will be replaced with an absolute path to the RTOS SDK directory

--- a/docs/BoardDescriptions.md
+++ b/docs/BoardDescriptions.md
@@ -161,10 +161,12 @@ by passing a comma-separated list of file paths to the `--board-mixins` option.
 These mixins are just JSON arrays of JSON Patch "add", "remove", and "replace" operations,
 which are all applied, in order, to the (patched) board definition computed above.
 
-Board patch base file names and board mixin names are subject to the following expansions:
+Board patch base file names, board mixin names, and paths within board files are subject to the following expansions:
 - `${sdk}` will be replaced with an absolute path to the RTOS SDK directory
 - `${sdkboards}` will be replaced with an absolute path to the RTOS SDK's boards/ directory
 - `${project}` will be replaced with an absolute path to the project being built
-- `${board}` will be replaced with an absolute path to the board file
+- `${board}` will be replaced with an absolute path to the board file given to the `--board` option.
+* `${boardBase}` will be replaced with the absolute path to the JSON file to which all board patches apply.
 
 The first three of these are also applicable to the argument given to the `--board` option.
+`${boardBase}` is not available during the initial descent through board patches, but it is available to mixin paths and paths within board descriptions.

--- a/sdk/boards/ibex-safe-simulator.json
+++ b/sdk/boards/ibex-safe-simulator.json
@@ -41,9 +41,9 @@
         "MICROSOFT_CHERIOT_SAFE"
     ],
     "driver_includes" : [
-        "../include/platform/ibex",
-        "../include/platform/microsoft_cheriot_safe",
-        "../include/platform/generic-riscv"
+        "${sdk}/include/platform/ibex",
+        "${sdk}/include/platform/microsoft_cheriot_safe",
+        "${sdk}/include/platform/generic-riscv"
     ],
     "timer_hz" : 100000,
     "tickrate_hz" : 10,

--- a/sdk/boards/kudu-safe-simulator.json
+++ b/sdk/boards/kudu-safe-simulator.json
@@ -37,9 +37,9 @@
         "RDCYCLE_OVERRIDE_CSR=mcycle"
     ],
     "driver_includes" : [
-        "../include/platform/kudu",
-        "../include/platform/microsoft_cheriot_safe",
-        "../include/platform/generic-riscv"
+        "${sdk}/include/platform/kudu",
+        "${sdk}/include/platform/microsoft_cheriot_safe",
+        "${sdk}/include/platform/generic-riscv"
     ],
     "timer_hz" : 100000,
     "tickrate_hz" : 10,

--- a/sdk/boards/sail.json
+++ b/sdk/boards/sail.json
@@ -32,8 +32,8 @@
         "RISCV_HTIF"
     ],
     "driver_includes" : [
-        "../include/platform/sail",
-        "../include/platform/generic-riscv"
+        "${sdk}/include/platform/sail",
+        "${sdk}/include/platform/generic-riscv"
     ],
     "timer_hz" : 2000,
     "tickrate_hz" : 10,

--- a/sdk/boards/sonata-0.2.json
+++ b/sdk/boards/sonata-0.2.json
@@ -76,9 +76,9 @@
         "CHERIOT_NO_SAIL_83"
     ],
     "driver_includes" : [
-        "../include/platform/sunburst/v0.2",
-        "../include/platform/sunburst",
-        "../include/platform/generic-riscv"
+        "${sdk}/include/platform/sunburst/v0.2",
+        "${sdk}/include/platform/sunburst",
+        "${sdk}/include/platform/generic-riscv"
     ],
     "timer_hz" : 30000000,
     "tickrate_hz" : 100,

--- a/sdk/boards/sonata-1.1.json
+++ b/sdk/boards/sonata-1.1.json
@@ -130,9 +130,9 @@
         "STDERR_TO_STDOUT=1"
     ],
     "driver_includes" : [
-        "../include/platform/sunburst",
-        "../include/platform/ibex",
-        "../include/platform/generic-riscv"
+        "${sdk}/include/platform/sunburst",
+        "${sdk}/include/platform/ibex",
+        "${sdk}/include/platform/generic-riscv"
     ],
     "timer_hz" : 40000000,
     "tickrate_hz" : 100,

--- a/sdk/xmake/board-parsing.lua
+++ b/sdk/xmake/board-parsing.lua
@@ -146,6 +146,7 @@ end
 -- functions at the top level.
 local function load_board_file_inner(boardDir, boardFile, boardPathSubstitutes)
 	if path.extension(boardFile) == ".json" then
+		boardPathSubstitutes.boardBase = boardDir
 		return json.loadfile(boardFile)
 	end
 	if path.extension(boardFile) ~= ".patch" then
@@ -156,6 +157,7 @@ local function load_board_file_inner(boardDir, boardFile, boardPathSubstitutes)
 		raise("Board file " .. boardFile .. " does not specify a base")
 	end
 
+	-- Naturally, boardBase is not available on the descent.
 	substitutedBase = patch.base:gsub("${(%w)}", boardPathSubstitutes)
 
 	local baseDir, baseFile = board_file_for_name(substitutedBase, boardDir)

--- a/sdk/xmake/board-parsing.lua
+++ b/sdk/xmake/board-parsing.lua
@@ -184,10 +184,14 @@ local function load_board_file(boardDir, boardFile, mixinString, boardPathSubsti
 
 		mixinName = mixinName:gsub("${(%w)}", boardPathSubstitutes)
 
-		-- Initially, look next to the board file
-		local mixinDir, mixinFile = board_file_for_name(mixinName, boardDir)
+		-- Initially, look in the project directory if it isn't absolute after substitutions
+		local mixinDir, mixinFile = board_file_for_name(mixinName, os.projectdir())
 		if not mixinDir then
-			-- Fall back to looking in the SDK/ boards dir (which might be the same thing)
+			-- Try relative to the provided board file
+			mixinDir, mixinFile = board_file_for_name(mixinName, boardDir)
+		end
+		if not mixinDir then
+			-- Fall back to looking in the SDK/ boards dir
 			mixinDir, mixinFile = board_file_for_name(mixinName, path.join(scriptdir, "boards"))
 		end
 		if not mixinDir then


### PR DESCRIPTION
And while here, replace relative paths in the `sdk/boards` with ones using the `${sdk}` path substitution.

`${boardBase}` is of particular interest to out-of-tree BSPs: their base board files can use this to make it easier to combine them with (per-project, say) board patch files.