### PR TITLE
Appease clang-format-23

### DIFF
--- a/sdk/core/allocator/main.cc
+++ b/sdk/core/allocator/main.cc
@@ -206,7 +206,7 @@ namespace
 	                                 LockGuard<decltype(lock)> &g,
 	                                 T                         &r = revoker)
 	    requires(Revocation::SupportsInterruptNotification<T> &&
-	             Revocation::Revoker::IsAsynchronous)
+		         Revocation::Revoker::IsAsynchronous)
 	{
 		// Release the lock before sleeping
 		g.unlock();
@@ -232,7 +232,7 @@ namespace
 	                                 LockGuard<decltype(lock)> &g,
 	                                 T                         &r = revoker)
 	    requires(!Revocation::SupportsInterruptNotification<T> ||
-	             !Revocation::Revoker::IsAsynchronous)
+		         !Revocation::Revoker::IsAsynchronous)
 	{
 		/*
 		 * Yield and poll until a revocation pass has finished.
@@ -1271,8 +1271,8 @@ namespace
 			    payload.bounds() = payload.top() - payload.address();
 
 			    Debug::Assert(payload.is_valid(),
-			                  "Unsealed object {} is not representable",
-			                  payload);
+				              "Unsealed object {} is not representable",
+				              payload);
 			    return std::pair<SealedTokenHandle, TokenHandle<false>>{
 			      sealed, payload};
 		    },

--- a/sdk/core/loader/boot.cc
+++ b/sdk/core/loader/boot.cc
@@ -634,8 +634,8 @@ namespace
 			  ((entry.address >= LA_ABS(__mmio_region_start)) &&
 			   (entry.address + entry.size() <= LA_ABS(__mmio_region_end))) ||
 			    ((entry.address >= LA_ABS(__shared_objects_start)) &&
-			     (entry.address + entry.size() <=
-			      LA_ABS(__shared_objects_end))),
+				 (entry.address + entry.size() <=
+				  LA_ABS(__shared_objects_end))),
 			  "{}--{} is not in the MMIO range ({}--{}) or the shared object "
 			  "range ({}--{})",
 			  entry.address,

--- a/sdk/core/scheduler/main.cc
+++ b/sdk/core/scheduler/main.cc
@@ -362,9 +362,9 @@ namespace
 [[cheriot::interrupt_state(disabled)]] CHERI_SEALED(TrustedStack *)
   __cheri_compartment("scheduler")
     exception_entry(CHERI_SEALED(TrustedStack *) sealedTStack,
-                    size_t mcause,
-                    size_t mepc,
-                    size_t mtval)
+	                size_t mcause,
+	                size_t mepc,
+	                size_t mtval)
 {
 	if constexpr (DebugScheduler)
 	{

--- a/sdk/include/bitpack.hh
+++ b/sdk/include/bitpack.hh
@@ -563,8 +563,8 @@ class BITPACK_DECL_ANNOTATION Bitpack
 		 */
 		template<typename DerivedBitpack, typename RefTypeParam>
 		    requires std::is_base_of_v<Bitpack, DerivedBitpack> &&
-		             std::is_lvalue_reference_v<RefTypeParam> &&
-		             std::is_same_v<Storage, std::remove_cvref_t<RefTypeParam>>
+			         std::is_lvalue_reference_v<RefTypeParam> &&
+			         std::is_same_v<Storage, std::remove_cvref_t<RefTypeParam>>
 		class Proxy
 		{
 			/// A qualified reference to the containing `Bitpack`'s `Storage`.
@@ -878,8 +878,8 @@ class BITPACK_DECL_ANNOTATION Bitpack
 	template<typename Self>
 	constexpr void alter(this Self &&self, auto &&f)
 	    requires std::is_invocable_r_v<std::remove_cvref_t<Self>,
-	                                   decltype(f),
-	                                   std::remove_cvref_t<Self>>
+		                               decltype(f),
+		                               std::remove_cvref_t<Self>>
 	{
 		std::remove_cvref_t<Self> value{self.value};
 		self = f(value);
@@ -893,8 +893,8 @@ class BITPACK_DECL_ANNOTATION Bitpack
 	template<typename Self>
 	constexpr void assign_from(this Self &&self, auto &&f)
 	    requires std::is_invocable_r_v<std::remove_cvref_t<Self>,
-	                                   decltype(f),
-	                                   std::remove_cvref_t<Self>>
+		                               decltype(f),
+		                               std::remove_cvref_t<Self>>
 	{
 		self = f(std::remove_cvref_t<Self>(0));
 	}

--- a/sdk/include/cheri.hh
+++ b/sdk/include/cheri.hh
@@ -1314,7 +1314,7 @@ namespace CHERI
 	  check_pointer(auto  &ptr,
 	                size_t space = sizeof(std::remove_pointer<decltype(ptr)>))
 	    requires(std::is_pointer_v<std::remove_cvref_t<decltype(ptr)>> ||
-	             IsSmartPointerLike<std::remove_cvref_t<decltype(ptr)>>)
+		         IsSmartPointerLike<std::remove_cvref_t<decltype(ptr)>>)
 	{
 		// We can skip a stack check if we've asked for Global because the
 		// stack does not have this permission.
@@ -1645,12 +1645,12 @@ namespace CHERI
 		__always_inline auto either(auto &&onT,
 		                            auto &&onE) /* 🏳️‍⚧️ */
 		    requires std::is_invocable_v<decltype(onT),
-		                                 Capability<T, IsSealed>> &&
-		             std::is_invocable_v<decltype(onE), int> &&
-		             std::convertible_to<
+			                             Capability<T, IsSealed>> &&
+			         std::is_invocable_v<decltype(onE), int> &&
+			         std::convertible_to<
 		               std::invoke_result_t<decltype(onE), int>,
 		               std::invoke_result_t<decltype(onT),
-		                                    Capability<T, IsSealed>>>
+					                        Capability<T, IsSealed>>>
 		{
 			if (is_error())
 			{
@@ -1664,7 +1664,7 @@ namespace CHERI
 				 */
 				if constexpr (std::is_void_v<
 				                std::invoke_result_t<decltype(onT),
-				                                     Capability<T, IsSealed>>>)
+								                     Capability<T, IsSealed>>>)
 				{
 					return onE(e);
 				}
@@ -1739,7 +1739,7 @@ namespace CHERI
 		 */
 		auto and_then(auto &&function)
 		    requires std::is_convertible_v<decltype(pointer), T *> &&
-		             std::is_void_v<
+			         std::is_void_v<
 		               std::invoke_result_t<decltype(function), T *>>
 		{
 			either([function](T *t) { function(t); }, [](int) { return; });
@@ -1755,9 +1755,9 @@ namespace CHERI
 		   * constructor in the success case.
 		   */
 		    requires std::is_convertible_v<decltype(pointer), T *> &&
-		             requires(std::invoke_result_t<decltype(function), T *> r) {
+			         requires(std::invoke_result_t<decltype(function), T *> r) {
 			             requires std::is_same_v<decltype(CHERI::ErrorOr(r)),
-			                                     decltype(r)>;
+						                         decltype(r)>;
 		             }
 		{
 			return either(function, [](int e) {
@@ -1774,7 +1774,7 @@ namespace CHERI
 		 */
 		int and_then(auto &&function)
 		    requires std::is_convertible_v<decltype(pointer), T *> &&
-		             std::is_same_v<
+			         std::is_same_v<
 		               std::invoke_result_t<decltype(function), T *>,
 		               int>
 		{

--- a/sdk/include/compartment-macros.h
+++ b/sdk/include/compartment-macros.h
@@ -305,7 +305,7 @@
 		__attribute__((section(".sealed_objects"), used)) __if_cxx(            \
 		  inline) _Alignas(_Alignof(type) < 8                                  \
 		                     ? 8                                               \
-		                     : _Alignof(type)) struct __##name##_type          \
+							 : _Alignof(type)) struct __##name##_type          \
 		  name = /* NOLINT(bugprone-macro-parentheses) */                      \
 		  {(uint32_t)&__sealing_key_##compartment##_##keyName,                 \
 		   0,                                                                  \
@@ -326,19 +326,12 @@
  */
 #define DECLARE_AND_DEFINE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                  \
   type, valueType, compartment, keyName, name, initialiser, ...)               \
+	/* NOLINTBEGIN(bugprone-macro-parentheses) */                              \
 	DECLARE_STATIC_SEALED_VALUE_EXPLICIT_TYPE(                                 \
-	  type,                                                                    \
-	  valueType,                                                               \
-	  compartment,                                                             \
-	  keyName,                                                                 \
-	  name); /* NOLINT(bugprone-macro-parentheses) */                          \
+	  type, valueType, compartment, keyName, name);                            \
 	DEFINE_STATIC_SEALED_VALUE(                                                \
-	  type,                                                                    \
-	  compartment,                                                             \
-	  keyName,                                                                 \
-	  name,                                                                    \
-	  initialiser,                                                             \
-	  ##__VA_ARGS__); /* NOLINT(bugprone-macro-parentheses) */
+	  type, compartment, keyName, name, initialiser, ##__VA_ARGS__);           \
+	/* NOLINTEND(bugprone-macro-parentheses) */
 
 /**
  * Helper macro that declares and defines a sealed value.

--- a/sdk/include/fail-simulator-on-error.h
+++ b/sdk/include/fail-simulator-on-error.h
@@ -58,7 +58,7 @@ compartment_error_handler(ErrorState *frame, size_t mcause, size_t mtval)
 		  registerNumber,
 		  registerNumber == CHERI::RegisterNumber::CZR
 		    ? nullptr
-		    : *frame->get_register_value(registerNumber));
+			: *frame->get_register_value(registerNumber));
 	}
 	else
 	{

--- a/sdk/lib/debug/debug.cc
+++ b/sdk/lib/debug/debug.cc
@@ -351,7 +351,7 @@ namespace
 							  DebugFormatArgumentBool:
 								write(static_cast<bool>(argument.value)
 								        ? "true"
-								        : "false");
+										: "false");
 								break;
 							case DebugFormatArgumentKind::
 							  DebugFormatArgumentCharacter:

--- a/sdk/lib/stdio/printf.cc
+++ b/sdk/lib/stdio/printf.cc
@@ -673,9 +673,9 @@ namespace
  * Scaled down version of vsnprintf(3).
  */
 int __cheri_libcall
-vsnprintf(char *str, // NOLINT (clang-tidy spuriously thinks this should be
-                     // const, even though it's being written to)
-          size_t      size,
+vsnprintf(char  *str, // NOLINT (clang-tidy spuriously thinks this should be
+                      // const, even though it's being written to)
+          size_t size,
           const char *format,
           va_list     ap)
 {


### PR DESCRIPTION
The upcoming LLVM version bump changes the way clang-format uses tabs in a few places.  All but one of the hunks herein are mechanical.  The exception is in compartment-macros.hh's
`DECLARE_AND_DEFINE_STATIC_SEALED_VALUE_EXPLICIT_TYPE` to avoid clang-format-23 breaking the 80 column rule.

This won't pass CI until we have a LLVM-23 devcontainer.