### PR TITLE
Make MultiWaiter event source const.

### DIFF
--- a/sdk/core/scheduler/multiwait.h
+++ b/sdk/core/scheduler/multiwait.h
@@ -26,7 +26,7 @@ namespace
 		 * The object (queue, event channel, or `uint32_t` address for futexes)
 		 * that is monitored by this event waiter.
 		 */
-		void *eventSource = nullptr;
+		const void *eventSource = nullptr;
 		/**
 		 * Event-type value.
 		 */
@@ -64,9 +64,9 @@ namespace
 		 * Reset method.  Takes a pointer to the futex word and the
 		 * user-provided value describing when it should fire.
 		 */
-		bool reset(uint32_t *address, uint32_t value)
+		bool reset(const uint32_t *address, uint32_t value)
 		{
-			eventSource = reinterpret_cast<void *>(
+			eventSource = reinterpret_cast<const void *>(
 			  static_cast<uintptr_t>(Capability{address}.address()));
 			eventValue  = value;
 			flags       = 0;
@@ -235,8 +235,8 @@ class MultiWaiterInternal : public Handle</*IsDynamic*/ true>
 		// Reset the events that this contains.
 		for (size_t i = 0; i < count; i++)
 		{
-			void *ptr     = newEvents[i].eventSource;
-			auto *address = static_cast<uint32_t *>(ptr);
+			const void *ptr     = newEvents[i].eventSource;
+			auto       *address = static_cast<const uint32_t *>(ptr);
 			if (!check_pointer<PermissionSet{Permission::Load}>(address))
 			{
 				return EventOperationResult::Error;

--- a/sdk/include/multiwaiter.h
+++ b/sdk/include/multiwaiter.h
@@ -43,7 +43,7 @@ struct EventWaiterSource
 	 * A pointer to the event source.  This is the futex that is monitored for
 	 * the multiwaiter.
 	 */
-	void *eventSource;
+	const void *eventSource;
 	/**
 	 * Event value.  This field is modified during the wait
 	 * call.


### PR DESCRIPTION
This means we don't have to cast away const e.g. for interrupt futexes.  This should possibly also be a uint32 and atomic but that would require more changes and is incompatible with existing code: see #759 .