### PR TITLE
Make MultiWaiter eventSource a pointer to const atomic uint32.

### DIFF
--- a/sdk/core/scheduler/multiwait.h
+++ b/sdk/core/scheduler/multiwait.h
@@ -64,7 +64,7 @@ namespace
 		 * Reset method.  Takes a pointer to the futex word and the
 		 * user-provided value describing when it should fire.
 		 */
-		bool reset(uint32_t *address, uint32_t value)
+		bool reset(const _Atomic(uint32_t) *address, uint32_t value)
 		{
 			eventSource = reinterpret_cast<void *>(
 			  static_cast<uintptr_t>(Capability{address}.address()));
@@ -235,8 +235,7 @@ class MultiWaiterInternal : public Handle</*IsDynamic*/ true>
 		// Reset the events that this contains.
 		for (size_t i = 0; i < count; i++)
 		{
-			void *ptr     = newEvents[i].eventSource;
-			auto *address = static_cast<uint32_t *>(ptr);
+			auto *address = newEvents[i].eventSource;
 			if (!check_pointer<PermissionSet{Permission::Load}>(address))
 			{
 				return EventOperationResult::Error;

--- a/sdk/include/multiwaiter.h
+++ b/sdk/include/multiwaiter.h
@@ -43,7 +43,7 @@ struct EventWaiterSource
 	 * A pointer to the event source.  This is the futex that is monitored for
 	 * the multiwaiter.
 	 */
-	void *eventSource;
+	const _Atomic(uint32_t) *eventSource;
 	/**
 	 * Event value.  This field is modified during the wait
 	 * call.

--- a/tests/multiwaiter-test.cc
+++ b/tests/multiwaiter-test.cc
@@ -3,6 +3,7 @@
 
 #define TEST_NAME "Multiwaiter"
 #include "tests.hh"
+#include <atomic>
 #include <cheri.hh>
 #include <errno.h>
 #include <futex.h>
@@ -16,11 +17,11 @@ using namespace thread_pool;
 
 int test_multiwaiter()
 {
-	static uint32_t futex  = 0;
-	static uint32_t futex2 = 0;
-	int             ret;
-	MultiWaiter     mw;
-	Timeout         t{0};
+	static _Atomic(uint32_t) futex  = 0;
+	static _Atomic(uint32_t) futex2 = 0;
+	int                      ret;
+	MultiWaiter              mw;
+	Timeout                  t{0};
 	ret = multiwaiter_create(&t, MALLOC_CAPABILITY, &mw, 4);
 	TEST((ret == 0) && (mw != nullptr),
 	     "Allocating multiwaiter failed {} ({})",
@@ -46,12 +47,13 @@ int test_multiwaiter()
 	ret         = multiwaiter_wait(&t, mw, events, 1);
 	TEST(ret == 0, "multiwaiter returned {}, expected 0", ret);
 
-	auto setFutex = [](uint32_t *futexWord, uint32_t value) {
+	auto setFutex = [](_Atomic(uint32_t) *futexWord, uint32_t value) {
 		async([=]() {
 			sleep(1);
 			debug_log("Waking futex from background thread");
 			*futexWord = value;
-			TEST(futex_wake(futexWord, 1) >= 0, "futex_wait failed");
+			TEST(futex_wake(reinterpret_cast<uint32_t *>(futexWord), 1) >= 0,
+			     "futex_wait failed");
 		});
 	};
 

--- a/tests/xmake.lua
+++ b/tests/xmake.lua
@@ -202,7 +202,7 @@ test("eventgroup", { name = "Event groups" })
 
 -- Test the multiwaiter
 test("multiwaiter", { name = "Multiwatier" })
-    add_deps("cxxrt", "message_queue")
+    add_deps("cxxrt", "message_queue", "atomic")
 
 -- Test the allocator and the revoker.
 test("allocator", { name = "Allocator" })


### PR DESCRIPTION
I noticed it ought to be const and David pointed out that it should
also be atomic and a uint32 so I've attempted that change.  This
breaks users unless they are already using atomic uint32s (which they
probably should be...).  Unfortunately this is now incompatible with the
futex API which requires a const _volatile_ uint32* for API
compatibility reasons.
